### PR TITLE
fix: register config__open_relay tool (Transparent Bridge Wave 3)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,7 +47,7 @@ dependencies = [
     "pillow>=10.0",
     "diskcache>=5.6",
     "loguru>=0.7",
-    "n24q02m-mcp-core>=1.10.0",
+    "n24q02m-mcp-core>=1.11.0",
     "platformdirs>=4.0",
 ]
 

--- a/src/imagine_mcp/server.py
+++ b/src/imagine_mcp/server.py
@@ -11,9 +11,11 @@ from typing import Any, Literal
 import platformdirs
 from fastmcp import FastMCP
 from loguru import logger
+from mcp_core.relay.tool_helpers import register_open_relay_tool
 
 from imagine_mcp.config import settings
 from imagine_mcp.dispatcher import dispatch_generate, dispatch_understand
+from imagine_mcp.relay_schema import RELAY_SCHEMA
 
 VALID_HELP_TOPICS = {"understand", "generate", "config"}
 
@@ -224,6 +226,8 @@ def build_app() -> FastMCP:
         doc_file = files("imagine_mcp.docs").joinpath(f"{topic}.md")
         return doc_file.read_text(encoding="utf-8")
 
+    register_open_relay_tool(app, "imagine-mcp", RELAY_SCHEMA)
+
     return app
 
 
@@ -246,7 +250,6 @@ async def run_http(port: int = 0) -> None:
     from mcp_core.transport.local_server import run_local_server
 
     from imagine_mcp.credential_state import save_credentials
-    from imagine_mcp.relay_schema import RELAY_SCHEMA
 
     public_url = os.environ.get("PUBLIC_URL")
     if public_url:

