### PR TITLE
🛡️ Sentinel: [HIGH] Fix SSRF/Path Traversal vulnerability on image_url

### DIFF
--- a/src/imagine_mcp/server.py
+++ b/src/imagine_mcp/server.py
@@ -1,6 +1,7 @@
 """imagine-mcp server: mega-tool dispatcher for image/video across Gemini/OpenAI/Grok."""
 from __future__ import annotations
 from typing import Any
+from urllib.parse import urlparse
 
 from .providers import gemini, grok, openai
 
@@ -23,6 +24,14 @@ def dispatch(action: str, provider: str, tier: str = "poor", **kwargs: Any) -> d
         )
     if tier not in _TIERS:
         raise ValueError(f"Unknown tier: {tier!r}. Valid: {sorted(_TIERS)}")
+
+    # 🛡️ Sentinel: Validate external URLs to prevent SSRF and Path Traversal
+    image_url = kwargs.get("image_url")
+    if image_url is not None:
+        parsed = urlparse(image_url)
+        if parsed.scheme not in ("http", "https"):
+            raise ValueError(f"Security Error: Invalid URL scheme '{parsed.scheme}'. Only http and https are allowed.")
+
     mod = _PROVIDERS[provider]
     fn = getattr(mod, action, None)
     if fn is None:

--- a/tests/test_dispatch.py
+++ b/tests/test_dispatch.py
@@ -40,6 +40,17 @@ def test_dispatch_invalid_tier() -> None:
         dispatch(action="understand", provider="gemini", tier="mega")
 
 
+def test_dispatch_invalid_url_scheme_raises_error() -> None:
+    with pytest.raises(ValueError, match="Security Error: Invalid URL scheme 'file'"):
+        dispatch(
+            action="understand",
+            provider="gemini",
+            tier="poor",
+            image_url="file:///etc/passwd",
+            prompt="read this file",
+        )
+
+
 def test_dispatch_stubbed_path_raises_not_implemented() -> None:
     with pytest.raises(NotImplementedError):
         dispatch(


### PR DESCRIPTION
This PR addresses a security issue where `image_url` parameters could potentially lead to SSRF or path traversal vulnerabilities due to unvalidated URI schemes.

Changes:
- Added scheme validation in `src/imagine_mcp/server.py` to allow only `http` and `https` for external URLs.
- Added test case `test_dispatch_invalid_url_scheme_raises_error` in `tests/test_dispatch.py`.
- Documented findings in `.jules/sentinel.md`.

---
*PR created automatically by Jules for task [4510146418545684887](https://jules.google.com/task/4510146418545684887) started by @n24q02m*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced validation for image URLs to reject unsupported schemes, improving security by ensuring only HTTP and HTTPS URLs are processed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->