### PR TITLE
feat: declare userConfig schema and document install prompt

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -2,6 +2,29 @@
   "name": "imagine-mcp",
   "description": "Image/video understanding & generation across Gemini, OpenAI, Grok",
   "version": "1.2.0",
+  "userConfig": {
+    "XAI_API_KEY": {
+      "type": "string",
+      "title": "xAI (Grok) API key — recommended",
+      "description": "Default provider per spec. https://console.x.ai/",
+      "sensitive": true,
+      "required": false
+    },
+    "GEMINI_API_KEY": {
+      "type": "string",
+      "title": "Gemini API key (optional)",
+      "description": "Alternative provider. https://ai.google.dev/",
+      "sensitive": true,
+      "required": false
+    },
+    "OPENAI_API_KEY": {
+      "type": "string",
+      "title": "OpenAI API key (optional)",
+      "description": "Alternative provider. https://platform.openai.com/",
+      "sensitive": true,
+      "required": false
+    }
+  },
   "author": {
     "name": "n24q02m",
     "url": "https://github.com/n24q02m"
@@ -20,8 +43,17 @@
   "mcpServers": {
     "imagine": {
       "command": "uvx",
-      "args": ["--python", "3.13", "imagine-mcp"],
-      "env": {"MCP_TRANSPORT": "stdio"}
+      "args": [
+        "--python",
+        "3.13",
+        "imagine-mcp"
+      ],
+      "env": {
+        "MCP_TRANSPORT": "stdio",
+        "XAI_API_KEY": "${user_config.XAI_API_KEY}",
+        "GEMINI_API_KEY": "${user_config.GEMINI_API_KEY}",
+        "OPENAI_API_KEY": "${user_config.OPENAI_API_KEY}"
+      }
     }
   }
 }

--- a/docs/setup-manual.md
+++ b/docs/setup-manual.md
@@ -32,14 +32,30 @@ You can mix any subset. The server runs in degraded mode: providers without a ke
 
 Plugin marketplace install runs the server in **pure stdio mode** with provider env vars. No daemon-bridge, no auto-spawn, no relay form.
 
+### Step 0: Credential prompt
+
+When you run `/plugin install imagine-mcp@n24q02m-plugins`, Claude Code prompts for the optional fields declared in `plugin.json` `userConfig`:
+
+| Field | Required | Sensitive | Notes |
+|:------|:---------|:----------|:------|
+| `XAI_API_KEY` | No | Yes | xAI (Grok) -- recommended default. https://console.x.ai/ |
+| `GEMINI_API_KEY` | No | Yes | Google AI Studio. https://ai.google.dev/ |
+| `OPENAI_API_KEY` | No | Yes | OpenAI. https://platform.openai.com/ |
+
+**At least one** key must be set for the server to dispatch any tool call (it raises `CredentialMissingError` otherwise). All three keys are individually optional; pick the providers you want and skip the rest. Sensitive values are kept in the system keychain (or `~/.claude/.credentials.json` fallback) and persist across `/plugin update`. Claude Code substitutes each value into `mcpServers.imagine.env` via `${user_config.<KEY>}` -- you do not edit `env` manually.
+
+### Steps
+
 1. Get at least one provider API key (see Prerequisites above).
 2. Open Claude Code in your terminal.
-3. Install the plugin:
+3. Install the plugin (Claude Code prompts for `XAI_API_KEY` / `GEMINI_API_KEY` / `OPENAI_API_KEY` -- press Enter to skip the ones you do not have):
    ```bash
    /plugin marketplace add n24q02m/claude-plugins
    /plugin install imagine-mcp@n24q02m-plugins
    ```
-4. Set at least one of `GEMINI_API_KEY` / `OPENAI_API_KEY` / `XAI_API_KEY` in the plugin config when prompted (or in your Claude Code settings).
+4. Restart Claude Code -- the plugin auto-loads with your keys injected.
+
+> **HTTP transport (Method 3)** is a separate install path; the `userConfig` prompt only covers stdio Method 1.
 
 ## Method 2: Docker stdio (fallback)
 

--- a/docs/setup-with-agent.md
+++ b/docs/setup-with-agent.md
@@ -24,16 +24,26 @@ All MCP servers across this stack share this priority hierarchy. Note: 2 plugins
 
 Plugin marketplace install runs the server in **pure stdio mode** with provider env vars. No daemon-bridge, no auto-spawn, no relay form.
 
-1. Get at least one provider API key:
-   - **Google AI Studio** (Gemini): https://aistudio.google.com/apikey
-   - **OpenAI**: https://platform.openai.com/api-keys
-   - **xAI** (Grok): https://console.x.ai
-2. Install the plugin:
+### Step 0: Credential prompt
+
+When the install command runs, Claude Code prompts for the optional fields declared in `plugin.json` `userConfig`:
+
+| Field | Required | Sensitive | Source |
+|:------|:---------|:----------|:-------|
+| `XAI_API_KEY` | No | Yes | https://console.x.ai/ (recommended default) |
+| `GEMINI_API_KEY` | No | Yes | https://aistudio.google.com/apikey |
+| `OPENAI_API_KEY` | No | Yes | https://platform.openai.com/api-keys |
+
+**At least one** key must be set so the server can dispatch tool calls. Claude Code substitutes each value into `mcpServers.imagine.env` via `${user_config.<KEY>}` and stores sensitive values in the system keychain (persists across `/plugin update`). You do not edit `env` manually.
+
+### Steps
+
+1. Get at least one provider API key (see table above).
+2. Install the plugin (press Enter to skip providers you do not have):
    ```bash
    /plugin marketplace add n24q02m/claude-plugins
    /plugin install imagine-mcp@n24q02m-plugins
    ```
-3. Set at least one of `GEMINI_API_KEY` / `OPENAI_API_KEY` / `XAI_API_KEY` in the plugin config (or your Claude Code settings). Any subset works.
 
 This installs the server with skill: `/image-describe`.
 


### PR DESCRIPTION
## Summary

- Add `userConfig` with optional sensitive fields `XAI_API_KEY`, `GEMINI_API_KEY`, `OPENAI_API_KEY` so `/plugin install` prompts for the provider keys. All three are individually optional, but at least one must be set or the dispatcher raises `CredentialMissingError` on tool call.
- Substitute via `${user_config.<KEY>}` into `mcpServers.imagine.env`.
- Update `setup-manual.md` and `setup-with-agent.md` Method 1 with Step 0 prompt section.

## Test plan
- [ ] CI green
- [ ] `/plugin install` prompts for all three keys (skippable individually)
- [ ] Tool dispatch works when at least one key is set

Generated with [Claude Code](https://claude.com/claude-code)