### PR TITLE
feat(docs): add trust model section to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,15 @@ mise run setup      # or: uv sync --group dev
 mise run dev        # run http local relay daemon
 ```
 
+## Trust Model
+
+This plugin implements **TC-Local** (machine-bound, single trust principal). See [mcp-core/docs/TRUST-MODEL.md](https://github.com/n24q02m/mcp-core/blob/main/docs/TRUST-MODEL.md) for full classification.
+
+| Mode | Storage | Encryption | Who can read your data? |
+|---|---|---|---|
+| stdio (default) | `~/.imagine-mcp/config.json` | AES-GCM, machine-bound key | Only your OS user (file perm 0600) |
+| HTTP self-host | Same as stdio | Same | Only you (admin = user) |
+
 ## Contributing
 
 See [CONTRIBUTING.md](CONTRIBUTING.md) for the full development workflow, commit convention, and release process. Issues + Discussions welcome.


### PR DESCRIPTION
Add Trust Model section to README documenting the TC-Local trust class for stdio mode.

Links to canonical `mcp-core/docs/TRUST-MODEL.md` for full classification. Includes per-mode table showing storage location, encryption (AES-GCM, machine-bound key), and who can read stored data.

Part of Task 8 of the trust-model-alignment plan.