### PR TITLE
fix: gate PerPluginStore reads behind HTTP mode (stdio = env-only)

### DIFF
--- a/src/imagine_mcp/credential_state.py
+++ b/src/imagine_mcp/credential_state.py
@@ -7,15 +7,37 @@ Storage layout:
 
 Replaces legacy mcp_core.storage.config_file (shared config.enc) which
 caused multi-daemon path-drift contention.
+
+Stdio mode pure-env policy (spec 2026-05-01-stdio-pure-http-multiuser §4.1):
+    Stdio = env vars ONLY. PerPluginStore reads are gated behind ``_is_http()``
+    so that a stdio process never silently picks up credentials from a config
+    file written by a previous HTTP-mode session. ``_is_http`` mirrors the
+    detection logic in ``imagine_mcp.__main__`` (``--http`` flag,
+    ``MCP_TRANSPORT=http``, ``TRANSPORT_MODE=http``).
 """
 
 from __future__ import annotations
 
 import os
+import sys
 
 from mcp_core.storage.per_plugin_store import PerPluginStore
 
 PLUGIN_NAME = "imagine"
+
+
+def _is_http() -> bool:
+    """Return True when the current process runs in HTTP mode.
+
+    Mirrors ``imagine_mcp.__main__.main`` so PerPluginStore fallback reads
+    only happen in HTTP mode. In stdio mode, credentials must come from
+    env vars exclusively (per spec 2026-05-01 §4.1 + OQ3).
+    """
+    return (
+        "--http" in sys.argv
+        or os.environ.get("MCP_TRANSPORT") == "http"
+        or os.environ.get("TRANSPORT_MODE") == "http"
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -29,7 +51,14 @@ def store_for_sub(sub: str, config: dict[str, str]) -> None:
 
 
 def read_for_sub(sub: str) -> dict[str, str]:
-    """Read the stored config for ``sub``; ``{}`` if not yet stored."""
+    """Read the stored config for ``sub``; ``{}`` if not yet stored.
+
+    Per-sub reads only make sense in HTTP multi-user mode -- the JWT subject
+    is issued by mcp-core's local OAuth AS, which only runs under
+    ``run_http_server``. Returns ``{}`` in stdio mode (no fallback).
+    """
+    if not _is_http():
+        return {}
     return PerPluginStore(PLUGIN_NAME, sub).load() or {}
 
 
@@ -39,7 +68,13 @@ def read_for_sub(sub: str) -> dict[str, str]:
 
 
 def load_credentials(sub: str | None = None) -> dict:
-    """Load credentials for optional sub. Returns {} if not found."""
+    """Load credentials for optional sub. Returns {} if not found.
+
+    Stdio mode skips PerPluginStore entirely (env-only policy); HTTP mode
+    reads the per-sub or single-user store as before.
+    """
+    if not _is_http():
+        return {}
     return PerPluginStore(PLUGIN_NAME, sub).load() or {}
 
 

--- a/tests/integration/test_multi_user_remote.py
+++ b/tests/integration/test_multi_user_remote.py
@@ -1,8 +1,19 @@
-"""Per-sub LLM key isolation in imagine-mcp remote multi-user mode."""
+"""Per-sub LLM key isolation in imagine-mcp remote multi-user mode.
+
+Multi-user remote is an HTTP-mode deployment property (spec 2026-05-01
+§4.2). Stdio mode never reads from PerPluginStore, so these tests must
+opt into HTTP mode via ``MCP_TRANSPORT=http`` for ``read_for_sub`` to
+return the stored credentials.
+"""
 
 from __future__ import annotations
 
 import pytest
+
+
+@pytest.fixture(autouse=True)
+def _force_http_mode(monkeypatch):
+    monkeypatch.setenv("MCP_TRANSPORT", "http")
 
 
 @pytest.mark.integration

--- a/tests/test_credential_state_stdio_no_fallback.py
+++ b/tests/test_credential_state_stdio_no_fallback.py
@@ -1,0 +1,109 @@
+"""Regression: stdio mode MUST NOT read PerPluginStore as fallback.
+
+Spec: ``.superpower/mcp-core/specs/2026-05-01-stdio-pure-http-multiuser.md``
+§4.1 -- "Cred source: env vars ONLY (per OQ3, no auto-spawn relay)".
+
+Before this guard, ``credential_state.load_credentials`` and
+``read_for_sub`` would silently surface keys written by a previous
+HTTP-mode session even when the current process runs in pure stdio
+mode (no ``--http`` flag, ``MCP_TRANSPORT``/``TRANSPORT_MODE`` unset).
+That broke the env-only invariant and could leak credentials across
+storage scopes.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from imagine_mcp.credential_state import (
+    PLUGIN_NAME,
+    load_credentials,
+    read_for_sub,
+)
+
+
+@pytest.fixture
+def _no_http_env(monkeypatch):
+    """Force stdio mode: clear all HTTP indicators."""
+    monkeypatch.delenv("MCP_TRANSPORT", raising=False)
+    monkeypatch.delenv("TRANSPORT_MODE", raising=False)
+    monkeypatch.setattr("sys.argv", ["imagine-mcp"])
+
+
+@pytest.fixture
+def _http_env(monkeypatch):
+    """Force HTTP mode via MCP_TRANSPORT env var."""
+    monkeypatch.setenv("MCP_TRANSPORT", "http")
+    monkeypatch.delenv("TRANSPORT_MODE", raising=False)
+    monkeypatch.setattr("sys.argv", ["imagine-mcp"])
+
+
+def test_stdio_skips_per_plugin_store_load(tmp_path, monkeypatch, _no_http_env):
+    """Stdio mode: load_credentials returns {} even when store has keys."""
+    monkeypatch.setattr("pathlib.Path.home", lambda: tmp_path)
+    from mcp_core.storage.per_plugin_store import PerPluginStore
+
+    # Simulate prior HTTP-mode write.
+    PerPluginStore(PLUGIN_NAME).save({"GEMINI_API_KEY": "leaked-key"})
+
+    # Stdio process must NOT see those keys.
+    assert load_credentials() == {}
+
+
+def test_stdio_skips_read_for_sub(tmp_path, monkeypatch, _no_http_env):
+    """Stdio mode: read_for_sub returns {} even when sub bucket has keys."""
+    monkeypatch.setattr("pathlib.Path.home", lambda: tmp_path)
+    monkeypatch.setenv("CREDENTIAL_SECRET", "test-secret-value")
+    from mcp_core.storage.per_plugin_store import PerPluginStore
+
+    PerPluginStore(PLUGIN_NAME, "user-abc").save({"OPENAI_API_KEY": "sk-leaked"})
+
+    assert read_for_sub("user-abc") == {}
+
+
+def test_stdio_argv_http_flag_enables_per_plugin_store(tmp_path, monkeypatch):
+    """``--http`` flag in argv enables HTTP-mode PerPluginStore reads."""
+    monkeypatch.delenv("MCP_TRANSPORT", raising=False)
+    monkeypatch.delenv("TRANSPORT_MODE", raising=False)
+    monkeypatch.setattr("sys.argv", ["imagine-mcp", "--http"])
+    monkeypatch.setattr("pathlib.Path.home", lambda: tmp_path)
+    from mcp_core.storage.per_plugin_store import PerPluginStore
+
+    PerPluginStore(PLUGIN_NAME).save({"GEMINI_API_KEY": "http-key"})
+
+    assert load_credentials().get("GEMINI_API_KEY") == "http-key"
+
+
+def test_http_mode_uses_per_plugin_store(tmp_path, monkeypatch, _http_env):
+    """HTTP mode (MCP_TRANSPORT=http): load_credentials reads the store."""
+    monkeypatch.setattr("pathlib.Path.home", lambda: tmp_path)
+    from mcp_core.storage.per_plugin_store import PerPluginStore
+
+    PerPluginStore(PLUGIN_NAME).save({"XAI_API_KEY": "xai-key"})
+
+    result = load_credentials()
+    assert result.get("XAI_API_KEY") == "xai-key"
+
+
+def test_http_mode_uses_per_sub_store(tmp_path, monkeypatch, _http_env):
+    """HTTP mode: read_for_sub returns the sub-scoped credentials."""
+    monkeypatch.setattr("pathlib.Path.home", lambda: tmp_path)
+    monkeypatch.setenv("CREDENTIAL_SECRET", "test-secret-value")
+    from mcp_core.storage.per_plugin_store import PerPluginStore
+
+    PerPluginStore(PLUGIN_NAME, "user-xyz").save({"OPENAI_API_KEY": "sk-xyz"})
+
+    assert read_for_sub("user-xyz").get("OPENAI_API_KEY") == "sk-xyz"
+
+
+def test_transport_mode_env_enables_per_plugin_store(tmp_path, monkeypatch):
+    """``TRANSPORT_MODE=http`` env var also enables PerPluginStore reads."""
+    monkeypatch.delenv("MCP_TRANSPORT", raising=False)
+    monkeypatch.setenv("TRANSPORT_MODE", "http")
+    monkeypatch.setattr("sys.argv", ["imagine-mcp"])
+    monkeypatch.setattr("pathlib.Path.home", lambda: tmp_path)
+    from mcp_core.storage.per_plugin_store import PerPluginStore
+
+    PerPluginStore(PLUGIN_NAME).save({"GEMINI_API_KEY": "transport-key"})
+
+    assert load_credentials().get("GEMINI_API_KEY") == "transport-key"

