### PR TITLE
🛡️ Sentinel: [HIGH] Fix SSRF bypass via HTTP redirects

### DIFF
--- a/src/imagine_mcp/media.py
+++ b/src/imagine_mcp/media.py
@@ -29,8 +29,14 @@ class SSRFSafeTransport(httpx.HTTPTransport):
         return super().handle_request(request)
 
 
+_CLIENT: httpx.Client | None = None
+
+
 def get_ssrf_safe_client() -> httpx.Client:
-    return httpx.Client(transport=SSRFSafeTransport())
+    global _CLIENT
+    if _CLIENT is None:
+        _CLIENT = httpx.Client(transport=SSRFSafeTransport())
+    return _CLIENT
 
 
 def detect_media_type(url: str) -> MediaType:
@@ -46,9 +52,9 @@ def detect_media_type(url: str) -> MediaType:
         return "video"
 
     try:
-        with get_ssrf_safe_client() as client:
-            resp = client.head(url, follow_redirects=True, timeout=10)
-            resp.raise_for_status()
+        client = get_ssrf_safe_client()
+        resp = client.head(url, follow_redirects=True, timeout=10)
+        resp.raise_for_status()
     except httpx.HTTPError as e:
         raise MediaDetectError(f"HEAD request failed for {url}: {e}") from e
     except InvalidURLError as e:
@@ -78,10 +84,8 @@ def download_to_path(url: str, dest: Path) -> Path:
     """Download URL content to dest path. Returns path."""
     dest.parent.mkdir(parents=True, exist_ok=True)
     try:
-        with (
-            get_ssrf_safe_client() as client,
-            client.stream("GET", url, follow_redirects=True, timeout=60) as resp,
-        ):
+        client = get_ssrf_safe_client()
+        with client.stream("GET", url, follow_redirects=True, timeout=60) as resp:
             resp.raise_for_status()
             with dest.open("wb") as f:
                 for chunk in resp.iter_bytes(chunk_size=65536):

