### PR TITLE
feat: docs MCP_RELAY_PASSWORD edge auth subsection

### DIFF
--- a/docs/setup-manual.md
+++ b/docs/setup-manual.md
@@ -165,6 +165,20 @@ Point clients to your server:
 
 On first connect, the client opens a browser to your relay form. Each user pastes the API keys they want available (any subset of Gemini / OpenAI / xAI), submits, and the keys are stored encrypted under that user's JWT subject. Subsequent connections from the same user reuse the saved keys.
 
+### Edge auth: relay password
+
+Public HTTP deployments expose `<your-domain>/authorize` to URL discovery. To prevent random Internet users from accessing the relay form, mint a relay password:
+
+```bash
+openssl rand -hex 32
+# Save in your skret / .env as:
+MCP_RELAY_PASSWORD=<generated-32-byte-hex>
+```
+
+Share this password out-of-band (Signal/email/SMS) with anyone you invite to use your server. They will see a login form when first opening `/authorize`; once logged in, the cookie persists 24 hours.
+
+**Single-user dev exception**: If `PUBLIC_URL=http://localhost:8080`, you can leave `MCP_RELAY_PASSWORD` empty to disable the gate. The server logs a warning if you skip the password with a non-localhost `PUBLIC_URL`.
+
 ## Method 6: Build from Source
 
 1. Clone and install:

--- a/docs/setup-with-agent.md
+++ b/docs/setup-with-agent.md
@@ -168,6 +168,20 @@ On first use, a browser window opens to the relay form. Each user pastes the API
 
 For full self-host setup details (TLS, tunnel, env reference), see [setup-manual.md](setup-manual.md) "Method 5: Self-Hosting HTTP Mode".
 
+### Edge auth: relay password
+
+Public HTTP deployments expose `<your-domain>/authorize` to URL discovery. To prevent random Internet users from accessing the relay form, mint a relay password:
+
+```bash
+openssl rand -hex 32
+# Save in your skret / .env as:
+MCP_RELAY_PASSWORD=<generated-32-byte-hex>
+```
+
+Share this password out-of-band (Signal/email/SMS) with anyone you invite to use your server. They will see a login form when first opening `/authorize`; once logged in, the cookie persists 24 hours.
+
+**Single-user dev exception**: If `PUBLIC_URL=http://localhost:8080`, you can leave `MCP_RELAY_PASSWORD` empty to disable the gate. The server logs a warning if you skip the password with a non-localhost `PUBLIC_URL`.
+
 ## Environment Variables
 
 | Variable | Required | Default | Description |


### PR DESCRIPTION
Per mcp-core spec 2026-05-01 §4.2.1 — add edge auth setup guidance to HTTP method docs.