### PR TITLE
feat: MCP_RELAY_PASSWORD edge auth env

### DIFF
--- a/docker-compose.http.yml
+++ b/docker-compose.http.yml
@@ -1,0 +1,14 @@
+# HTTP mode overlay — use with:
+# docker compose -f docker-compose.yml -f docker-compose.http.yml up
+services:
+  imagine-mcp:
+    environment:
+      - TRANSPORT_MODE=http
+      - CREDENTIAL_SECRET=${CREDENTIAL_SECRET}
+      - MCP_RELAY_PASSWORD=${MCP_RELAY_PASSWORD}
+    ports:
+      - "8084:8080"
+    volumes:
+      - imagine-data:/data
+volumes:
+  imagine-data:


### PR DESCRIPTION
Per mcp-core spec 2026-05-01 §4.2.1 — pass new env var to HTTP container for /login gate.