### PR TITLE
fix: align setup-manual env example with GEMINI_API_KEY rename

### DIFF
--- a/docs/setup-manual.md
+++ b/docs/setup-manual.md
@@ -40,7 +40,7 @@ Set in your MCP client config:
       "command": "uvx",
       "args": ["imagine-mcp"],
       "env": {
-        "GOOGLE_AI_STUDIO_API_KEY": "...",
+        "GEMINI_API_KEY": "...",
         "OPENAI_API_KEY": "...",
         "XAI_API_KEY": "..."
       }


### PR DESCRIPTION
setup-manual.md still exposed the legacy `GOOGLE_AI_STUDIO_API_KEY` env in its MCP-client config example after the 2026-04-26 rename. Replace with `GEMINI_API_KEY` so copy-pasted configs hit the renamed reader.

🤖 Generated with [Claude Code](https://claude.com/claude-code)