### PR TITLE
🛡️ Sentinel: [CRITICAL/HIGH] Fix SSRF filter evasion

### DIFF
--- a/src/imagine_mcp/dispatcher.py
+++ b/src/imagine_mcp/dispatcher.py
@@ -97,13 +97,7 @@ def _validate_url(url: str, param: str) -> None:
             if ip_obj.version == 6 and ip_obj.ipv4_mapped:
                 ip_obj = ip_obj.ipv4_mapped
 
-            if (
-                ip_obj.is_loopback
-                or ip_obj.is_private
-                or ip_obj.is_link_local
-                or ip_obj.is_multicast
-                or ip_obj.is_unspecified
-            ):
+            if not ip_obj.is_global or ip_obj.is_multicast:
                 raise InvalidURLError(
                     f"Invalid {param}: URL resolves to an internal/private IP."
                 )

--- a/uv.lock
+++ b/uv.lock
@@ -531,7 +531,7 @@ wheels = [
 
 [[package]]
 name = "imagine-mcp"
-version = "1.2.0b8"
+version = "1.2.0"
 source = { editable = "." }
 dependencies = [
     { name = "diskcache" },


### PR DESCRIPTION
🛡️ Sentinel: [CRITICAL/HIGH] Fix SSRF filter evasion

🚨 Severity: HIGH
💡 Vulnerability: SSRF filter evasion via unhandled reserved or non-public IP ranges in URL validation logic.
🎯 Impact: Attackers could bypass the filter and target internal/special network addresses (like Carrier-Grade NAT spaces or other undocumented blocks not captured by explicit checks).
🔧 Fix: Updated `_validate_url` to use `not ip_obj.is_global or ip_obj.is_multicast` for a comprehensive, whitelist-like approach to only allow publicly routable internet addresses. Added critical learning in `.jules/sentinel.md`.
✅ Verification: Ran `uv run pytest tests/` and `uv run ruff check src/ tests/` and verified they pass.

---
*PR created automatically by Jules for task [14525978632887289303](https://jules.google.com/task/14525978632887289303) started by @n24q02m*