### PR TITLE
feat: route stdio mode to FastMCP/MCP SDK direct + multi-target Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,13 @@
 # syntax=docker/dockerfile:1
+# Multi-target Dockerfile per spec
+# `~/projects/.superpower/mcp-core/specs/2026-04-30-multi-mode-stdio-http-architecture.md`
+# section D6. Build stdio: `docker buildx build --target stdio -t <repo>:stdio .`
+# Build http:  `docker buildx build --target http  -t <repo>:http .`
+# Build latest (= http): `docker buildx build --target http -t <repo>:latest .`
 
+# ========================
+# Stage 1: Builder
+# ========================
 FROM python:3.13-slim-bookworm AS builder
 COPY --from=ghcr.io/astral-sh/uv:latest /uv /uvx /usr/local/bin/
 
@@ -20,7 +28,10 @@ RUN sed -i '/^\[tool\.uv\.sources\]/,/^$/d' pyproject.toml
 RUN --mount=type=cache,target=/root/.cache/uv \
     uv sync --frozen --no-dev
 
-FROM python:3.13-slim-bookworm
+# ========================
+# Stage 2: Runtime base (shared by stdio + http targets)
+# ========================
+FROM python:3.13-slim-bookworm AS runtime
 
 LABEL io.modelcontextprotocol.server.name="io.github.n24q02m/imagine-mcp"
 LABEL org.opencontainers.image.source="https://github.com/n24q02m/imagine-mcp"
@@ -39,4 +50,18 @@ RUN groupadd -r appuser && useradd -r -g appuser -d /home/appuser -m appuser \
     && chown -R appuser:appuser /app
 USER appuser
 
+# ========================
+# Stage 3a: stdio target (default for plugin marketplace & uvx-style usage)
+# ========================
+FROM runtime AS stdio
+ENV MCP_TRANSPORT=stdio
+ENTRYPOINT ["python", "-m", "imagine_mcp"]
+
+# ========================
+# Stage 3b: http target (multi-user remote daemon)
+# ========================
+FROM runtime AS http
+ENV MCP_TRANSPORT=http \
+    MCP_PORT=8080
+EXPOSE 8080
 ENTRYPOINT ["python", "-m", "imagine_mcp"]

--- a/src/imagine_mcp/__main__.py
+++ b/src/imagine_mcp/__main__.py
@@ -7,8 +7,9 @@ Modes (parity with wet-mcp / mnemo-mcp / better-code-review-graph):
 - ``http remote relay (multi-user)`` -- same ``run_http`` codepath, activated
   by setting ``PUBLIC_URL`` (and ``MCP_DCR_SERVER_SECRET``). Daemon binds
   ``0.0.0.0:8080`` and scopes LLM API keys per JWT ``sub``.
