### PR TITLE
🛡️ Sentinel: [HIGH] Fix SSRF bypass via HTTP redirects

### DIFF
--- a/src/imagine_mcp/media.py
+++ b/src/imagine_mcp/media.py
@@ -8,7 +8,7 @@ from typing import Literal
 
 import httpx
 
-from imagine_mcp.errors import MediaDetectError
+from imagine_mcp.errors import InvalidURLError, MediaDetectError
 
 MediaType = Literal["image", "video"]
 
@@ -17,6 +17,20 @@ _VIDEO_EXT = {".mp4", ".webm", ".mov", ".avi", ".mkv", ".flv", ".m4v"}
 
 _IMAGE_MIME_PREFIX = "image/"
 _VIDEO_MIME_PREFIX = "video/"
+
+
+class SSRFSafeTransport(httpx.HTTPTransport):
+    """Custom transport that validates redirect locations against SSRF checks."""
+
+    def handle_request(self, request: httpx.Request) -> httpx.Response:
+        from imagine_mcp.dispatcher import _validate_url
+
+        _validate_url(str(request.url), "redirect_url")
+        return super().handle_request(request)
+
+
+def get_ssrf_safe_client() -> httpx.Client:
+    return httpx.Client(transport=SSRFSafeTransport())
 
 
 def detect_media_type(url: str) -> MediaType:
@@ -32,10 +46,15 @@ def detect_media_type(url: str) -> MediaType:
         return "video"
 
     try:
-        resp = httpx.head(url, follow_redirects=True, timeout=10)
-        resp.raise_for_status()
+        with get_ssrf_safe_client() as client:
+            resp = client.head(url, follow_redirects=True, timeout=10)
+            resp.raise_for_status()
     except httpx.HTTPError as e:
         raise MediaDetectError(f"HEAD request failed for {url}: {e}") from e
+    except InvalidURLError as e:
+        raise MediaDetectError(
+            f"HEAD request failed due to invalid redirect for {url}: {e}"
+        ) from e
 
     ctype = resp.headers.get("content-type", "").lower()
     if ctype.startswith(_IMAGE_MIME_PREFIX):
@@ -58,9 +77,15 @@ def _extract_extension(url: str) -> str:
 def download_to_path(url: str, dest: Path) -> Path:
     """Download URL content to dest path. Returns path."""
     dest.parent.mkdir(parents=True, exist_ok=True)
-    with httpx.stream("GET", url, follow_redirects=True, timeout=60) as resp:
-        resp.raise_for_status()
-        with dest.open("wb") as f:
-            for chunk in resp.iter_bytes(chunk_size=65536):
-                f.write(chunk)
+    try:
+        with (
+            get_ssrf_safe_client() as client,
+            client.stream("GET", url, follow_redirects=True, timeout=60) as resp,
+        ):
+            resp.raise_for_status()
+            with dest.open("wb") as f:
+                for chunk in resp.iter_bytes(chunk_size=65536):
+                    f.write(chunk)
+    except InvalidURLError as e:
+        raise httpx.HTTPError(f"Download failed due to invalid redirect: {e}") from e
     return dest

--- a/tests/test_media.py
+++ b/tests/test_media.py
@@ -23,7 +23,18 @@ def test_detect_by_content_type_image(monkeypatch: pytest.MonkeyPatch) -> None:
     mock_response = MagicMock()
     mock_response.headers = {"content-type": "image/jpeg"}
     mock_response.raise_for_status = MagicMock()
-    monkeypatch.setattr("httpx.head", lambda url, **kw: mock_response)
+
+    class MockClient:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *args):
+            pass
+
+        def head(self, url, **kw):
+            return mock_response
+
+    monkeypatch.setattr("imagine_mcp.media.get_ssrf_safe_client", lambda: MockClient())
     assert detect_media_type("https://example.com/xyz") == "image"
 
 
@@ -31,7 +42,18 @@ def test_detect_by_content_type_video(monkeypatch: pytest.MonkeyPatch) -> None:
     mock_response = MagicMock()
     mock_response.headers = {"content-type": "video/mp4"}
     mock_response.raise_for_status = MagicMock()
-    monkeypatch.setattr("httpx.head", lambda url, **kw: mock_response)
+
+    class MockClient:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *args):
+            pass
+
+        def head(self, url, **kw):
+            return mock_response
+
+    monkeypatch.setattr("imagine_mcp.media.get_ssrf_safe_client", lambda: MockClient())
     assert detect_media_type("https://example.com/xyz") == "video"
 
 
@@ -39,7 +61,18 @@ def test_detect_ambiguous_raises(monkeypatch: pytest.MonkeyPatch) -> None:
     mock_response = MagicMock()
     mock_response.headers = {"content-type": "application/octet-stream"}
     mock_response.raise_for_status = MagicMock()
-    monkeypatch.setattr("httpx.head", lambda url, **kw: mock_response)
+
+    class MockClient:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *args):
+            pass
+
+        def head(self, url, **kw):
+            return mock_response
+
+    monkeypatch.setattr("imagine_mcp.media.get_ssrf_safe_client", lambda: MockClient())
     with pytest.raises(MediaDetectError):
         detect_media_type("https://example.com/unknown-bin")
 

--- a/uv.lock
+++ b/uv.lock
@@ -531,7 +531,7 @@ wheels = [
 
 [[package]]
 name = "imagine-mcp"
-version = "1.1.0b1"
+version = "1.1.0"
 source = { editable = "." }
 dependencies = [
     { name = "diskcache" },


### PR DESCRIPTION
🚨 **Severity:** HIGH
💡 **Vulnerability:** The application was vulnerable to a Server-Side Request Forgery (SSRF) bypass because the `httpx` client in `media.py` was configured to automatically follow redirects (`follow_redirects=True`). Even though the initial URL is validated (e.g. against private/local IPs), an attacker could provide a safe URL that subsequently redirects to an internal or restricted endpoint, bypassing the checks.
🎯 **Impact:** An attacker could potentially bypass the SSRF protection and access internal systems or local files by leveraging external HTTP redirect servers.
🔧 **Fix:** Introduced an `SSRFSafeTransport` in `media.py` that inherits from `httpx.HTTPTransport`. This transport intercepts every request—including redirects—and re-runs the `_validate_url` check on the new URL before the request is dispatched. `detect_media_type` and `download_to_path` have been updated to use this custom safe client.
✅ **Verification:** Run `uv run pytest tests/` to ensure tests continue to pass and the mock `get_ssrf_safe_client` functions correctly in the test suite.

---
*PR created automatically by Jules for task [11983196159110681148](https://jules.google.com/task/11983196159110681148) started by @n24q02m*