### PR TITLE
fix: imagine auto-fallback provider when default API key missing

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -64,11 +64,18 @@ For the authoritative leaderboard-sorted table see [`docs/models.md`](docs/model
 
 3 API keys (all optional — server runs in degraded mode with missing creds):
 
-- `GEMINI_API_KEY` (renamed from `GOOGLE_AI_STUDIO_API_KEY` 2026-04-26 for parity with wet/mnemo/crg)
-- `OPENAI_API_KEY`
 - `XAI_API_KEY`
+- `OPENAI_API_KEY`
+- `GEMINI_API_KEY` (renamed from `GOOGLE_AI_STUDIO_API_KEY` 2026-04-26 for parity with wet/mnemo/crg)
 
-Priority: env var > `config.enc` (via mcp-core) > relay setup > degraded mode.
+Source priority: env var > `config.enc` (via mcp-core) > relay setup > degraded mode.
+
+Auto-fallback provider (when `understand`/`generate` is called without an
+explicit `provider`): the first key present in this order wins —
+`XAI_API_KEY` → `grok`, `OPENAI_API_KEY` → `openai`, `GEMINI_API_KEY` →
+`gemini`. Gemini is last because Google AI Studio accounts can be
+billing-locked at the org level (403 PERMISSION_DENIED) without warning. If
+no key is configured the dispatcher raises `CredentialMissingError`.
 
 ## Install
 

--- a/src/imagine_mcp/dispatcher.py
+++ b/src/imagine_mcp/dispatcher.py
@@ -5,11 +5,13 @@ from __future__ import annotations
 import concurrent.futures
 import importlib
 import ipaddress
+import os
 import socket
 from typing import Any
 from urllib.parse import urlparse
 
 from imagine_mcp.errors import (
+    CredentialMissingError,
     InvalidMediaTypeError,
     InvalidProviderError,
     InvalidTierError,
@@ -22,6 +24,17 @@ from imagine_mcp.models import UNSUPPORTED, get_model_id
 VALID_PROVIDERS = ["gemini", "openai", "grok"]
 VALID_TIERS = ["poor", "rich"]
 VALID_MEDIA_TYPES = ["image", "video"]
+
+# Auto-fallback priority when caller does not pin a provider. Order is
+# (XAI, OpenAI, Gemini): Gemini stays last because Google AI Studio
+# accounts can be billing-locked at the org level (403 PERMISSION_DENIED
+# on every :generateContent call) without warning, so we prefer keys
+# that are less prone to silent revocation.
+_DEFAULT_PROVIDER_PRIORITY: tuple[tuple[str, str], ...] = (
+    ("XAI_API_KEY", "grok"),
+    ("OPENAI_API_KEY", "openai"),
+    ("GEMINI_API_KEY", "gemini"),
+)
 
 _UNSUPPORTED_HINTS: dict[tuple[str, str, str], str] = {
     ("openai", "video", "understand"): (
@@ -114,6 +127,28 @@ def _validate(provider: str, tier: str) -> None:
         raise InvalidTierError(f"Unknown tier {tier!r}. Valid: {VALID_TIERS}")
 
 
+def _default_provider() -> str:
+    """Return the first provider whose API key is present in the environment.
+
+    Resolution order: XAI_API_KEY -> OPENAI_API_KEY -> GEMINI_API_KEY.
+    Reads ``os.environ`` directly because credentials saved post-startup
+    (via the relay form / config.enc) are written back into ``os.environ``
+    by ``imagine_mcp.credential_state.save_credentials`` and the settings
+    singleton is frozen at import time.
+
+    Raises:
+        CredentialMissingError: when no provider key is configured.
+    """
+    for env_var, provider in _DEFAULT_PROVIDER_PRIORITY:
+        if os.environ.get(env_var):
+            return provider
+    keys = ", ".join(env for env, _ in _DEFAULT_PROVIDER_PRIORITY)
+    raise CredentialMissingError(
+        "No provider API key configured. Set one of: "
+        f"{keys}, or run config(action='open_relay') to configure via browser."
+    )
+
+
 def _load_provider(provider: str) -> Any:
     return importlib.import_module(f"imagine_mcp.providers.{provider}")
 
@@ -129,11 +164,17 @@ def _unsupported(provider: str, media: str, action: str) -> ProviderUnsupportedE
 def dispatch_understand(
     media_urls: list[str],
     prompt: str,
-    provider: str,
+    provider: str | None,
     tier: str,
     max_tokens: int = 2048,
 ) -> dict[str, Any]:
-    """Dispatch understand call to provider."""
+    """Dispatch understand call to provider.
+
+    When ``provider`` is ``None``, auto-resolve via :func:`_default_provider`
+    (first provider whose API key is present in the environment).
+    """
+    if provider is None:
+        provider = _default_provider()
     _validate(provider, tier)
     if not media_urls:
         raise InvalidMediaTypeError("media_urls is empty")
@@ -164,14 +205,20 @@ def dispatch_understand(
 def dispatch_generate(
     media_type: str,
     prompt: str,
-    provider: str,
+    provider: str | None,
     tier: str,
     reference_image_url: str | None = None,
     job_id: str | None = None,
     aspect_ratio: str = "16:9",
     duration_seconds: int = 8,
 ) -> dict[str, Any]:
-    """Dispatch generate call to provider."""
+    """Dispatch generate call to provider.
+
+    When ``provider`` is ``None``, auto-resolve via :func:`_default_provider`
+    (first provider whose API key is present in the environment).
+    """
+    if provider is None:
+        provider = _default_provider()
     _validate(provider, tier)
     if media_type not in VALID_MEDIA_TYPES:
         raise InvalidMediaTypeError(

--- a/src/imagine_mcp/docs/generate.md
+++ b/src/imagine_mcp/docs/generate.md
@@ -8,7 +8,7 @@ Generate an image or video from a text prompt (optionally with a reference image
 generate(
     media_type: "image" | "video",
     prompt: str,
-    provider: str = "gemini",
+    provider: str | None = None,  # auto-fallback when None
     tier: str = "poor",
     reference_image_url: str | None = None,
     job_id: str | None = None,
@@ -17,6 +17,15 @@ generate(
     duration_seconds: int = 8,
 ) -> dict
 ```
+
+## Auto-fallback provider
+
+When ``provider`` is omitted (``None``), imagine resolves the first provider
+whose API key is present in the environment, in priority order
+``XAI_API_KEY`` -> ``OPENAI_API_KEY`` -> ``GEMINI_API_KEY``. Gemini is last
+because Google AI Studio billing-locking can return 403 ``PERMISSION_DENIED``
+without warning. If no key is configured the call raises
+``CredentialMissingError`` listing the three env vars.
 
 ## Image generate
 

--- a/src/imagine_mcp/docs/understand.md
+++ b/src/imagine_mcp/docs/understand.md
@@ -8,11 +8,25 @@ Understand images and/or videos via a multimodal LLM.
 understand(
     media_urls: list[str],       # HTTP(S) URLs -- max 5
     prompt: str,                 # Your question or instruction
-    provider: str = "gemini",    # "gemini" | "openai" | "grok"
+    provider: str | None = None, # "gemini" | "openai" | "grok" (auto-fallback when None)
     tier: str = "poor",          # "poor" | "rich"
     max_tokens: int = 2048,
 ) -> dict
 ```
+
+## Auto-fallback provider
+
+When ``provider`` is omitted (``None``), imagine resolves the first provider
+whose API key is present in the environment, in this priority order:
+
+1. ``XAI_API_KEY`` -> ``grok``
+2. ``OPENAI_API_KEY`` -> ``openai``
+3. ``GEMINI_API_KEY`` -> ``gemini``
+
+Gemini is intentionally last because Google AI Studio accounts can be
+billing-locked at the org level (403 ``PERMISSION_DENIED``) without warning.
+If no key is configured, the call raises ``CredentialMissingError`` listing
+the three env vars.
 
 ## Returns
 

--- a/src/imagine_mcp/server.py
+++ b/src/imagine_mcp/server.py
@@ -115,7 +115,7 @@ def build_app() -> FastMCP:
     def understand(
         media_urls: list[str],
         prompt: str,
-        provider: str = "gemini",
+        provider: str | None = None,
         tier: str = "poor",
         max_tokens: int = 2048,
     ) -> dict[str, Any]:
@@ -136,7 +136,7 @@ def build_app() -> FastMCP:
     def generate(
         media_type: Literal["image", "video"],
         prompt: str,
-        provider: str = "gemini",
+        provider: str | None = None,
         tier: str = "poor",
         reference_image_url: str | None = None,
         job_id: str | None = None,

--- a/tests/test_dispatcher.py
+++ b/tests/test_dispatcher.py
@@ -2,14 +2,26 @@ from __future__ import annotations
 
 import pytest
 
-from imagine_mcp.dispatcher import dispatch_generate, dispatch_understand
+from imagine_mcp.dispatcher import (
+    _default_provider,
+    dispatch_generate,
+    dispatch_understand,
+)
 from imagine_mcp.errors import (
+    CredentialMissingError,
     InvalidMediaTypeError,
     InvalidProviderError,
     InvalidTierError,
     InvalidURLError,
     ProviderUnsupportedError,
 )
+
+
+@pytest.fixture
+def clean_provider_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Ensure no provider API key is leaking from the host environment."""
+    for var in ("XAI_API_KEY", "OPENAI_API_KEY", "GEMINI_API_KEY"):
+        monkeypatch.delenv(var, raising=False)
 
 
 def test_understand_routes_to_gemini_image(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -146,6 +158,122 @@ def test_generate_rejects_non_http_reference_image_url() -> None:
             provider="gemini",
             tier="poor",
             reference_image_url="file:///etc/passwd",
+        )
+
+
+def test_default_provider_grok_only(
+    clean_provider_env: None, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("XAI_API_KEY", "xai-test")
+    assert _default_provider() == "grok"
+
+
+def test_default_provider_openai_only(
+    clean_provider_env: None, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("OPENAI_API_KEY", "sk-test")
+    assert _default_provider() == "openai"
+
+
+def test_default_provider_priority_grok_over_openai(
+    clean_provider_env: None, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("XAI_API_KEY", "xai-test")
+    monkeypatch.setenv("OPENAI_API_KEY", "sk-test")
+    assert _default_provider() == "grok"
+
+
+def test_default_provider_gemini_last_resort(
+    clean_provider_env: None, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("GEMINI_API_KEY", "gem-test")
+    assert _default_provider() == "gemini"
+
+
+def test_default_provider_priority_openai_over_gemini(
+    clean_provider_env: None, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("OPENAI_API_KEY", "sk-test")
+    monkeypatch.setenv("GEMINI_API_KEY", "gem-test")
+    assert _default_provider() == "openai"
+
+
+def test_default_provider_raises_when_none_set(clean_provider_env: None) -> None:
+    with pytest.raises(CredentialMissingError) as exc_info:
+        _default_provider()
+    msg = str(exc_info.value)
+    assert "XAI_API_KEY" in msg
+    assert "OPENAI_API_KEY" in msg
+    assert "GEMINI_API_KEY" in msg
+
+
+def test_dispatch_understand_resolves_default_provider(
+    clean_provider_env: None,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("XAI_API_KEY", "xai-test")
+
+    captured: dict[str, str] = {}
+
+    def mock_fn(url: str, prompt: str, tier: str, max_tokens: int = 2048) -> dict:
+        captured["called"] = "grok"
+        return {"text": "ok", "model": "grok-x", "provider": "grok"}
+
+    import imagine_mcp.providers.grok as grok_mod
+
+    monkeypatch.setattr(grok_mod, "understand_image", mock_fn, raising=False)
+    monkeypatch.setattr("imagine_mcp.dispatcher.detect_media_type", lambda u: "image")
+
+    result = dispatch_understand(
+        media_urls=["https://example.com/cat.png"],
+        prompt="describe",
+        provider=None,
+        tier="poor",
+    )
+    assert captured["called"] == "grok"
+    assert result["provider"] == "grok"
+
+
+def test_dispatch_generate_resolves_default_provider(
+    clean_provider_env: None,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("OPENAI_API_KEY", "sk-test")
+
+    captured: dict[str, str] = {}
+
+    def mock_fn(
+        prompt: str,
+        tier: str,
+        reference_image_url: str | None,
+        aspect_ratio: str,
+    ) -> dict:
+        captured["called"] = "openai"
+        return {"image": "...", "model": "gpt-image", "provider": "openai"}
+
+    import imagine_mcp.providers.openai as openai_mod
+
+    monkeypatch.setattr(openai_mod, "generate_image", mock_fn, raising=False)
+
+    result = dispatch_generate(
+        media_type="image",
+        prompt="a cat",
+        provider=None,
+        tier="poor",
+    )
+    assert captured["called"] == "openai"
+    assert result["provider"] == "openai"
+
+
+def test_dispatch_understand_no_keys_raises_credential_missing(
+    clean_provider_env: None,
+) -> None:
+    with pytest.raises(CredentialMissingError):
+        dispatch_understand(
+            media_urls=["https://example.com/cat.png"],
+            prompt="describe",
+            provider=None,
+            tier="poor",
         )
 
 

--- a/uv.lock
+++ b/uv.lock
@@ -531,7 +531,7 @@ wheels = [
 
 [[package]]
 name = "imagine-mcp"
-version = "1.2.0b3"
+version = "1.2.0b4"
 source = { editable = "." }
 dependencies = [
     { name = "diskcache" },


### PR DESCRIPTION
## Summary

- Default provider was hardcoded `"gemini"` in the `understand` / `generate` tool signatures, so any call failed with `CredentialMissingError` (or upstream 403 `PERMISSION_DENIED` on billing-locked Google AI Studio accounts) when the user only had `XAI_API_KEY` or `OPENAI_API_KEY` configured.
- New `_default_provider()` helper in `src/imagine_mcp/dispatcher.py` resolves the first provider whose API key is present in the environment, priority **XAI -> OpenAI -> Gemini** (Gemini stays last because Google AI Studio billing-locking can silently revoke access).
- `dispatch_understand` / `dispatch_generate` now accept `provider: str | None`; when `None`, they delegate to `_default_provider()`.
- Tool defaults in `server.py` change from `"gemini"` to `None`. Existing `_validate(provider, tier)` still runs after resolution.
- Docs updated: `docs/understand.md`, `docs/generate.md`, and `CLAUDE.md` describe the auto-fallback behaviour and ordering rationale.

## Test plan

- [x] `uv run pytest -x` -- 118 passed, 3 deselected.
- [x] New tests in `tests/test_dispatcher.py`:
  - `_default_provider()` returns `"grok"` when only `XAI_API_KEY` set.
  - returns `"openai"` when only `OPENAI_API_KEY` set.
  - returns `"grok"` when both XAI + OpenAI set (priority).
  - returns `"openai"` when OpenAI + Gemini set.
  - returns `"gemini"` when only `GEMINI_API_KEY` set (last resort).
  - raises `CredentialMissingError` listing all three env vars when none set.
  - `dispatch_understand(provider=None)` resolves via `_default_provider()` and routes to grok provider module.
  - `dispatch_generate(provider=None)` resolves via `_default_provider()` and routes to openai provider module.
  - `dispatch_understand(provider=None)` with no keys raises `CredentialMissingError`.
- [x] `uv run ruff check . --fix` -- All checks passed.
- [x] `uv run ruff format .` -- 42 files left unchanged.
- [x] `uv run ty check src/` -- All checks passed.

## Spec reference

§4.1 imagine row of `~/projects/.superpower/mcp-core/specs/2026-05-01-stdio-pure-http-multiuser.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)