### PR TITLE
fix: bump mcp-core to 1.11.3 (D17 cache refresh)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,7 +47,7 @@ dependencies = [
     "pillow>=10.0",
     "diskcache>=5.6",
     "loguru>=0.7",
-    "n24q02m-mcp-core>=1.11.0",
+    "n24q02m-mcp-core>=1.11.3",
     "platformdirs>=4.0",
 ]
 

--- a/uv.lock
+++ b/uv.lock
@@ -531,7 +531,7 @@ wheels = [
 
 [[package]]
 name = "imagine-mcp"
-version = "1.1.2"
+version = "1.1.3"
 source = { editable = "." }
 dependencies = [
     { name = "diskcache" },
@@ -571,7 +571,7 @@ requires-dist = [
     { name = "httpx", specifier = ">=0.27" },
     { name = "loguru", specifier = ">=0.7" },
     { name = "mcp", extras = ["cli"], specifier = ">=1.0" },
-    { name = "n24q02m-mcp-core", specifier = ">=1.11.0" },
+    { name = "n24q02m-mcp-core", specifier = ">=1.11.3" },
     { name = "openai", specifier = ">=1.60" },
     { name = "pillow", specifier = ">=10.0" },
     { name = "platformdirs", specifier = ">=4.0" },
@@ -839,7 +839,7 @@ wheels = [
 
 [[package]]
 name = "n24q02m-mcp-core"
-version = "1.11.0"
+version = "1.11.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "authlib" },
@@ -853,9 +853,9 @@ dependencies = [
     { name = "starlette" },
     { name = "tomli-w" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/2e/b6/f56dccb0ae3938fae35c52f64d76ff4d3ed809688574d2bc81a140adba33/n24q02m_mcp_core-1.11.0.tar.gz", hash = "sha256:adf4b22b437e19d58bbd768c9d1213bc0da5872c9e19be3add62b952a0faa4b7", size = 193216, upload-time = "2026-04-29T05:03:34.856Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/b1/ce/2a174b08ea2d6e8bb6913756295e58a35460ca63e89201c58f4e80042fb5/n24q02m_mcp_core-1.11.3.tar.gz", hash = "sha256:55873571bf310d915917ff7ffc742948729215e807c514241b284a720eefa0b3", size = 200469, upload-time = "2026-04-29T10:59:50.138Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/96/f6/e75f6cfa808bd0121b059194d5aeeed4c26f9f226d258f589c4047a95371/n24q02m_mcp_core-1.11.0-py3-none-any.whl", hash = "sha256:40f4566ec3985bf170d21470da4c7942b97a5c33e11177617f004fb3da308527", size = 119914, upload-time = "2026-04-29T05:03:33.469Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/a8/15d750245bc44bc21cdddb267ec026cf45f3c8c2c400c564e8808ed1f001/n24q02m_mcp_core-1.11.3-py3-none-any.whl", hash = "sha256:fe15f0b0da7152400da7fa6a0663ab1d0141b7d6c1d585d3d32ae40c6e0243fd", size = 123129, upload-time = "2026-04-29T10:59:48.631Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Per Bridge v2 addendum spec — picks up tools cache refresh + listChanged + sentinel polling fixes from mcp-core 1.11.3.