### PR TITLE
🛡️ Sentinel: [HIGH] Fix SSRF / Path Traversal via image_url

### DIFF
--- a/src/imagine_mcp/server.py
+++ b/src/imagine_mcp/server.py
@@ -15,6 +15,12 @@ def dispatch(action: str, provider: str, tier: str = "poor", **kwargs: Any) -> d
     Raises ValueError cho unknown action/provider/tier.
     NotImplementedError bubbled up từ provider stubs cho unimplemented paths.
     """
+    if "image_url" in kwargs:
+        from urllib.parse import urlparse
+        parsed = urlparse(kwargs["image_url"])
+        if parsed.scheme not in ("http", "https"):
+            raise ValueError(f"Invalid image_url scheme: {parsed.scheme!r}. Must be 'http' or 'https'")
+
     if action not in _ACTIONS:
         raise ValueError(f"Unknown action: {action!r}. Valid: {sorted(_ACTIONS)}")
     if provider not in _PROVIDERS:

--- a/tests/test_dispatch.py
+++ b/tests/test_dispatch.py
@@ -40,6 +40,17 @@ def test_dispatch_invalid_tier() -> None:
         dispatch(action="understand", provider="gemini", tier="mega")
 
 
+def test_dispatch_invalid_image_url_scheme() -> None:
+    with pytest.raises(ValueError, match="Invalid image_url scheme: 'file'. Must be 'http' or 'https'"):
+        dispatch(
+            action="understand",
+            provider="gemini",
+            tier="poor",
+            image_url="file:///etc/passwd",
+            prompt="hi",
+        )
+
+
 def test_dispatch_stubbed_path_raises_not_implemented() -> None:
     with pytest.raises(NotImplementedError):
         dispatch(


### PR DESCRIPTION
🚨 **Severity:** HIGH
💡 **Vulnerability:** The `image_url` parameter in the `dispatch` function lacked URL scheme validation. This could potentially allow Server-Side Request Forgery (SSRF) or Local File Inclusion (LFI) (e.g., `file://`, `ftp://`) if provider endpoints fetch URLs directly.
🎯 **Impact:** If an external user provides an invalid scheme (such as `file:///etc/passwd`), a provider's library could access internal/local paths or traverse sensitive directories.
🔧 **Fix:** Added validation in `src/imagine_mcp/server.py` to parse the `image_url` and strictly enforce the `http` and `https` schemes before routing to any provider. Throw a `ValueError` if an invalid scheme is detected.
✅ **Verification:** A specific test case `test_dispatch_invalid_image_url_scheme` was added to `tests/test_dispatch.py` ensuring that standard non-HTTP schemes throw the validation error correctly. Validated via `uv run pytest`.

---
*PR created automatically by Jules for task [10431318569648673065](https://jules.google.com/task/10431318569648673065) started by @n24q02m*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Implemented strict URL scheme validation for image inputs. Only HTTP and HTTPS protocols are accepted; any other scheme (such as file://) is now rejected with an error message indicating the allowed protocols.

* **Tests**
  * Added test coverage to verify URL scheme validation correctly rejects invalid schemes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->