--- a/tests/test_config_open_relay_registered.py
+++ b/tests/test_config_open_relay_registered.py
@@ -1,0 +1,33 @@
+"""Smoke test: ``config__open_relay`` MCP tool is registered.
+
+Transparent Bridge Wave 3 (mcp-core v1.11+) gives the LLM the ability to
+re-trigger the relay form via tool call. Each consumer server registers the
+helper from ``mcp_core.relay.tool_helpers``; this test guards against
+regressions where the registration line is removed or the tool name changes.
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+from imagine_mcp.server import build_app
+
+
+def test_config_open_relay_tool_registered() -> None:
+    """``config__open_relay`` must appear in the MCP tool list."""
+    app = build_app()
+    tools = asyncio.run(app.list_tools())
+    tool_names = {t.name for t in tools}
+    assert "config__open_relay" in tool_names, (
+        f"config__open_relay missing from tool list: {sorted(tool_names)}"
+    )
+
+
+def test_config_open_relay_tool_is_callable() -> None:
+    """The registered tool is wired through FastMCP and exposes a handler."""
+    app = build_app()
+    tools = asyncio.run(app.list_tools())
+    tool = next(t for t in tools if t.name == "config__open_relay")
+    # FastMCP wraps the closure as a FunctionTool; just assert it's there.
+    assert tool is not None
+    assert tool.name == "config__open_relay"

--- a/tests/test_server_tools.py
+++ b/tests/test_server_tools.py
@@ -11,7 +11,14 @@ def test_four_tools_registered() -> None:
     app = build_app()
     tools = asyncio.run(app.list_tools())
     tool_names = {t.name for t in tools}
-    assert tool_names == {"understand", "generate", "config", "help"}
+    # 4 product tools + config__open_relay (Transparent Bridge Wave 3, mcp-core v1.11+).
+    assert tool_names == {
+        "understand",
+        "generate",
+        "config",
+        "help",
+        "config__open_relay",
+    }
 
 
 def test_help_topic_set() -> None:
@@ -19,8 +26,13 @@ def test_help_topic_set() -> None:
 
 
 def test_tools_have_non_empty_descriptions() -> None:
+    # config__open_relay is registered by mcp-core's helper and inherits its
+    # docstring; FastMCP does not lift it onto FunctionTool.description, so we
+    # only enforce the description contract on the 4 product tools defined here.
     app = build_app()
     tools = asyncio.run(app.list_tools())
     for t in tools:
+        if t.name == "config__open_relay":
+            continue
         assert t.description, f"tool {t.name} has empty description"
         assert len(t.description) >= 20

--- a/uv.lock
+++ b/uv.lock
@@ -571,7 +571,7 @@ requires-dist = [
     { name = "httpx", specifier = ">=0.27" },
     { name = "loguru", specifier = ">=0.7" },
     { name = "mcp", extras = ["cli"], specifier = ">=1.0" },
-    { name = "n24q02m-mcp-core", specifier = ">=1.10.0" },
+    { name = "n24q02m-mcp-core", specifier = ">=1.11.0" },
     { name = "openai", specifier = ">=1.60" },
     { name = "pillow", specifier = ">=10.0" },
     { name = "platformdirs", specifier = ">=4.0" },
@@ -839,12 +839,13 @@ wheels = [
 
 [[package]]
 name = "n24q02m-mcp-core"
-version = "1.10.0"
+version = "1.11.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "authlib" },
     { name = "cryptography" },
     { name = "fastmcp" },
+    { name = "filelock" },
     { name = "httpx" },
     { name = "loguru" },
     { name = "platformdirs" },
@@ -852,9 +853,9 @@ dependencies = [
     { name = "starlette" },
     { name = "tomli-w" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/bf/76/7db8d34e2b0e452d16cd2275f540d0538d4e5f4140c88ebf0c9d97361f50/n24q02m_mcp_core-1.10.0.tar.gz", hash = "sha256:761f2545d252927d1090bf8222dba566f3789ee4f38e172c2c128ebdd7881f30", size = 177223, upload-time = "2026-04-28T15:24:02.064Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/2e/b6/f56dccb0ae3938fae35c52f64d76ff4d3ed809688574d2bc81a140adba33/n24q02m_mcp_core-1.11.0.tar.gz", hash = "sha256:adf4b22b437e19d58bbd768c9d1213bc0da5872c9e19be3add62b952a0faa4b7", size = 193216, upload-time = "2026-04-29T05:03:34.856Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/d7/f9/b0d79f041ae9af5ffbea4250a29c72f6bf90a8ad1a40ea342af114cbc7dd/n24q02m_mcp_core-1.10.0-py3-none-any.whl", hash = "sha256:8965068bf98597181f3f8944d00d2295b17eceafa1f500fee325a0c5bfd08688", size = 107410, upload-time = "2026-04-28T15:24:00.297Z" },
+    { url = "https://files.pythonhosted.org/packages/96/f6/e75f6cfa808bd0121b059194d5aeeed4c26f9f226d258f589c4047a95371/n24q02m_mcp_core-1.11.0-py3-none-any.whl", hash = "sha256:40f4566ec3985bf170d21470da4c7942b97a5c33e11177617f004fb3da308527", size = 119914, upload-time = "2026-04-29T05:03:33.469Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- Wires the new ``mcp_core.relay.tool_helpers.register_open_relay_tool`` helper (mcp-core v1.11.0, just published to PyPI) into ``imagine-mcp``'s FastMCP app so the LLM can re-trigger the relay credential form via a tool call. Returns ``{ url, browser_opened, status }``.
- Bumps ``n24q02m-mcp-core>=1.11.0`` and refreshes ``uv.lock`` (resolved 118 packages, 1.10.0 → 1.11.0).
- Adds smoke test ``tests/test_config_open_relay_registered.py`` and updates ``test_server_tools`` to account for the new system tool.

## Wave 3 cascade

Part of the "Transparent Bridge v2" cascade across the MCP server stack. Each consumer server (wet, mnemo, crg, telegram, notion, email, godot, imagine) registers the same helper so the relay form is reachable from inside an LLM session without restarting the daemon.

## Test plan

- [x] ``uv lock --upgrade-package n24q02m-mcp-core`` clean (1.10.0 → 1.11.0)
- [x] ``uv run pytest tests/test_config_open_relay_registered.py -v`` (2 passed)
- [x] ``uv run pytest -q`` (89 passed, 1 deselected -- live tier)
- [x] ``uv run pre-commit run --from-ref HEAD~1 --to-ref HEAD`` (gitleaks, ruff, ty, pytest, trailing-whitespace, etc. all pass)

## Notes

- ``config__open_relay`` is registered by mcp-core via ``@mcp.tool(name=...)`` only -- FastMCP does not lift the closure docstring onto ``FunctionTool.description``. The pre-existing ``test_tools_have_non_empty_descriptions`` is updated to exempt this single system tool (the 4 product tools still must have ``len(description) >= 20``).
- Relay schema (``RELAY_SCHEMA``) is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)