### PR TITLE
⚡ Bolt: Add LRU cache to default_provider_for

### DIFF
--- a/src/imagine_mcp/models.py
+++ b/src/imagine_mcp/models.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 from collections.abc import Callable
 from dataclasses import dataclass, field
 from datetime import date
+from functools import lru_cache
 from typing import Final, Literal
 
 
@@ -393,10 +394,14 @@ def list_models(
     return rows
 
 
+@lru_cache(maxsize=32)
 def default_provider_for(action: str, media: str, tier: str) -> str:
     """Pick provider with rank 1 for (action, media, tier).
 
     Fallback 'gemini' if all unranked.
+
+    Performance: Uses lru_cache to convert O(N log N) list traversal and sorting
+    into an O(1) hit, taking advantage of the small bounded parameter space.
     """
     candidates = list_models(
         filter_fn=lambda e: (

--- a/uv.lock
+++ b/uv.lock
@@ -531,7 +531,7 @@ wheels = [
 
 [[package]]
 name = "imagine-mcp"
-version = "1.2.0b8"
+version = "1.2.0"
 source = { editable = "." }
 dependencies = [
     { name = "diskcache" },


### PR DESCRIPTION
💡 What:
Added `@lru_cache(maxsize=32)` to the `default_provider_for` function in `src/imagine_mcp/models.py`. Documented this learning in `.jules/bolt.md`.

🎯 Why:
The `default_provider_for` function involves filtering and sorting static lists (`MODELS`). Executing this logic over and over for the same inputs causes unnecessary `O(N log N)` overhead. By using `lru_cache`, we optimize repeated lookups because the parameter space (action, media, tier) is tiny and bounded.

📊 Impact:
Transforms `O(N log N)` list operations into an `O(1)` cache hit, significantly reducing CPU overhead for provider resolution.

🔬 Measurement:
Run the tests (`uv run pytest tests/`) to verify that functionality remains correct while performance naturally improves on repetitive calls.

---
*PR created automatically by Jules for task [4665460271728267998](https://jules.google.com/task/4665460271728267998) started by @n24q02m*