--- a/tests/test_per_plugin_storage_migration.py
+++ b/tests/test_per_plugin_storage_migration.py
@@ -1,6 +1,24 @@
-"""Verify migration to PerPluginStore + cred persistence works."""
+"""Verify migration to PerPluginStore + cred persistence works.
+
+These tests validate HTTP-mode credential storage semantics. Stdio mode
+forbids PerPluginStore reads (spec 2026-05-01 §4.1) -- see
+``test_credential_state_stdio_no_fallback.py`` for the stdio-side guard.
+"""
 
 from __future__ import annotations
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def _force_http_mode(monkeypatch):
+    """Run all tests in this module under HTTP mode.
+
+    ``credential_state.load_credentials`` / ``read_for_sub`` skip the
+    PerPluginStore in stdio mode per spec 2026-05-01 §4.1, so the legacy
+    storage tests must opt in to HTTP mode explicitly.
+    """
+    monkeypatch.setenv("MCP_TRANSPORT", "http")
 
 
 def test_loads_from_new_path(tmp_path, monkeypatch):

--- a/uv.lock
+++ b/uv.lock
@@ -531,7 +531,7 @@ wheels = [
 
 [[package]]
 name = "imagine-mcp"
-version = "1.2.0b2"
+version = "1.2.0b3"
 source = { editable = "." }
 dependencies = [
     { name = "diskcache" },


### PR DESCRIPTION
## Summary

- Stdio mode pure-env policy per spec [`2026-05-01-stdio-pure-http-multiuser`](../.superpower/mcp-core/specs/2026-05-01-stdio-pure-http-multiuser.md) §4.1 + OQ3: *"Cred source: env vars ONLY"*.
- `credential_state.load_credentials` and `read_for_sub` previously read `PerPluginStore` unconditionally (lines 33, 43) — a stdio process could silently surface keys written by a prior HTTP-mode session, breaking the env-only invariant.
- New `_is_http()` helper mirrors `imagine_mcp.__main__` detection (`--http` flag, `MCP_TRANSPORT=http`, `TRANSPORT_MODE=http`) and gates both reads.
- Mirrors the wet-mcp pattern referenced in the task.

## Test plan

- [x] `tests/test_credential_state_stdio_no_fallback.py` (6 cases): stdio skip via missing env, stdio skip via `read_for_sub`, `--http` argv enables fallback, `MCP_TRANSPORT=http` enables fallback (single-user + per-sub), `TRANSPORT_MODE=http` enables fallback.
- [x] Existing `test_per_plugin_storage_migration.py` + `tests/integration/test_multi_user_remote.py` opt into HTTP mode via autouse fixture (these validate HTTP-mode storage semantics).
- [x] `uv run pytest` -> 109 passed.
- [x] `uv run pytest -m integration` -> 2 passed.
- [x] `uv run ruff check .` + `uv run ruff format --check .` + `uv run ty check` -> all green.
- [x] `UV_NO_SOURCES=1 uv lock` regenerated.

Spec impact: imagine-mcp has optional creds (≥1 of `GEMINI_API_KEY`/`OPENAI_API_KEY`/`XAI_API_KEY`). `__main__.py` already exits with the stdio missing-cred message when none are set; this PR closes the silent-fallback gap when at least one HTTP-mode key was previously persisted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)