### PR TITLE
⚡ Bolt: optimize default_provider_for with lru_cache

### DIFF
--- a/src/imagine_mcp/models.py
+++ b/src/imagine_mcp/models.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 from collections.abc import Callable
 from dataclasses import dataclass, field
 from datetime import date
+from functools import lru_cache
 from typing import Final, Literal
 
 
@@ -393,10 +394,16 @@ def list_models(
     return rows
 
 
+@lru_cache(maxsize=32)
 def default_provider_for(action: str, media: str, tier: str) -> str:
     """Pick provider with rank 1 for (action, media, tier).
 
     Fallback 'gemini' if all unranked.
+
+    Performance optimization: `action`, `media`, and `tier` form a tiny
+    bounded set of combinations. Caching this function reduces the O(N log N)
+    cost of traversing, filtering, and sorting `MODELS` to an O(1) hit,
+    speeding up repeated dispatches.
     """
     candidates = list_models(
         filter_fn=lambda e: (

--- a/uv.lock
+++ b/uv.lock
@@ -531,7 +531,7 @@ wheels = [
 
 [[package]]
 name = "imagine-mcp"
-version = "1.2.0b7"
+version = "1.2.0b8"
 source = { editable = "." }
 dependencies = [
     { name = "diskcache" },


### PR DESCRIPTION
💡 **What**: Added `@lru_cache(maxsize=32)` to `default_provider_for` in `models.py`.
🎯 **Why**: The function repeatedly queries, filters, and sorts a static list of models, doing O(N log N) work every time. Since the arguments (`action`, `media`, `tier`) form a tiny set of combinations (2x2x2=8), caching is highly effective.
📊 **Impact**: Reduces list traversal and sorting from O(N log N) to an O(1) cache hit for identical parameters, speeding up repeated dispatch logic.
🔬 **Measurement**: Verified tests pass; code structure ensures memoization works deterministically for string arguments. Recorded learning in `.jules/bolt.md`.

---
*PR created automatically by Jules for task [17180660888333856028](https://jules.google.com/task/17180660888333856028) started by @n24q02m*