### PR TITLE
⚡ Bolt: Reuse connection pools for SSRF-safe HTTP requests

### DIFF
--- a/src/imagine_mcp/media.py
+++ b/src/imagine_mcp/media.py
@@ -29,8 +29,16 @@ class SSRFSafeTransport(httpx.HTTPTransport):
         return super().handle_request(request)
 
 
+# ⚡ Bolt: Global client instance to reuse connection pools across SSRF-safe HTTP requests.
+# Creating a new httpx.Client per request adds significant overhead for TCP/TLS handshakes.
+_CLIENT: httpx.Client | None = None
+
+
 def get_ssrf_safe_client() -> httpx.Client:
-    return httpx.Client(transport=SSRFSafeTransport())
+    global _CLIENT
+    if _CLIENT is None:
+        _CLIENT = httpx.Client(transport=SSRFSafeTransport())
+    return _CLIENT
 
 
 def detect_media_type(url: str) -> MediaType:
@@ -46,9 +54,9 @@ def detect_media_type(url: str) -> MediaType:
         return "video"
 
     try:
-        with get_ssrf_safe_client() as client:
-            resp = client.head(url, follow_redirects=True, timeout=10)
-            resp.raise_for_status()
+        client = get_ssrf_safe_client()
+        resp = client.head(url, follow_redirects=True, timeout=10)
+        resp.raise_for_status()
     except httpx.HTTPError as e:
         raise MediaDetectError(f"HEAD request failed for {url}: {e}") from e
     except InvalidURLError as e:
@@ -78,10 +86,8 @@ def download_to_path(url: str, dest: Path) -> Path:
     """Download URL content to dest path. Returns path."""
     dest.parent.mkdir(parents=True, exist_ok=True)
     try:
-        with (
-            get_ssrf_safe_client() as client,
-            client.stream("GET", url, follow_redirects=True, timeout=60) as resp,
-        ):
+        client = get_ssrf_safe_client()
+        with client.stream("GET", url, follow_redirects=True, timeout=60) as resp:
             resp.raise_for_status()
             with dest.open("wb") as f:
                 for chunk in resp.iter_bytes(chunk_size=65536):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,15 @@
+import pytest
+
+import imagine_mcp.media
+
+
+@pytest.fixture(autouse=True)
+def reset_ssrf_safe_client():
+    """Reset the global _CLIENT in imagine_mcp.media before each test."""
+    if imagine_mcp.media._CLIENT is not None:
+        imagine_mcp.media._CLIENT.close()
+    imagine_mcp.media._CLIENT = None
+    yield
+    if imagine_mcp.media._CLIENT is not None:
+        imagine_mcp.media._CLIENT.close()
+    imagine_mcp.media._CLIENT = None

--- a/tests/test_g6_ux_status_accuracy.py
+++ b/tests/test_g6_ux_status_accuracy.py
@@ -47,7 +47,9 @@ def _relay_skip() -> dict[str, Any]:
 class TestRelayStatusLiveDerivedState:
     """relay_status derives state from live PerPluginStore, not env-only."""
 
-    def test_returns_configured_when_store_has_keys(self, monkeypatch: pytest.MonkeyPatch) -> None:
+    def test_returns_configured_when_store_has_keys(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
         """relay_status returns configured when PerPluginStore has provider keys."""
         monkeypatch.delenv("GEMINI_API_KEY", raising=False)
         monkeypatch.delenv("OPENAI_API_KEY", raising=False)
@@ -62,7 +64,9 @@ class TestRelayStatusLiveDerivedState:
         assert result["status"] == "configured"
         assert "gemini" in result["providers_configured"]
 
-    def test_returns_pending_when_store_empty(self, monkeypatch: pytest.MonkeyPatch) -> None:
+    def test_returns_pending_when_store_empty(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
         """relay_status returns pending when store empty and no env vars."""
         monkeypatch.delenv("GEMINI_API_KEY", raising=False)
         monkeypatch.delenv("OPENAI_API_KEY", raising=False)
@@ -77,7 +81,9 @@ class TestRelayStatusLiveDerivedState:
         assert result["status"] == "pending"
         assert result["providers_configured"] == []
 
-    def test_response_includes_providers_configured_field(self, monkeypatch: pytest.MonkeyPatch) -> None:
+    def test_response_includes_providers_configured_field(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
         """relay_status always includes providers_configured key in response."""
         monkeypatch.delenv("GEMINI_API_KEY", raising=False)
         monkeypatch.delenv("OPENAI_API_KEY", raising=False)
@@ -108,7 +114,9 @@ class TestRelayStatusLiveDerivedState:
 class TestRelaySkipHonesty:
     """relay_skip reports needs_setup when no env vars are set (Bug 2 fix)."""
 
-    def test_returns_needs_setup_when_no_env_vars(self, monkeypatch: pytest.MonkeyPatch) -> None:
+    def test_returns_needs_setup_when_no_env_vars(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
         """relay_skip returns needs_setup status when no provider env vars set."""
         monkeypatch.delenv("GEMINI_API_KEY", raising=False)
         monkeypatch.delenv("OPENAI_API_KEY", raising=False)
@@ -119,7 +127,9 @@ class TestRelaySkipHonesty:
         assert result["status"] == "needs_setup"
         assert "open_relay" in result["message"]
 
-    def test_returns_using_env_when_env_vars_set(self, monkeypatch: pytest.MonkeyPatch) -> None:
+    def test_returns_using_env_when_env_vars_set(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
         """relay_skip returns using_env status when provider env vars are set."""
         monkeypatch.setenv("OPENAI_API_KEY", "sk-test")
         monkeypatch.delenv("GEMINI_API_KEY", raising=False)

--- a/uv.lock
+++ b/uv.lock
@@ -531,7 +531,7 @@ wheels = [
 
 [[package]]
 name = "imagine-mcp"
-version = "1.2.0b1"
+version = "1.2.0b2"
 source = { editable = "." }
 dependencies = [
     { name = "diskcache" },


### PR DESCRIPTION
💡 What: Implemented a global connection pool using `httpx.Client` for SSRF-safe HTTP requests in `src/imagine_mcp/media.py`. Replaced `with` blocks around client usage in functions to ensure the pool isn't prematurely closed while retaining context managers for stream downloads. Also added a `reset_ssrf_safe_client` fixture in `tests/conftest.py` to prevent test pollution and `ResourceWarning`s.

🎯 Why: Creating a new `httpx.Client` instance for every external media URL request introduces significant overhead due to repetitive TCP and TLS handshakes. This architectural change avoids that cost.

📊 Impact: Significantly faster execution when sequentially or concurrently validating or downloading multiple media files from external URLs, as connections are now pooled and reused.

🔬 Measurement: Verify by running tests via `uv run pytest tests/` to ensure no `ResourceWarning`s appear and that `MediaDetectError` assertions remain functional. Real-world verification involves tracing application requests before and after the change; connection establishment time will be vastly reduced.

---
*PR created automatically by Jules for task [16283926862803128705](https://jules.google.com/task/16283926862803128705) started by @n24q02m*