### PR TITLE
🛡️ Sentinel: [HIGH] Fix SSRF via HTTP Redirects

### DIFF
--- a/src/imagine_mcp/media.py
+++ b/src/imagine_mcp/media.py
@@ -19,6 +19,9 @@ _IMAGE_MIME_PREFIX = "image/"
 _VIDEO_MIME_PREFIX = "video/"
 
 
+_CLIENT: httpx.Client | None = None
+
+
 class SSRFSafeTransport(httpx.HTTPTransport):
     """Custom transport that validates redirect locations against SSRF checks."""
 
@@ -30,7 +33,10 @@ class SSRFSafeTransport(httpx.HTTPTransport):
 
 
 def get_ssrf_safe_client() -> httpx.Client:
-    return httpx.Client(transport=SSRFSafeTransport())
+    global _CLIENT
+    if _CLIENT is None:
+        _CLIENT = httpx.Client(transport=SSRFSafeTransport())
+    return _CLIENT
 
 
 def detect_media_type(url: str) -> MediaType:
@@ -46,9 +52,9 @@ def detect_media_type(url: str) -> MediaType:
         return "video"
 
     try:
-        with get_ssrf_safe_client() as client:
-            resp = client.head(url, follow_redirects=True, timeout=10)
-            resp.raise_for_status()
+        client = get_ssrf_safe_client()
+        resp = client.head(url, follow_redirects=True, timeout=10)
+        resp.raise_for_status()
     except httpx.HTTPError as e:
         raise MediaDetectError(f"HEAD request failed for {url}: {e}") from e
     except InvalidURLError as e:
@@ -78,10 +84,8 @@ def download_to_path(url: str, dest: Path) -> Path:
     """Download URL content to dest path. Returns path."""
     dest.parent.mkdir(parents=True, exist_ok=True)
     try:
-        with (
-            get_ssrf_safe_client() as client,
-            client.stream("GET", url, follow_redirects=True, timeout=60) as resp,
-        ):
+        client = get_ssrf_safe_client()
+        with client.stream("GET", url, follow_redirects=True, timeout=60) as resp:
             resp.raise_for_status()
             with dest.open("wb") as f:
                 for chunk in resp.iter_bytes(chunk_size=65536):

--- a/src/imagine_mcp/providers/grok.py
+++ b/src/imagine_mcp/providers/grok.py
@@ -21,6 +21,7 @@ from imagine_mcp.errors import (
     ProviderAPIError,
     ProviderUnsupportedError,
 )
+from imagine_mcp.media import get_ssrf_safe_client
 from imagine_mcp.models import get_model_id
 
 _CLIENT: Any = None
