### PR TITLE
⚡ Bolt: optimize model lookups with O(1) dictionary cache

### DIFF
--- a/src/imagine_mcp/models.py
+++ b/src/imagine_mcp/models.py
@@ -335,14 +335,19 @@ MODELS: Final[list[ModelEntry]] = [
 ]
 
 
+# O(1) dictionary cache for fast model lookups, replacing O(n) list traversal.
+_MODEL_CACHE: Final[dict[tuple[str, str, str, str], ModelEntry]] = {
+    (e.provider, e.action, e.media, e.tier): e for e in MODELS
+}
+
 def _lookup(provider: str, action: str, media: str, tier: str) -> ModelEntry:
-    for e in MODELS:
-        if (e.provider, e.action, e.media, e.tier) == (provider, action, media, tier):
-            return e
-    raise KeyError(
-        f"unknown combo: provider={provider!r} action={action!r} "
-        f"media={media!r} tier={tier!r}"
-    )
+    try:
+        return _MODEL_CACHE[(provider, action, media, tier)]
+    except KeyError:
+        raise KeyError(
+            f"unknown combo: provider={provider!r} action={action!r} "
+            f"media={media!r} tier={tier!r}"
+        ) from None
 
 
 def get_model_id(

--- a/src/imagine_mcp/models.py
+++ b/src/imagine_mcp/models.py
@@ -340,6 +340,7 @@ _MODEL_CACHE: Final[dict[tuple[str, str, str, str], ModelEntry]] = {
     (e.provider, e.action, e.media, e.tier): e for e in MODELS
 }
 
+
 def _lookup(provider: str, action: str, media: str, tier: str) -> ModelEntry:
     try:
         return _MODEL_CACHE[(provider, action, media, tier)]

--- a/uv.lock
+++ b/uv.lock
@@ -531,7 +531,7 @@ wheels = [
 
 [[package]]
 name = "imagine-mcp"
-version = "1.1.0b1"
+version = "1.1.0"
 source = { editable = "." }
 dependencies = [
     { name = "diskcache" },

--- a/uv.lock
+++ b/uv.lock
@@ -531,7 +531,7 @@ wheels = [
 
 [[package]]
 name = "imagine-mcp"
-version = "1.1.0"
+version = "1.1.0b1"
 source = { editable = "." }
 dependencies = [
     { name = "diskcache" },


### PR DESCRIPTION
💡 **What:** Replaced the O(n) list traversal in `_lookup` (inside `src/imagine_mcp/models.py`) with an O(1) dictionary lookup by pre-computing a `_MODEL_CACHE` from the static `MODELS` list. Added a journal entry to `.jules/bolt.md`.
🎯 **Why:** The `_lookup` function was linearly scanning the `MODELS` list for every query. For configurations where combinations map to specific entries, repeatedly traversing a static list is a performance anti-pattern. Using a dictionary cache eliminates this overhead.
📊 **Impact:** Reduces the time complexity of model lookups from O(n) to O(1), making model resolution extremely fast, especially beneficial if called frequently.
🔬 **Measurement:** Verify by running the test suite (`uv run pytest tests/`). The tests pass, proving the logic remains perfectly equivalent while avoiding the loop.

---
*PR created automatically by Jules for task [10663481332867295762](https://jules.google.com/task/10663481332867295762) started by @n24q02m*