### PR TITLE
fix(deps): bump mcp-core to 1.10.0 — Transparent Bridge waves 1-3

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,7 +47,7 @@ dependencies = [
     "pillow>=10.0",
     "diskcache>=5.6",
     "loguru>=0.7",
-    "n24q02m-mcp-core>=1.9.0",
+    "n24q02m-mcp-core>=1.10.0",
     "platformdirs>=4.0",
 ]
 

--- a/uv.lock
+++ b/uv.lock
@@ -531,7 +531,7 @@ wheels = [
 
 [[package]]
 name = "imagine-mcp"
-version = "1.1.0"
+version = "1.1.1"
 source = { editable = "." }
 dependencies = [
     { name = "diskcache" },
@@ -571,7 +571,7 @@ requires-dist = [
     { name = "httpx", specifier = ">=0.27" },
     { name = "loguru", specifier = ">=0.7" },
     { name = "mcp", extras = ["cli"], specifier = ">=1.0" },
-    { name = "n24q02m-mcp-core", specifier = ">=1.9.0" },
+    { name = "n24q02m-mcp-core", specifier = ">=1.10.0" },
     { name = "openai", specifier = ">=1.60" },
     { name = "pillow", specifier = ">=10.0" },
     { name = "platformdirs", specifier = ">=4.0" },
@@ -839,7 +839,7 @@ wheels = [
 
 [[package]]
 name = "n24q02m-mcp-core"
-version = "1.9.0"
+version = "1.10.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "authlib" },
@@ -852,9 +852,9 @@ dependencies = [
     { name = "starlette" },
     { name = "tomli-w" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/55/08/db4700b412cfffdf7a07b27412e83368d8456d661bfddd09b681e1a337e7/n24q02m_mcp_core-1.9.0.tar.gz", hash = "sha256:5bf4e27091ad92c0fe3cc1a9a483f0737221d62189919ea00de4b7a61410a84d", size = 164515, upload-time = "2026-04-28T03:16:47.741Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/bf/76/7db8d34e2b0e452d16cd2275f540d0538d4e5f4140c88ebf0c9d97361f50/n24q02m_mcp_core-1.10.0.tar.gz", hash = "sha256:761f2545d252927d1090bf8222dba566f3789ee4f38e172c2c128ebdd7881f30", size = 177223, upload-time = "2026-04-28T15:24:02.064Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/ec/2f/c5c0c6261e30a78410a04226b718ab6a15f2795a7450d1282d5d49107a25/n24q02m_mcp_core-1.9.0-py3-none-any.whl", hash = "sha256:d9a6d11b89d06e11df607b743507980d3fb15d4e46ee6ad84202fcc8e341d93e", size = 100661, upload-time = "2026-04-28T03:16:46.187Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/f9/b0d79f041ae9af5ffbea4250a29c72f6bf90a8ad1a40ea342af114cbc7dd/n24q02m_mcp_core-1.10.0-py3-none-any.whl", hash = "sha256:8965068bf98597181f3f8944d00d2295b17eceafa1f500fee325a0c5bfd08688", size = 107410, upload-time = "2026-04-28T15:24:00.297Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Bump mcp-core to v1.10.0, picking up:
- Wave 1: schema-completeness gate + `_setup_complete` flag
- Wave 2: 4-line lock format + sweepStaleLocks + hourly mtime refresh
- Wave 3: fast-handshake stdio-proxy with capabilities cache (Python only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)