### PR TITLE
fix: bump mcp-core to 1.13.0 (STABLE)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,7 +47,7 @@ dependencies = [
     "pillow>=10.0",
     "diskcache>=5.6",
     "loguru>=0.7",
-    "n24q02m-mcp-core>=1.13.0b9",
+    "n24q02m-mcp-core>=1.13.0",
     "platformdirs>=4.0",
 ]
 

--- a/uv.lock
+++ b/uv.lock
@@ -531,7 +531,7 @@ wheels = [
 
 [[package]]
 name = "imagine-mcp"
-version = "1.2.0b7"
+version = "1.2.0b8"
 source = { editable = "." }
 dependencies = [
     { name = "diskcache" },
@@ -571,7 +571,7 @@ requires-dist = [
     { name = "httpx", specifier = ">=0.27" },
     { name = "loguru", specifier = ">=0.7" },
     { name = "mcp", extras = ["cli"], specifier = ">=1.0" },
-    { name = "n24q02m-mcp-core", specifier = ">=1.13.0b9" },
+    { name = "n24q02m-mcp-core", specifier = ">=1.13.0" },
     { name = "openai", specifier = ">=1.60" },
     { name = "pillow", specifier = ">=10.0" },
     { name = "platformdirs", specifier = ">=4.0" },
@@ -839,7 +839,7 @@ wheels = [
 
 [[package]]
 name = "n24q02m-mcp-core"
-version = "1.13.0b9"
+version = "1.13.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "authlib" },
@@ -853,9 +853,9 @@ dependencies = [
     { name = "starlette" },
     { name = "tomli-w" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/b2/83/62231d50dc150328f58c78fac135962e5a7641a00035d1e2b332d7b340a2/n24q02m_mcp_core-1.13.0b9.tar.gz", hash = "sha256:45ca969044f84a06db37d54705f03928dfaf53fd23ab3d13b4e59b86a70e4f3f", size = 192382, upload-time = "2026-05-03T14:27:54.192Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/d5/95/3c71730e420bf3cf863e778ecbedd4676067f5de54cfca537225bfac54ed/n24q02m_mcp_core-1.13.0.tar.gz", hash = "sha256:9e8361ae0a43b8e943ad6ed7b91c1cc76d6a3eb2a428eb0907a55545e700b529", size = 192365, upload-time = "2026-05-04T12:36:51.169Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/50/89/7fac8548690857aa6932af2987a9ff19bce595cc975b890c8d83eff27381/n24q02m_mcp_core-1.13.0b9-py3-none-any.whl", hash = "sha256:32ebc4b96b12b8c033bf0f50a938c891020e393a67e5bebde6944f6d4a555eae", size = 123359, upload-time = "2026-05-03T14:27:55.796Z" },
+    { url = "https://files.pythonhosted.org/packages/81/28/e41c732d2246b4f2fdcb05dc5037795904ea9455f5f0f90f8f09fd370da5/n24q02m_mcp_core-1.13.0-py3-none-any.whl", hash = "sha256:c21a825bdb6981f3c83a3cd8fb0987bdf4679851274e453d033aa39d2f1c78bd", size = 123341, upload-time = "2026-05-04T12:36:52.256Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Phase 5 STABLE cascade: bump mcp-core dep to 1.13.0 STABLE.