### PR TITLE
fix: HTTP multi-user credential wiring (per-sub contextvar)

### DIFF
--- a/src/imagine_mcp/credential_state.py
+++ b/src/imagine_mcp/credential_state.py
@@ -14,16 +14,75 @@ Stdio mode pure-env policy (spec 2026-05-01-stdio-pure-http-multiuser §4.1):
     file written by a previous HTTP-mode session. ``_is_http`` mirrors the
     detection logic in ``imagine_mcp.__main__`` (``--http`` flag,
     ``MCP_TRANSPORT=http``, ``TRANSPORT_MODE=http``).
+
+Per-request sub contextvar (HTTP multi-user mode):
+    The ``auth_scope`` middleware wired by ``imagine_mcp.server.run_http``
+    sets ``_current_sub`` to the JWT ``sub`` claim for the duration of each
+    MCP request. Tool handlers (``understand`` / ``generate``) and the
+    dispatcher resolve credentials via ``credentials_for_current_request()``
+    which picks the per-sub config when a sub is set, or merges os.environ
+    when running single-user / stdio.
 """
 
 from __future__ import annotations
 
+import contextvars
 import os
 import sys
 
 from mcp_core.storage.per_plugin_store import PerPluginStore
 
 PLUGIN_NAME = "imagine"
+
+# Cloud provider API keys; mirrors ``relay_setup.CREDENTIAL_KEYS`` and the
+# rename to GEMINI_API_KEY (was GOOGLE_AI_STUDIO_API_KEY) finalised 2026-04-26.
+CLOUD_KEYS: tuple[str, ...] = (
+    "XAI_API_KEY",
+    "OPENAI_API_KEY",
+    "GEMINI_API_KEY",
+)
+
+# Per-request JWT sub. Set by ``auth_scope`` middleware in HTTP multi-user
+# mode; ``None`` in stdio + single-user HTTP. ContextVar is asyncio-safe and
+# stays scoped to the request task (ASGI handlers are tasks).
+_current_sub: contextvars.ContextVar[str | None] = contextvars.ContextVar(
+    "imagine_current_sub", default=None
+)
+
+
+def set_current_sub(sub: str | None) -> None:
+    """Set the JWT sub for the current request scope (testing helper).
+
+    Production code should use ``_current_sub.set()`` directly inside the
+    ``auth_scope`` callback so the matching ``reset(token)`` runs in a
+    ``finally`` block.
+    """
+    _current_sub.set(sub)
+
+
+def get_current_sub() -> str | None:
+    """Return the JWT sub for the current request scope, or ``None``."""
+    return _current_sub.get()
+
+
+def credentials_for_current_request() -> dict[str, str]:
+    """Resolve cloud-provider credentials for the active request.
+
+    Resolution rules:
+
+    * Multi-user HTTP (``_current_sub`` set): return the per-sub config from
+      ``~/.imagine-mcp/subs/<sub>/config.json``. ``os.environ`` is NOT
+      merged -- per-sub isolation is the whole point.
+    * Single-user / stdio (no sub): return cloud keys from ``os.environ``
+      so tool handlers see the same view as the legacy direct-env path.
+
+    Returns a dict mapping ``CLOUD_KEYS`` -> value. Missing/empty keys are
+    omitted so callers can use ``mapping.get(K)`` safely.
+    """
+    sub = _current_sub.get()
+    if sub is None:
+        return {k: v for k, v in os.environ.items() if k in CLOUD_KEYS and v}
+    return read_for_sub(sub)
 
 
 def _is_http() -> bool:

--- a/src/imagine_mcp/dispatcher.py
+++ b/src/imagine_mcp/dispatcher.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 import concurrent.futures
 import importlib
 import ipaddress
-import os
 import socket
 from typing import Any
 from urllib.parse import urlparse
@@ -128,19 +127,28 @@ def _validate(provider: str, tier: str) -> None:
 
 
 def _default_provider() -> str:
-    """Return the first provider whose API key is present in the environment.
+    """Return the first provider whose API key is present for this request.
 
     Resolution order: XAI_API_KEY -> OPENAI_API_KEY -> GEMINI_API_KEY.
-    Reads ``os.environ`` directly because credentials saved post-startup
-    (via the relay form / config.enc) are written back into ``os.environ``
-    by ``imagine_mcp.credential_state.save_credentials`` and the settings
-    singleton is frozen at import time.
+
+    Single-user / stdio path: reads ``os.environ`` (credentials saved via the
+    relay form / config.enc are written back into ``os.environ`` by
+    ``imagine_mcp.relay_setup.apply_config``).
+
+    HTTP multi-user path (``auth_scope`` middleware sets ``_current_sub``):
+        Reads the per-sub config from ``~/.imagine-mcp/subs/<sub>/config.json``.
+        ``os.environ`` is intentionally NOT consulted -- isolating users is
+        the whole point of multi-user mode.
 
     Raises:
-        CredentialMissingError: when no provider key is configured.
+        CredentialMissingError: when no provider key is configured for the
+        current request scope.
     """
