### PR TITLE
🛡️ Sentinel: [MEDIUM] Enhance SSRF IP validation by using is_global

### DIFF
--- a/src/imagine_mcp/dispatcher.py
+++ b/src/imagine_mcp/dispatcher.py
@@ -97,15 +97,12 @@ def _validate_url(url: str, param: str) -> None:
             if ip_obj.version == 6 and ip_obj.ipv4_mapped:
                 ip_obj = ip_obj.ipv4_mapped
 
-            if (
-                ip_obj.is_loopback
-                or ip_obj.is_private
-                or ip_obj.is_link_local
-                or ip_obj.is_multicast
-                or ip_obj.is_unspecified
-            ):
+            if not ip_obj.is_global or ip_obj.is_multicast:
+                # `is_global` covers loopback, private, link-local, unspecified, and reserved IPs.
+                # However, some multicast IPs (e.g., global multicast) are considered global,
+                # so we block all multicast as well to ensure security against any local attacks.
                 raise InvalidURLError(
-                    f"Invalid {param}: URL resolves to an internal/private IP."
+                    f"Invalid {param}: URL resolves to a non-public or internal IP."
                 )
     except concurrent.futures.TimeoutError as e:
         raise InvalidURLError(

--- a/uv.lock
+++ b/uv.lock
@@ -531,7 +531,7 @@ wheels = [
 
 [[package]]
 name = "imagine-mcp"
-version = "1.2.0b7"
+version = "1.2.0b8"
 source = { editable = "." }
 dependencies = [
     { name = "diskcache" },


### PR DESCRIPTION
🚨 **Severity:** MEDIUM
💡 **Vulnerability:** The application's SSRF protection in `dispatcher.py` (`_validate_url`) used a manual blocklist of specific IP types (`is_loopback`, `is_private`, `is_link_local`, `is_unspecified`). This approach was vulnerable to bypasses because it failed to block other IANA reserved ranges (like Carrier-Grade NAT `100.64.0.0/10` or TEST-NET IPs), potentially allowing SSRF attacks against internal network infrastructure.
🎯 **Impact:** An attacker could bypass the SSRF filter and interact with internal network resources or services hosted on reserved IP ranges that were not explicitly blocked by the previous logic.
🔧 **Fix:** Refactored the validation logic to use an allowlist approach. It now rejects any IP that is not publicly routable (`not ip_obj.is_global`) or is a multicast address (`ip_obj.is_multicast`), providing a comprehensive defense against SSRF that covers all non-public/reserved IPs.
✅ **Verification:** Run `uv run pytest tests/` to ensure no tests break and verify the SSRF validation changes are fully robust.

---
*PR created automatically by Jules for task [718322902415325747](https://jules.google.com/task/718322902415325747) started by @n24q02m*