@@ -113,7 +114,11 @@ def generate_image(
     img_b64 = data["data"][0].get("b64_json")
     if not img_b64:
         img_url = data["data"][0].get("url")
-        img_b64 = base64.b64encode(httpx.get(img_url, timeout=60).content).decode()
+        img_b64 = base64.b64encode(
+            get_ssrf_safe_client()
+            .get(img_url, timeout=60, follow_redirects=True)
+            .content
+        ).decode()
 
     img_bytes = base64.b64decode(img_b64)
     out_dir = Path(platformdirs.user_cache_dir("imagine-mcp")) / "generations"
@@ -197,7 +202,11 @@ def generate_video(
         )
 
     video_url = data["video_url"]
-    video_bytes = httpx.get(video_url, timeout=120).content
+    video_bytes = (
+        get_ssrf_safe_client()
+        .get(video_url, timeout=120, follow_redirects=True)
+        .content
+    )
 
     out_dir = Path(platformdirs.user_cache_dir("imagine-mcp")) / "generations"
     out_dir.mkdir(parents=True, exist_ok=True)

--- a/src/imagine_mcp/providers/openai.py
+++ b/src/imagine_mcp/providers/openai.py
@@ -8,7 +8,6 @@ import uuid
 from pathlib import Path
 from typing import Any
 
-import httpx
 import platformdirs
 
 from imagine_mcp.config import settings
@@ -17,6 +16,7 @@ from imagine_mcp.errors import (
     ProviderAPIError,
     ProviderUnsupportedError,
 )
+from imagine_mcp.media import get_ssrf_safe_client
 from imagine_mcp.models import get_model_id
 
 _CLIENT: Any = None
@@ -87,7 +87,11 @@ def generate_image(
     size = size_map.get(aspect_ratio, "1024x1024")
 
     if reference_image_url:
-        img_bytes = httpx.get(reference_image_url, timeout=60).content
+        img_bytes = (
+            get_ssrf_safe_client()
+            .get(reference_image_url, timeout=60, follow_redirects=True)
+            .content
+        )
         resp = _client().images.edit(
             model=model, image=img_bytes, prompt=prompt, size=size
         )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,9 @@
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def reset_media_client():
+    """Reset the module-level SSRF safe client to ensure test isolation."""
+    import imagine_mcp.media
+
+    imagine_mcp.media._CLIENT = None

--- a/tests/test_g6_ux_status_accuracy.py
+++ b/tests/test_g6_ux_status_accuracy.py
@@ -47,7 +47,9 @@ def _relay_skip() -> dict[str, Any]:
 class TestRelayStatusLiveDerivedState:
     """relay_status derives state from live PerPluginStore, not env-only."""
 
-    def test_returns_configured_when_store_has_keys(self, monkeypatch: pytest.MonkeyPatch) -> None:
+    def test_returns_configured_when_store_has_keys(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
         """relay_status returns configured when PerPluginStore has provider keys."""
         monkeypatch.delenv("GEMINI_API_KEY", raising=False)
         monkeypatch.delenv("OPENAI_API_KEY", raising=False)
@@ -62,7 +64,9 @@ class TestRelayStatusLiveDerivedState:
         assert result["status"] == "configured"
         assert "gemini" in result["providers_configured"]
 
-    def test_returns_pending_when_store_empty(self, monkeypatch: pytest.MonkeyPatch) -> None:
+    def test_returns_pending_when_store_empty(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
         """relay_status returns pending when store empty and no env vars."""
         monkeypatch.delenv("GEMINI_API_KEY", raising=False)
         monkeypatch.delenv("OPENAI_API_KEY", raising=False)
@@ -77,7 +81,9 @@ class TestRelayStatusLiveDerivedState:
         assert result["status"] == "pending"
         assert result["providers_configured"] == []
 
-    def test_response_includes_providers_configured_field(self, monkeypatch: pytest.MonkeyPatch) -> None:
+    def test_response_includes_providers_configured_field(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
         """relay_status always includes providers_configured key in response."""
         monkeypatch.delenv("GEMINI_API_KEY", raising=False)
         monkeypatch.delenv("OPENAI_API_KEY", raising=False)
@@ -108,7 +114,9 @@ class TestRelayStatusLiveDerivedState:
 class TestRelaySkipHonesty:
     """relay_skip reports needs_setup when no env vars are set (Bug 2 fix)."""
 
-    def test_returns_needs_setup_when_no_env_vars(self, monkeypatch: pytest.MonkeyPatch) -> None:
+    def test_returns_needs_setup_when_no_env_vars(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
         """relay_skip returns needs_setup status when no provider env vars set."""
         monkeypatch.delenv("GEMINI_API_KEY", raising=False)
         monkeypatch.delenv("OPENAI_API_KEY", raising=False)
@@ -119,7 +127,9 @@ class TestRelaySkipHonesty:
         assert result["status"] == "needs_setup"
         assert "open_relay" in result["message"]
 
-    def test_returns_using_env_when_env_vars_set(self, monkeypatch: pytest.MonkeyPatch) -> None:
+    def test_returns_using_env_when_env_vars_set(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
         """relay_skip returns using_env status when provider env vars are set."""
         monkeypatch.setenv("OPENAI_API_KEY", "sk-test")
         monkeypatch.delenv("GEMINI_API_KEY", raising=False)

--- a/uv.lock
+++ b/uv.lock
@@ -531,7 +531,7 @@ wheels = [
 
 [[package]]
 name = "imagine-mcp"
-version = "1.2.0b1"
+version = "1.2.0b2"
 source = { editable = "." }
 dependencies = [
     { name = "diskcache" },


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: The application fetches external media (reference images, API-returned URLs) in `grok.py` and `openai.py` using raw `httpx.get()` calls. This bypassing the initial URL validation checks and makes the application vulnerable to Server-Side Request Forgery (SSRF) if a redirect occurs pointing to a local or internal IP.
🎯 Impact: An attacker could potentially bypass the initial validation and cause the server to make requests to internal services or localhost via HTTP redirects.
🔧 Fix:
1. Replaced `httpx.get` with `get_ssrf_safe_client().get` in providers to ensure redirect URLs are validated against `SSRFSafeTransport`.
2. Implemented connection pooling via a module-level `_CLIENT` variable in `media.py` so the connection doesn't drop.
3. Removed `with get_ssrf_safe_client()` blocks in `media.py` since the global client should not be closed.
4. Added an autouse test fixture in `tests/conftest.py` to clear the `_CLIENT` global, maintaining test isolation.
5. Logged learning to `.jules/sentinel.md`.

✅ Verification: Run `uv run pytest tests/` to confirm all tests pass successfully.

---
*PR created automatically by Jules for task [13784445967606221999](https://jules.google.com/task/13784445967606221999) started by @n24q02m*