+    from imagine_mcp.credential_state import credentials_for_current_request
+
+    creds = credentials_for_current_request()
     for env_var, provider in _DEFAULT_PROVIDER_PRIORITY:
-        if os.environ.get(env_var):
+        if creds.get(env_var):
             return provider
     keys = ", ".join(env for env, _ in _DEFAULT_PROVIDER_PRIORITY)
     raise CredentialMissingError(

--- a/src/imagine_mcp/providers/gemini.py
+++ b/src/imagine_mcp/providers/gemini.py
@@ -15,12 +15,53 @@ from imagine_mcp.errors import CredentialMissingError, ProviderAPIError
 from imagine_mcp.models import get_model_id
 
 _CLIENT: Any = None
+# Per-sub client cache for HTTP multi-user mode. Keyed by JWT sub so each
+# user gets a client wired to their own ``GEMINI_API_KEY``. Single-user /
+# stdio mode still uses the module-level ``_CLIENT`` above.
+_SUB_CLIENTS: dict[str, Any] = {}
+
+
+def _resolve_api_key() -> str | None:
+    """Return the GEMINI_API_KEY for the current request scope.
+
+    Multi-user HTTP path uses the per-sub config from PerPluginStore. The
+    settings singleton is read first (frozen at import) for backwards
+    compatibility, then ``credentials_for_current_request()`` which falls
+    back to ``os.environ`` when no sub is active.
+    """
+    from imagine_mcp.credential_state import (
+        credentials_for_current_request,
+        get_current_sub,
+    )
+
+    if get_current_sub() is not None:
+        return credentials_for_current_request().get("GEMINI_API_KEY")
+    return settings.gemini_api_key or os.environ.get("GEMINI_API_KEY")
 
 
 def _client() -> Any:
     global _CLIENT
+    from imagine_mcp.credential_state import get_current_sub
+
+    sub = get_current_sub()
+    if sub is not None:
+        cached = _SUB_CLIENTS.get(sub)
+        if cached is not None:
+            return cached
+        api_key = _resolve_api_key()
+        if not api_key:
+            raise CredentialMissingError(
+                "Gemini API key missing. Run config(action='open_relay') for "
+                "browser-based setup, or set GEMINI_API_KEY."
+            )
+        from google import genai
+
+        client = genai.Client(api_key=api_key)
+        _SUB_CLIENTS[sub] = client
+        return client
+
     if _CLIENT is None:
-        api_key = settings.gemini_api_key or os.environ.get("GEMINI_API_KEY")
+        api_key = _resolve_api_key()
         if not api_key:
             raise CredentialMissingError(
                 "Gemini API key missing. Run config(action='open_relay') for "
@@ -36,6 +77,7 @@ def _reset_client() -> None:
     """Test hook: force _client() to re-read settings."""
     global _CLIENT
     _CLIENT = None
+    _SUB_CLIENTS.clear()
 
 
 def understand_image(

--- a/src/imagine_mcp/providers/grok.py
+++ b/src/imagine_mcp/providers/grok.py
@@ -25,10 +25,25 @@ from imagine_mcp.models import get_model_id
 
 _CLIENT: Any = None
 _BASE_URL = "https://api.x.ai/v1"
+# Per-sub client cache for HTTP multi-user mode (see providers/gemini.py).
+_SUB_CLIENTS: dict[str, Any] = {}
 
 
 def _api_key() -> str:
-    key = settings.xai_api_key or os.environ.get("XAI_API_KEY")
+    """Return XAI_API_KEY for the current request scope.
+
+    Multi-user HTTP requests pull from the per-sub config; single-user /
+    stdio falls back to settings + os.environ.
+    """
+    from imagine_mcp.credential_state import (
+        credentials_for_current_request,
+        get_current_sub,
+    )
+
+    if get_current_sub() is not None:
+        key = credentials_for_current_request().get("XAI_API_KEY")
+    else:
+        key = settings.xai_api_key or os.environ.get("XAI_API_KEY")
     if not key:
         raise CredentialMissingError(
             "xAI (Grok) API key missing. Run config(action='open_relay') for "
@@ -39,6 +54,19 @@ def _api_key() -> str:
 
 def _openai_compat_client() -> Any:
     global _CLIENT
+    from imagine_mcp.credential_state import get_current_sub
+
+    sub = get_current_sub()
+    if sub is not None:
+        cached = _SUB_CLIENTS.get(sub)
+        if cached is not None:
+            return cached
+        from openai import OpenAI
+
+        client = OpenAI(api_key=_api_key(), base_url=_BASE_URL)
+        _SUB_CLIENTS[sub] = client
+        return client
+
     if _CLIENT is None:
         from openai import OpenAI
 
@@ -49,6 +77,7 @@ def _openai_compat_client() -> Any:
 def _reset_client() -> None:
     global _CLIENT
     _CLIENT = None
+    _SUB_CLIENTS.clear()
 
 
 def understand_image(

--- a/src/imagine_mcp/providers/openai.py
+++ b/src/imagine_mcp/providers/openai.py
@@ -19,12 +19,46 @@ from imagine_mcp.errors import (
 from imagine_mcp.models import get_model_id
 
 _CLIENT: Any = None
+# Per-sub client cache for HTTP multi-user mode. See providers/gemini.py
+# for rationale; module-level ``_CLIENT`` still serves stdio + single-user.
+_SUB_CLIENTS: dict[str, Any] = {}
+
+
+def _resolve_api_key() -> str | None:
+    """Return OPENAI_API_KEY for the current request scope (per-sub or env)."""
+    from imagine_mcp.credential_state import (
+        credentials_for_current_request,
+        get_current_sub,
+    )
+
+    if get_current_sub() is not None:
+        return credentials_for_current_request().get("OPENAI_API_KEY")
+    return settings.openai_api_key or os.environ.get("OPENAI_API_KEY")
 
 
 def _client() -> Any:
     global _CLIENT
+    from imagine_mcp.credential_state import get_current_sub
+
+    sub = get_current_sub()
+    if sub is not None:
+        cached = _SUB_CLIENTS.get(sub)
+        if cached is not None:
+            return cached
+        api_key = _resolve_api_key()
+        if not api_key:
+            raise CredentialMissingError(
+                "OpenAI API key missing. Run config(action='open_relay') for "
+                "browser-based setup, or set OPENAI_API_KEY."
+            )
+        from openai import OpenAI
+
+        client = OpenAI(api_key=api_key)
+        _SUB_CLIENTS[sub] = client
+        return client
+
     if _CLIENT is None:
-        api_key = settings.openai_api_key or os.environ.get("OPENAI_API_KEY")
+        api_key = _resolve_api_key()
         if not api_key:
             raise CredentialMissingError(
                 "OpenAI API key missing. Run config(action='open_relay') for "
@@ -39,6 +73,7 @@ def _client() -> Any:
 def _reset_client() -> None:
     global _CLIENT
     _CLIENT = None
+    _SUB_CLIENTS.clear()
 
 
 def understand_image(

--- a/src/imagine_mcp/server.py
+++ b/src/imagine_mcp/server.py
@@ -270,6 +270,26 @@ def build_app() -> FastMCP:
     return app
 
 
+async def _per_request_sub_scope(claims: dict[str, Any], next_: Any) -> None:
+    """``auth_scope`` middleware: pin JWT sub into a contextvar for the request.
+
+    mcp-core invokes this after Bearer JWT verification with the decoded
+    claims dict. We push ``claims["sub"]`` into ``_current_sub`` so tool
+    handlers (``understand`` / ``generate``) and the dispatcher's auto-fallback
+    (``_default_provider``) can resolve credentials per-user via
+    ``credentials_for_current_request()``. ``contextvars.Context.set`` returns
+    a token that we ``reset()`` in ``finally`` so a request that errors out
+    cannot leak its sub into the next request handled by the same task.
+    """
+    from imagine_mcp.credential_state import _current_sub
+
+    token = _current_sub.set(claims.get("sub"))
+    try:
+        await next_()
+    finally:
+        _current_sub.reset(token)
+
+
 async def run_http(port: int = 0) -> None:
     """Unified HTTP daemon -- single-user (default) or multi-user remote.
 
@@ -285,6 +305,9 @@ async def run_http(port: int = 0) -> None:
         scoped per-sub in ``IMAGINE_DATA_DIR/subs/<sub>/config.json``.
         Refuses to start if ``MCP_DCR_SERVER_SECRET`` is missing -- DCR
         requires a server secret to mint per-user JWTs safely.
+
+        ``auth_scope=_per_request_sub_scope`` is wired only in this branch
+        so single-user mode keeps reading ``os.environ`` unchanged.
     """
     from mcp_core.transport.local_server import run_http_server
 
@@ -315,6 +338,7 @@ async def run_http(port: int = 0) -> None:
         host=host,
         open_browser=not public_url,
         on_credentials_saved=save_credentials,
+        auth_scope=_per_request_sub_scope if public_url else None,
     )
 
 

--- a/tests/test_multi_user.py
+++ b/tests/test_multi_user.py
@@ -1,0 +1,266 @@
+"""HTTP multi-user credential wiring (per-sub contextvar).
+
+These tests cover the auth_scope + per-sub credential flow added so each
+JWT subject sees only its own provider keys. Spec requirements:
+
+* Stdio mode is unchanged (env-only, no contextvar leak).
+* Single-user HTTP behaves like stdio for credential reads (no sub set).
+* Multi-user HTTP scopes credentials per ``_current_sub`` ContextVar.
+* The ``auth_scope`` middleware sets/resets the ContextVar around each request.
+* PR #58's auto-fallback dispatcher (``_default_provider``) honours the
+  per-sub keys instead of leaking ``os.environ``.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from collections.abc import Iterator
+
+import pytest
+
+from imagine_mcp.credential_state import (
+    CLOUD_KEYS,
+    PLUGIN_NAME,
+    _current_sub,
+    credentials_for_current_request,
+    get_current_sub,
+    set_current_sub,
+)
+
+
+@pytest.fixture(autouse=True)
+def _isolate_storage(tmp_path, monkeypatch) -> Iterator[None]:
+    """Pin PerPluginStore + reset contextvar before every test."""
+    monkeypatch.setattr("pathlib.Path.home", lambda: tmp_path)
+    monkeypatch.setenv("CREDENTIAL_SECRET", "test-secret-value")
+    # Force HTTP mode so credential_state helpers touch PerPluginStore.
+    monkeypatch.setenv("MCP_TRANSPORT", "http")
+    # Make sure no env-leak into per-sub assertions.
+    for key in CLOUD_KEYS:
+        monkeypatch.delenv(key, raising=False)
+    # Reset contextvar state.
+    token = _current_sub.set(None)
+    yield
+    _current_sub.reset(token)
+
+
+def test_stdio_mode_unchanged(monkeypatch) -> None:
+    """Stdio mode (no --http, no transport env): env vars only.
+
+    The contextvar is None and ``credentials_for_current_request`` returns
+    keys from ``os.environ`` -- NOT from PerPluginStore (matches the
+    pure-env-only invariant guarded by ``feedback_stdio_fallback_local_only``).
+    """
+    monkeypatch.delenv("MCP_TRANSPORT", raising=False)
+    monkeypatch.delenv("TRANSPORT_MODE", raising=False)
+    monkeypatch.setattr("sys.argv", ["imagine-mcp"])
+
+    monkeypatch.setenv("XAI_API_KEY", "stdio-xai")
+    creds = credentials_for_current_request()
+    assert creds == {"XAI_API_KEY": "stdio-xai"}
+    assert get_current_sub() is None
+
+
+def test_http_sub_a_isolation(tmp_path) -> None:
+    """sub-a sees only sub-a's stored XAI key."""
+    from mcp_core.storage.per_plugin_store import PerPluginStore
+
+    PerPluginStore(PLUGIN_NAME, "sub-a").save({"XAI_API_KEY": "key-a"})
+    PerPluginStore(PLUGIN_NAME, "sub-b").save({"OPENAI_API_KEY": "key-b"})
+
+    set_current_sub("sub-a")
+    creds = credentials_for_current_request()
+    assert creds == {"XAI_API_KEY": "key-a"}
+    assert "OPENAI_API_KEY" not in creds
+
+
+def test_http_sub_b_no_bleed(tmp_path) -> None:
+    """sub-b sees only sub-b's stored OPENAI key (no env or sub-a leak)."""
+    from mcp_core.storage.per_plugin_store import PerPluginStore
+
+    PerPluginStore(PLUGIN_NAME, "sub-a").save({"XAI_API_KEY": "key-a"})
+    PerPluginStore(PLUGIN_NAME, "sub-b").save({"OPENAI_API_KEY": "key-b"})
+
+    set_current_sub("sub-b")
+    creds = credentials_for_current_request()
+    assert creds == {"OPENAI_API_KEY": "key-b"}
+    assert "XAI_API_KEY" not in creds
+
+
+def test_http_no_sub_returns_env(monkeypatch) -> None:
+    """HTTP mode + no sub set: helper merges os.environ (single-user fallback).
+
+    Even though ``MCP_TRANSPORT=http`` is set, the contextvar may still be
+    ``None`` for the local-credential-form authorize POST itself (it runs
+    OUTSIDE the bearer-protected MCP route). We must therefore behave like
+    stdio for credential reads when no sub is active.
+    """
+    monkeypatch.setenv("OPENAI_API_KEY", "single-user-key")
+    creds = credentials_for_current_request()
+    assert creds == {"OPENAI_API_KEY": "single-user-key"}
+
+
+def test_concurrent_subs_isolation(tmp_path) -> None:
+    """Two ContextVar-aware coroutines must see independent sub state.
+
+    Verifies that ``contextvars`` (not threading.local) is the correct
+    choice -- asyncio tasks each have their own Context, so even
+    interleaved suspensions cannot bleed sub-a's keys into sub-b's
+    coroutine.
+    """
+    from mcp_core.storage.per_plugin_store import PerPluginStore
+
+    PerPluginStore(PLUGIN_NAME, "sub-a").save({"XAI_API_KEY": "key-a"})
+    PerPluginStore(PLUGIN_NAME, "sub-b").save({"OPENAI_API_KEY": "key-b"})
+
+    captured: dict[str, dict[str, str]] = {}
+
+    async def request_for(sub: str) -> None:
+        token = _current_sub.set(sub)
+        try:
+            # Yield control so the other coroutine interleaves between
+            # set() and read().
+            await asyncio.sleep(0)
+            captured[sub] = credentials_for_current_request()
+        finally:
+            _current_sub.reset(token)
+
+    async def driver() -> None:
+        await asyncio.gather(request_for("sub-a"), request_for("sub-b"))
+
+    asyncio.run(driver())
+
+    assert captured["sub-a"] == {"XAI_API_KEY": "key-a"}
+    assert captured["sub-b"] == {"OPENAI_API_KEY": "key-b"}
+
+
+def test_per_request_sub_scope_callback(tmp_path) -> None:
+    """The ``_per_request_sub_scope`` middleware sets + resets _current_sub.
+
+    Mirrors the ``auth_scope`` callback signature mcp-core invokes after
+    JWT verification. Ensures (a) the contextvar carries the sub during
+    ``next_()``, (b) it resets to None even if ``next_()`` raises.
+    """
+    from imagine_mcp.server import _per_request_sub_scope
+
+    seen: list[str | None] = []
+
+    async def _next_ok() -> None:
+        seen.append(get_current_sub())
+
+    async def driver() -> None:
+        await _per_request_sub_scope({"sub": "user-42"}, _next_ok)
+        # After the middleware returns, the contextvar must be reset.
+        seen.append(get_current_sub())
+
+    asyncio.run(driver())
+    assert seen == ["user-42", None]
+
+    # Failure path: middleware must reset the contextvar even when
+    # next_() raises so the next request handled by this asyncio task
+    # cannot inherit a stale sub.
+    async def _next_raises() -> None:
+        seen.append(get_current_sub())
+        raise RuntimeError("boom")
+
+    seen.clear()
+
+    async def driver_raises() -> None:
+        with pytest.raises(RuntimeError, match="boom"):
+            await _per_request_sub_scope({"sub": "user-99"}, _next_raises)
+        seen.append(get_current_sub())
+
+    asyncio.run(driver_raises())
+    assert seen == ["user-99", None]
+
+
+def test_default_provider_with_per_sub_keys(tmp_path) -> None:
+    """PR #58 auto-fallback honours per-sub keys, not os.environ.
+
+    sub-grok holds only XAI -> dispatcher must pick ``grok``.
+    sub-openai holds only OPENAI -> dispatcher must pick ``openai``.
+    sub-gemini holds only GEMINI -> dispatcher must pick ``gemini``.
+    A sub with no keys must raise ``CredentialMissingError``.
+    """
+    from mcp_core.storage.per_plugin_store import PerPluginStore
+
+    from imagine_mcp.dispatcher import _default_provider
+    from imagine_mcp.errors import CredentialMissingError
+
+    PerPluginStore(PLUGIN_NAME, "sub-grok").save({"XAI_API_KEY": "k1"})
+    PerPluginStore(PLUGIN_NAME, "sub-openai").save({"OPENAI_API_KEY": "k2"})
+    PerPluginStore(PLUGIN_NAME, "sub-gemini").save({"GEMINI_API_KEY": "k3"})
+    PerPluginStore(PLUGIN_NAME, "sub-empty").save({})
+
+    set_current_sub("sub-grok")
+    assert _default_provider() == "grok"
+
+    set_current_sub("sub-openai")
+    assert _default_provider() == "openai"
+
+    set_current_sub("sub-gemini")
+    assert _default_provider() == "gemini"
+
+    set_current_sub("sub-empty")
+    with pytest.raises(CredentialMissingError):
+        _default_provider()
+
+
+def test_default_provider_priority_xai_over_openai(tmp_path) -> None:
+    """When a sub has multiple keys, XAI > OPENAI > GEMINI per PR #58."""
+    from mcp_core.storage.per_plugin_store import PerPluginStore
+
+    from imagine_mcp.dispatcher import _default_provider
+
+    PerPluginStore(PLUGIN_NAME, "sub-multi").save(
+        {"XAI_API_KEY": "x", "OPENAI_API_KEY": "o", "GEMINI_API_KEY": "g"}
+    )
+
+    set_current_sub("sub-multi")
+    assert _default_provider() == "grok"
+
+
+def test_provider_client_isolated_per_sub(tmp_path, monkeypatch) -> None:
+    """Provider clients cache per-sub so concurrent users get distinct keys.
+
+    Verifies the ``_SUB_CLIENTS`` map: each sub builds its own client wired
+    to that sub's API key, and switching back to a different sub returns
+    that sub's cached client (not a shared module-level client).
+    """
+    from mcp_core.storage.per_plugin_store import PerPluginStore
+
+    from imagine_mcp.providers import gemini
+
+    captured: list[str] = []
+
+    class _FakeClient:
+        def __init__(self, api_key: str) -> None:
+            self.api_key = api_key
+            captured.append(api_key)
+
+    class _FakeGenaiModule:
+        Client = _FakeClient
+
+    monkeypatch.setitem(
+        __import__("sys").modules, "google", type("g", (), {"genai": _FakeGenaiModule})
+    )
+
+    PerPluginStore(PLUGIN_NAME, "sub-a").save({"GEMINI_API_KEY": "ga"})
+    PerPluginStore(PLUGIN_NAME, "sub-b").save({"GEMINI_API_KEY": "gb"})
+
+    gemini._reset_client()
+
+    set_current_sub("sub-a")
+    client_a = gemini._client()
+    set_current_sub("sub-b")
+    client_b = gemini._client()
+    set_current_sub("sub-a")
+    client_a_again = gemini._client()
+
+    assert client_a is client_a_again
+    assert client_a is not client_b
+    assert client_a.api_key == "ga"
+    assert client_b.api_key == "gb"
+    # Each sub triggers exactly one client construction.
+    assert captured.count("ga") == 1
+    assert captured.count("gb") == 1


### PR DESCRIPTION
## Summary

Wires the existing ``auth_scope`` parameter on
``mcp_core.transport.local_server.run_http_server`` so each authenticated
MCP request resolves provider keys from the JWT-sub-scoped per-plugin
store instead of the shared ``os.environ``. Closes the consumer-side gap
described in ``feedback_mcp_core_multi_user_state.md`` (mcp-core multi-user
infra is already in place; only consumer plumbing was missing).

* ``credential_state``: ``ContextVar[str | None]`` (``_current_sub``) +
  ``get_current_sub`` / ``set_current_sub`` + ``credentials_for_current_request()``.
* ``server.run_http``: adds ``_per_request_sub_scope`` ``auth_scope``
  middleware. Wired only when ``PUBLIC_URL`` is set — single-user / stdio
  is byte-identical.
* ``dispatcher._default_provider``: uses ``credentials_for_current_request()``
  so PR #58 auto-fallback honours per-sub state (XAI > OpenAI > Gemini).
* ``providers/{gemini,grok,openai}``: keep ``_CLIENT`` cache for single-user;
  add ``_SUB_CLIENTS`` map so each sub gets a client built with that sub's
  API key (no cross-user bleed via cached SDK clients).

No mcp-core or PR #58 dispatcher logic changes. Stdio path untouched.

## Test plan

- [x] ``UV_NO_SOURCES=1 uv run pytest -x`` — 127 passed, 3 deselected
- [x] ``uv run ruff check . && uv run ruff format --check .``
- [x] ``uv run ty check src/`` — All checks passed
- [x] Pre-commit hooks pass (no ``--no-verify``)
- [x] ``tests/test_multi_user.py`` 9 new tests:
  - ``test_stdio_mode_unchanged`` — stdio = env-only, contextvar None
  - ``test_http_sub_a_isolation`` — sub-a sees only sub-a's keys
  - ``test_http_sub_b_no_bleed`` — sub-b cannot see sub-a or env
  - ``test_http_no_sub_returns_env`` — single-user HTTP fallback
  - ``test_concurrent_subs_isolation`` — asyncio coroutines independent
  - ``test_per_request_sub_scope_callback`` — middleware set+reset on
    success and exception paths
  - ``test_default_provider_with_per_sub_keys`` — PR #58 auto-fallback
    walks per-sub config, raises when sub has no keys
  - ``test_default_provider_priority_xai_over_openai`` — XAI > OpenAI >
    Gemini priority preserved
  - ``test_provider_client_isolated_per_sub`` — per-sub client cache
    builds + reuses correctly

## Notes for reviewer

- DO NOT merge — leaving open per request.
- Non-trivial path: provider clients now cache per-sub. The cache lives
  for the daemon lifetime; if a user rotates their key via the relay
  form a follow-up patch should call ``_reset_client()`` on save. Out
  of scope here.

References: ``feedback_mcp_core_multi_user_state.md``,
``feedback_remote_relay_multi_user_enforcement.md``,
``mcp-dev/references/multi-user-pattern.md``.