### PR TITLE
fix: wire on_credentials_saved into run_local_server

### DIFF
--- a/src/imagine_mcp/relay_setup.py
+++ b/src/imagine_mcp/relay_setup.py
@@ -44,6 +44,24 @@ def apply_config(config: dict[str, str]) -> None:
             logger.debug("Applied relay config: {}", key)
 
 
+def save_credentials(
+    config: dict[str, str],
+    _context: dict[str, str] | None = None,
+) -> dict | None:
+    """Persist credentials from the OAuth form to config.enc + env vars.
+
+    Wired into `run_local_server(on_credentials_saved=save_credentials)`.
+    `_context` carries the per-authorize `sub` for future multi-user use;
+    imagine-mcp is single-user by design so the subject is unused here.
+    """
+    from mcp_core.storage.config_file import write_config
+
+    write_config(SERVER_NAME, config)
+    apply_config(config)
+    logger.info("Credentials saved via local OAuth form")
+    return None
+
+
 async def ensure_config(
     *, force: bool = False, timeout: float | None = RELAY_TIMEOUT_S
 ) -> dict[str, str] | None:

--- a/src/imagine_mcp/server.py
+++ b/src/imagine_mcp/server.py
@@ -32,10 +32,11 @@ def _get_version() -> str:
 
 
 def _creds_state() -> str:
-    if (
-        settings.google_ai_studio_api_key
-        or settings.openai_api_key
-        or settings.xai_api_key
+    # Read from os.environ -- settings singleton is frozen at import time
+    # and does not observe post-startup relay-saved credentials.
+    if any(
+        os.environ.get(k)
+        for k in ("GOOGLE_AI_STUDIO_API_KEY", "OPENAI_API_KEY", "XAI_API_KEY")
     ):
         return "CONFIGURED"
     return "NEEDS_SETUP"
@@ -43,11 +44,11 @@ def _creds_state() -> str:
 
 def _providers_configured() -> list[str]:
     out: list[str] = []
-    if settings.google_ai_studio_api_key:
+    if os.environ.get("GOOGLE_AI_STUDIO_API_KEY"):
         out.append("gemini")
-    if settings.openai_api_key:
+    if os.environ.get("OPENAI_API_KEY"):
         out.append("openai")
-    if settings.xai_api_key:
+    if os.environ.get("XAI_API_KEY"):
         out.append("grok")
     return out
 
@@ -239,6 +240,7 @@ async def run_http(port: int = 0) -> None:
     from mcp_core.transport.local_server import run_local_server
 
     from imagine_mcp.relay_schema import RELAY_SCHEMA
+    from imagine_mcp.relay_setup import save_credentials
 
     app = build_app()
     logger.info("imagine-mcp {} starting (http local relay)", _get_version())
@@ -248,6 +250,7 @@ async def run_http(port: int = 0) -> None:
         relay_schema=RELAY_SCHEMA,
         port=port,
         open_browser=True,
+        on_credentials_saved=save_credentials,
     )
 
 


### PR DESCRIPTION
## Summary

Local-relay paste form submissions were being dropped on the floor: `run_local_server` was called without `on_credentials_saved`, so nothing persisted the submitted keys. The form flashed "saved" but tools still reported `NEEDS_SETUP` on the next call because `config.enc` stayed empty.

- Add `save_credentials()` in `relay_setup.py`: writes submitted dict to `config.enc` via `mcp_core.storage.config_file.write_config`, then calls `apply_config()` so the running process picks up the new env vars immediately.
- Wire it into `run_local_server(on_credentials_saved=save_credentials)`.
- Fix `_creds_state()` + `_providers_configured()` to read `os.environ` directly instead of the `settings` Pydantic singleton, which is frozen at import time and never observes post-startup relay writes.

## Test plan

- [x] `uv run ruff check` + `uv run ruff format --check` clean
- [x] `uv run pytest` 74/74 pass
- [ ] Post-merge: E2E via local daemon → paste form → verify `config status` returns CONFIGURED

🤖 Generated with [Claude Code](https://claude.com/claude-code)