-- ``stdio proxy`` -- ``run_smart_stdio_proxy``: bridge stdin/stdout to a local
-  HTTP daemon (same backend as http local relay, client-side transport only).
+- ``stdio direct`` -- ``mcp.run(transport="stdio")``: FastMCP stdio server
+  served directly on stdin/stdout (no daemon-spawn bridge). Universal MCP
+  client compatibility (Claude Code, Cursor, VS Code Copilot, etc.).
 """
 
 from __future__ import annotations
@@ -22,10 +23,13 @@ def main() -> None:
     mode = (os.environ.get("MCP_MODE") or "").strip().lower()
 
     if "--stdio" in sys.argv or os.environ.get("MCP_TRANSPORT") == "stdio":
-        from mcp_core.transport import run_smart_stdio_proxy
+        # Stdio mode: run FastMCP stdio server directly. No bridge layer.
+        # Universal MCP client compatibility (Claude Code, Cursor, VS Code Copilot, etc.).
+        # See: ~/projects/.superpower/mcp-core/specs/2026-04-30-multi-mode-stdio-http-architecture.md
+        from imagine_mcp.server import build_app
 
-        daemon_cmd = [sys.executable, "-m", "imagine_mcp"]
-        sys.exit(run_smart_stdio_proxy("imagine-mcp", daemon_cmd))
+        build_app().run(transport="stdio")
+        return
 
     if mode == "remote-relay":
         raise SystemExit(

--- a/src/imagine_mcp/server.py
+++ b/src/imagine_mcp/server.py
@@ -69,7 +69,7 @@ def _set_runtime(key: str | None, value: str | None) -> dict[str, Any]:
 def build_app() -> FastMCP:
     """Create FastMCP app with 4 tools registered."""
     app: FastMCP = FastMCP(
-        "imagine-mcp",
+        "imagine",
         instructions=(
             "Image/video understanding and generation across Gemini, OpenAI, Grok. "
             "4 tools: understand, generate, config, help. "

--- a/tests/test_stdio_direct.py
+++ b/tests/test_stdio_direct.py
@@ -1,0 +1,143 @@
+"""Verify imagine-mcp runs in stdio direct mode (no smart_stdio bridge).
+
+Spawns ``python -m imagine_mcp`` with ``MCP_TRANSPORT=stdio`` and exercises
+the JSON-RPC handshake plus ``tools/list`` to prove the FastMCP stdio server
+is wired directly (no daemon-spawn bridge layer in front of it).
+
+Marked ``live`` because it spawns a real subprocess and speaks the MCP
+protocol; excluded from the default ``pytest`` invocation but runs under
+``uv run pytest -m live``.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+
+import pytest
+
+pytestmark = [pytest.mark.live, pytest.mark.timeout(60)]
+
+
+def _spawn_stdio_server() -> subprocess.Popen[str]:
+    """Start ``python -m imagine_mcp`` with stdio transport.
+
+    Returns the running subprocess. Caller is responsible for terminating it.
+    """
+    env = {**os.environ, "MCP_TRANSPORT": "stdio"}
+    return subprocess.Popen(
+        [sys.executable, "-m", "imagine_mcp"],
+        stdin=subprocess.PIPE,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        env=env,
+        text=True,
+        bufsize=1,
+    )
+
+
+def _read_response(proc: subprocess.Popen[str]) -> dict:
+    """Read one JSON-RPC line from stdout, parsed as dict."""
+    assert proc.stdout is not None and proc.stderr is not None
+    line = proc.stdout.readline()
+    if not line:
+        stderr = proc.stderr.read()
+        raise RuntimeError(
+            f"server closed stdout without sending a response. stderr=\n{stderr}"
+        )
+    return json.loads(line)
+
+
+def test_stdio_direct_init_responds():
+    """Spawn the server with MCP_TRANSPORT=stdio; verify init response shape."""
+    proc = _spawn_stdio_server()
+    assert proc.stdin is not None
+    init_request = (
+        json.dumps(
+            {
+                "jsonrpc": "2.0",
+                "id": 1,
+                "method": "initialize",
+                "params": {
+                    "protocolVersion": "2025-11-25",
+                    "capabilities": {},
+                    "clientInfo": {"name": "test", "version": "1.0"},
+                },
+            }
+        )
+        + "\n"
+    )
+    try:
+        proc.stdin.write(init_request)
+        proc.stdin.flush()
+        response = _read_response(proc)
+        assert response["id"] == 1
+        assert "result" in response, f"unexpected response: {response}"
+        # FastMCP negotiates protocol version; just assert it returned one.
+        assert "protocolVersion" in response["result"]
+        assert response["result"]["serverInfo"]["name"] == "imagine"
+    finally:
+        proc.terminate()
+        try:
+            proc.wait(timeout=5)
+        except subprocess.TimeoutExpired:
+            proc.kill()
+
+
+def test_stdio_direct_tools_list_returns_expected_tools():
+    """Verify tools/list returns the expected imagine tool set over stdio."""
+    proc = _spawn_stdio_server()
+    assert (
+        proc.stdin is not None and proc.stdout is not None and proc.stderr is not None
+    )
+    requests = [
+        json.dumps(
+            {
+                "jsonrpc": "2.0",
+                "id": 1,
+                "method": "initialize",
+                "params": {
+                    "protocolVersion": "2025-11-25",
+                    "capabilities": {},
+                    "clientInfo": {"name": "test", "version": "1.0"},
+                },
+            }
+        ),
+        json.dumps({"jsonrpc": "2.0", "method": "notifications/initialized"}),
+        json.dumps({"jsonrpc": "2.0", "id": 2, "method": "tools/list", "params": {}}),
+    ]
+    try:
+        for r in requests:
+            proc.stdin.write(r + "\n")
+            proc.stdin.flush()
+        responses: dict[int, dict] = {}
+        while len(responses) < 2:
+            line = proc.stdout.readline()
+            if not line:
+                stderr = proc.stderr.read()
+                raise RuntimeError(
+                    f"server closed stdout before tools/list response. "
+                    f"stderr=\n{stderr}"
+                )
+            data = json.loads(line)
+            if "id" in data:
+                responses[data["id"]] = data
+        assert 2 in responses, f"missing tools/list response: {responses}"
+        tools = responses[2]["result"]["tools"]
+        tool_names = {t["name"] for t in tools}
+        # Core imagine tools that must be exposed in stdio mode. Relay-only tool
+        # ``config__open_relay`` may or may not be registered depending on the
+        # relay-setup state, so we don't assert it here.
+        expected = {"understand", "generate", "config", "help"}
+        assert expected.issubset(tool_names), (
+            f"missing tools: {expected - tool_names}; got: {tool_names}"
+        )
+        assert len(tools) >= 3
+    finally:
+        proc.terminate()
+        try:
+            proc.wait(timeout=5)
+        except subprocess.TimeoutExpired:
+            proc.kill()

--- a/uv.lock
+++ b/uv.lock
@@ -531,7 +531,7 @@ wheels = [
 
 [[package]]
 name = "imagine-mcp"
-version = "1.1.3"
+version = "1.1.4"
 source = { editable = "." }
 dependencies = [
     { name = "diskcache" },


### PR DESCRIPTION
Migrate stdio path from smart_stdio bridge to direct FastMCP/MCP SDK stdio. Universal MCP client compat. Multi-target Dockerfile (:stdio + :http). Spec: ~/projects/.superpower/mcp-core/specs/2026-04-30-multi-mode-stdio-http-architecture.md