### PR TITLE
🛡️ Sentinel: [HIGH] Fix SSRF/LFI vulnerability in Gemini provider

### DIFF
--- a/src/imagine_mcp/providers/gemini.py
+++ b/src/imagine_mcp/providers/gemini.py
@@ -32,7 +32,12 @@ def _client():
 
 def understand(tier: str, image_url: str, prompt: str) -> dict[str, Any]:
     """Image understanding via Gemini flash/pro. Accepts http(s) image URL."""
+    from urllib.parse import urlparse
     from google.genai import types
+
+    parsed_url = urlparse(image_url)
+    if parsed_url.scheme not in {"http", "https"}:
+        raise ValueError("Invalid image_url scheme. Only http and https are allowed.")
 
     model = _MODELS["understand"][tier]
     resp = _client().models.generate_content(

--- a/tests/test_security.py
+++ b/tests/test_security.py
@@ -1,0 +1,14 @@
+from __future__ import annotations
+import pytest
+from imagine_mcp.server import dispatch
+
+def test_dispatch_rejects_non_http_urls(monkeypatch: pytest.MonkeyPatch) -> None:
+    # Need to verify that the understand path in gemini rejects local files
+    with pytest.raises(ValueError, match="Invalid image_url scheme"):
+        dispatch(
+            action="understand",
+            provider="gemini",
+            tier="poor",
+            image_url="file:///etc/passwd",
+            prompt="describe",
+        )


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: The Gemini `understand` provider accepted arbitrary URLs (`image_url`) and passed them directly to Google GenAI's `types.Part.from_uri()`.
🎯 Impact: This could lead to local file inclusion (e.g., reading `file:///etc/passwd`) or SSRF if a malicious actor controls the `image_url` parameter.
🔧 Fix: Added URL scheme validation using `urllib.parse.urlparse` to explicitly ensure only `http` or `https` URLs are allowed.
✅ Verification: Ran `uv run pytest` and verified the newly added security test rejects local file schemes appropriately. Logged the learning in `.jules/sentinel.md`.

---
*PR created automatically by Jules for task [16472653407629144095](https://jules.google.com/task/16472653407629144095) started by @n24q02m*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Implemented URL scheme validation that restricts image sources to HTTP and HTTPS protocols only, preventing access attempts through alternative URL schemes and improving security.

* **Tests**
  * Added comprehensive test coverage to verify that invalid URL schemes are properly detected and rejected during image processing with meaningful error messaging.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->