--- a/src/imagine_mcp/providers/grok.py
+++ b/src/imagine_mcp/providers/grok.py
@@ -112,8 +112,14 @@ def generate_image(
     data = resp.json()
     img_b64 = data["data"][0].get("b64_json")
     if not img_b64:
+        from imagine_mcp.media import get_ssrf_safe_client
+
         img_url = data["data"][0].get("url")
-        img_b64 = base64.b64encode(httpx.get(img_url, timeout=60).content).decode()
+        img_b64 = base64.b64encode(
+            get_ssrf_safe_client()
+            .get(img_url, follow_redirects=True, timeout=60)
+            .content
+        ).decode()
 
     img_bytes = base64.b64decode(img_b64)
     out_dir = Path(platformdirs.user_cache_dir("imagine-mcp")) / "generations"
@@ -196,8 +202,14 @@ def generate_video(
             status_code=500,
         )
 
+    from imagine_mcp.media import get_ssrf_safe_client
+
     video_url = data["video_url"]
-    video_bytes = httpx.get(video_url, timeout=120).content
+    video_bytes = (
+        get_ssrf_safe_client()
+        .get(video_url, follow_redirects=True, timeout=120)
+        .content
+    )
 
     out_dir = Path(platformdirs.user_cache_dir("imagine-mcp")) / "generations"
     out_dir.mkdir(parents=True, exist_ok=True)

--- a/src/imagine_mcp/providers/openai.py
+++ b/src/imagine_mcp/providers/openai.py
@@ -8,7 +8,6 @@ import uuid
 from pathlib import Path
 from typing import Any
 
-import httpx
 import platformdirs
 
 from imagine_mcp.config import settings
@@ -87,7 +86,13 @@ def generate_image(
     size = size_map.get(aspect_ratio, "1024x1024")
 
     if reference_image_url:
-        img_bytes = httpx.get(reference_image_url, timeout=60).content
+        from imagine_mcp.media import get_ssrf_safe_client
+
+        img_bytes = (
+            get_ssrf_safe_client()
+            .get(reference_image_url, follow_redirects=True, timeout=60)
+            .content
+        )
         resp = _client().images.edit(
             model=model, image=img_bytes, prompt=prompt, size=size
         )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,19 @@
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def reset_clients():
+    """Reset module-level clients before each test to ensure isolation."""
+    from imagine_mcp import media
+    from imagine_mcp.providers import gemini, grok, openai
+
+    media._CLIENT = None
+
+    if hasattr(grok, "_CLIENT"):
+        grok._CLIENT = None
+
+    if hasattr(gemini, "_CLIENT"):
+        gemini._CLIENT = None
+
+    if hasattr(openai, "_CLIENT"):
+        openai._CLIENT = None

--- a/tests/test_g6_ux_status_accuracy.py
+++ b/tests/test_g6_ux_status_accuracy.py
@@ -47,7 +47,9 @@ def _relay_skip() -> dict[str, Any]:
 class TestRelayStatusLiveDerivedState:
     """relay_status derives state from live PerPluginStore, not env-only."""
 
-    def test_returns_configured_when_store_has_keys(self, monkeypatch: pytest.MonkeyPatch) -> None:
+    def test_returns_configured_when_store_has_keys(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
         """relay_status returns configured when PerPluginStore has provider keys."""
         monkeypatch.delenv("GEMINI_API_KEY", raising=False)
         monkeypatch.delenv("OPENAI_API_KEY", raising=False)
@@ -62,7 +64,9 @@ class TestRelayStatusLiveDerivedState:
         assert result["status"] == "configured"
         assert "gemini" in result["providers_configured"]
 
-    def test_returns_pending_when_store_empty(self, monkeypatch: pytest.MonkeyPatch) -> None:
+    def test_returns_pending_when_store_empty(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
         """relay_status returns pending when store empty and no env vars."""
         monkeypatch.delenv("GEMINI_API_KEY", raising=False)
         monkeypatch.delenv("OPENAI_API_KEY", raising=False)
@@ -77,7 +81,9 @@ class TestRelayStatusLiveDerivedState:
         assert result["status"] == "pending"
         assert result["providers_configured"] == []
 
-    def test_response_includes_providers_configured_field(self, monkeypatch: pytest.MonkeyPatch) -> None:
+    def test_response_includes_providers_configured_field(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
         """relay_status always includes providers_configured key in response."""
         monkeypatch.delenv("GEMINI_API_KEY", raising=False)
         monkeypatch.delenv("OPENAI_API_KEY", raising=False)
@@ -108,7 +114,9 @@ class TestRelayStatusLiveDerivedState:
 class TestRelaySkipHonesty:
     """relay_skip reports needs_setup when no env vars are set (Bug 2 fix)."""
 
-    def test_returns_needs_setup_when_no_env_vars(self, monkeypatch: pytest.MonkeyPatch) -> None:
+    def test_returns_needs_setup_when_no_env_vars(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
         """relay_skip returns needs_setup status when no provider env vars set."""
         monkeypatch.delenv("GEMINI_API_KEY", raising=False)
         monkeypatch.delenv("OPENAI_API_KEY", raising=False)
@@ -119,7 +127,9 @@ class TestRelaySkipHonesty:
         assert result["status"] == "needs_setup"
         assert "open_relay" in result["message"]
 
-    def test_returns_using_env_when_env_vars_set(self, monkeypatch: pytest.MonkeyPatch) -> None:
+    def test_returns_using_env_when_env_vars_set(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
         """relay_skip returns using_env status when provider env vars are set."""
         monkeypatch.setenv("OPENAI_API_KEY", "sk-test")
         monkeypatch.delenv("GEMINI_API_KEY", raising=False)

--- a/uv.lock
+++ b/uv.lock
@@ -531,7 +531,7 @@ wheels = [
 
 [[package]]
 name = "imagine-mcp"
-version = "1.2.0b1"
+version = "1.2.0b2"
 source = { editable = "." }
 dependencies = [
     { name = "diskcache" },


### PR DESCRIPTION
🚨 **Severity:** HIGH
💡 **Vulnerability:** Server-Side Request Forgery (SSRF) bypass. The application fetched external URLs using raw `httpx.get(url)` inside provider files (`openai.py` and `grok.py`). While initial URLs were validated by `_validate_url`, `httpx` follows redirects by default without checking the target URLs. An attacker could provide a URL that redirects to an internal, private IP address, bypassing SSRF protection.
🎯 **Impact:** An attacker could exploit this to perform port scanning, interact with internal services, or access cloud metadata APIs on the local network.
🔧 **Fix:** 
1. Replaced raw `httpx.get` calls in `grok.py` and `openai.py` with `get_ssrf_safe_client().get()`. This client uses an `SSRFSafeTransport` which explicitly calls `_validate_url` on every redirect.
2. Optimized `get_ssrf_safe_client()` in `media.py` to use a lazy-initialized global `_CLIENT` for connection pooling, rather than instantiating and closing a new client per request.
3. Added `tests/conftest.py` with a `pytest` autouse fixture to reset module-level globals between test runs, preventing state bleed.
4. Documented the security pattern in `.jules/sentinel.md`.

✅ **Verification:** 
- Ran `uv run pytest tests/` – all 103 tests pass.
- Verified `ruff check` and `ruff format` pass cleanly.
- Inspected the patched code to verify the client is correctly retained and streamed connections are safely closed.

---
*PR created automatically by Jules for task [326466458472961338](https://jules.google.com/task/326466458472961338) started by @n24q02m*