### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix SSRF bypass via raw httpx get calls

### DIFF
--- a/src/imagine_mcp/providers/grok.py
+++ b/src/imagine_mcp/providers/grok.py
@@ -21,6 +21,7 @@ from imagine_mcp.errors import (
     ProviderAPIError,
     ProviderUnsupportedError,
 )
+from imagine_mcp.media import get_ssrf_safe_client
 from imagine_mcp.models import get_model_id
 
 _CLIENT: Any = None
@@ -113,7 +114,10 @@ def generate_image(
     img_b64 = data["data"][0].get("b64_json")
     if not img_b64:
         img_url = data["data"][0].get("url")
-        img_b64 = base64.b64encode(httpx.get(img_url, timeout=60).content).decode()
+        with get_ssrf_safe_client() as client:
+            resp_img = client.get(img_url, timeout=60, follow_redirects=True)
+            resp_img.raise_for_status()
+            img_b64 = base64.b64encode(resp_img.content).decode()
 
     img_bytes = base64.b64decode(img_b64)
     out_dir = Path(platformdirs.user_cache_dir("imagine-mcp")) / "generations"
@@ -197,7 +201,10 @@ def generate_video(
         )
 
     video_url = data["video_url"]
-    video_bytes = httpx.get(video_url, timeout=120).content
+    with get_ssrf_safe_client() as client:
+        resp_video = client.get(video_url, timeout=120, follow_redirects=True)
+        resp_video.raise_for_status()
+        video_bytes = resp_video.content
 
     out_dir = Path(platformdirs.user_cache_dir("imagine-mcp")) / "generations"
     out_dir.mkdir(parents=True, exist_ok=True)

--- a/src/imagine_mcp/providers/openai.py
+++ b/src/imagine_mcp/providers/openai.py
@@ -8,7 +8,6 @@ import uuid
 from pathlib import Path
 from typing import Any
 
-import httpx
 import platformdirs
 
 from imagine_mcp.config import settings
@@ -17,6 +16,7 @@ from imagine_mcp.errors import (
     ProviderAPIError,
     ProviderUnsupportedError,
 )
+from imagine_mcp.media import get_ssrf_safe_client
 from imagine_mcp.models import get_model_id
 
 _CLIENT: Any = None
@@ -87,7 +87,12 @@ def generate_image(
     size = size_map.get(aspect_ratio, "1024x1024")
 
     if reference_image_url:
-        img_bytes = httpx.get(reference_image_url, timeout=60).content
+        with get_ssrf_safe_client() as client:
+            resp_img = client.get(
+                reference_image_url, timeout=60, follow_redirects=True
+            )
+            resp_img.raise_for_status()
+            img_bytes = resp_img.content
         resp = _client().images.edit(
             model=model, image=img_bytes, prompt=prompt, size=size
         )

--- a/uv.lock
+++ b/uv.lock
@@ -531,7 +531,7 @@ wheels = [
 
 [[package]]
 name = "imagine-mcp"
-version = "1.1.3"
+version = "1.1.4"
 source = { editable = "." }
 dependencies = [
     { name = "diskcache" },


### PR DESCRIPTION
🚨 **Severity:** CRITICAL
💡 **Vulnerability:** The `openai.py` and `grok.py` providers used a raw `httpx.get()` client to fetch reference images and generated media. This bypassed the SSRF redirect protection implemented in the `SSRFSafeTransport` of `imagine_mcp.media`. Preliminary URL validation in `dispatcher.py` cannot catch SSRF via HTTP redirects if the final request client does not validate the redirect target.
🎯 **Impact:** If a malicious external URL redirects to an internal or private resource, the server could fetch it, potentially leaking sensitive internal data or interacting with unauthorized local services.
🔧 **Fix:** Replaced vulnerable `httpx.get()` calls with `get_ssrf_safe_client()` (with `follow_redirects=True`) in `src/imagine_mcp/providers/openai.py` and `src/imagine_mcp/providers/grok.py`. Also ensured HTTP errors are properly handled by calling `.raise_for_status()`.
✅ **Verification:** Verified that tests pass, linters output zero errors, and all references to the insecure `httpx.get()` for fetching URLs have been removed and replaced with the safe client. Documented the learning in `.jules/sentinel.md`.

---
*PR created automatically by Jules for task [8185048322891000443](https://jules.google.com/task/8185048322891000443) started by @n24q02m*