### PR TITLE
feat: document userConfig credential prompts per plugin

### DIFF
--- a/docs/setup-manual.md
+++ b/docs/setup-manual.md
@@ -32,17 +32,15 @@ You can mix any subset. The server runs in degraded mode: providers without a ke
 
 Plugin marketplace install runs the server in **pure stdio mode** with provider env vars. No daemon-bridge, no auto-spawn, no relay form.
 
-### Step 0: Credential prompt
+### Credential prompts at install
 
-When you run `/plugin install imagine-mcp@n24q02m-plugins`, Claude Code prompts for the optional fields declared in `plugin.json` `userConfig`:
+When you run `/plugin install`, Claude Code prompts you for the following credentials (declared in `userConfig` per CC docs). Sensitive values are stored in your system keychain and persist across `/plugin update`:
 
-| Field | Required | Sensitive | Notes |
-|:------|:---------|:----------|:------|
-| `XAI_API_KEY` | No | Yes | xAI (Grok) -- recommended default. https://console.x.ai/ |
-| `GEMINI_API_KEY` | No | Yes | Google AI Studio. https://ai.google.dev/ |
-| `OPENAI_API_KEY` | No | Yes | OpenAI. https://platform.openai.com/ |
-
-**At least one** key must be set for the server to dispatch any tool call (it raises `CredentialMissingError` otherwise). All three keys are individually optional; pick the providers you want and skip the rest. Sensitive values are kept in the system keychain (or `~/.claude/.credentials.json` fallback) and persist across `/plugin update`. Claude Code substitutes each value into `mcpServers.imagine.env` via `${user_config.<KEY>}` -- you do not edit `env` manually.
+| Field | Required | Where to obtain |
+|---|---|---|
+| `XAI_API_KEY` | Optional | https://console.x.ai/ (default provider per spec) |
+| `GEMINI_API_KEY` | Optional | https://aistudio.google.com/apikey |
+| `OPENAI_API_KEY` | Optional | https://platform.openai.com/api-keys |
 
 ### Steps
 
@@ -54,8 +52,6 @@ When you run `/plugin install imagine-mcp@n24q02m-plugins`, Claude Code prompts 
    /plugin install imagine-mcp@n24q02m-plugins
    ```
 4. Restart Claude Code -- the plugin auto-loads with your keys injected.
-
-> **HTTP transport (Method 3)** is a separate install path; the `userConfig` prompt only covers stdio Method 1.
 
 ## Method 2: Docker stdio (fallback)
 
@@ -95,6 +91,8 @@ Stdio is the default and works fine for single-user local setups. You may want t
 - **Always-on persistent process for webhooks/agents** -- HTTP servers stay alive between sessions, enabling background work, scheduled agents, or webhook listeners.
 
 ## Method 3: Docker HTTP (recommended)
+
+> **Switching transport vs. setting credentials**: The `userConfig` prompt only configures credentials for stdio mode (Method 1 / Option 1). To switch transport to HTTP, override `mcpServers` in your client settings per the snippets below -- this is a separate path from `userConfig` and is not driven by the install prompt.
 
 ### 3.1. Hosted (n24q02m.com)
 

--- a/docs/setup-with-agent.md
+++ b/docs/setup-with-agent.md
@@ -24,17 +24,15 @@ All MCP servers across this stack share this priority hierarchy. Note: 2 plugins
 
 Plugin marketplace install runs the server in **pure stdio mode** with provider env vars. No daemon-bridge, no auto-spawn, no relay form.
 
-### Step 0: Credential prompt
+### Credential prompts at install
 
-When the install command runs, Claude Code prompts for the optional fields declared in `plugin.json` `userConfig`:
+When you run `/plugin install`, Claude Code prompts you for the following credentials (declared in `userConfig` per CC docs). Sensitive values are stored in your system keychain and persist across `/plugin update`:
 
-| Field | Required | Sensitive | Source |
-|:------|:---------|:----------|:-------|
-| `XAI_API_KEY` | No | Yes | https://console.x.ai/ (recommended default) |
-| `GEMINI_API_KEY` | No | Yes | https://aistudio.google.com/apikey |
-| `OPENAI_API_KEY` | No | Yes | https://platform.openai.com/api-keys |
-
-**At least one** key must be set so the server can dispatch tool calls. Claude Code substitutes each value into `mcpServers.imagine.env` via `${user_config.<KEY>}` and stores sensitive values in the system keychain (persists across `/plugin update`). You do not edit `env` manually.
+| Field | Required | Where to obtain |
+|---|---|---|
+| `XAI_API_KEY` | Optional | https://console.x.ai/ (default provider per spec) |
+| `GEMINI_API_KEY` | Optional | https://aistudio.google.com/apikey |
+| `OPENAI_API_KEY` | Optional | https://platform.openai.com/api-keys |
 
 ### Steps
 
@@ -80,6 +78,8 @@ Stdio is the default and works fine for single-user local setups. You may want t
 - **Always-on persistent process for webhooks/agents** -- HTTP servers stay alive between sessions, enabling background work, scheduled agents, or webhook listeners.
 
 ## Option 3: Docker HTTP (recommended)
+
+> **Switching transport vs. setting credentials**: The `userConfig` prompt only configures credentials for stdio mode (Method 1 / Option 1). To switch transport to HTTP, override `mcpServers` in your client settings per the snippets below -- this is a separate path from `userConfig` and is not driven by the install prompt.
 
 ### 3.2. Self-host with docker-compose
 


### PR DESCRIPTION
## Summary
- Replace ad-hoc `Step 0: Credential prompt` paragraph in `docs/setup-manual.md` + `docs/setup-with-agent.md` with a canonical `Credential prompts at install` table per spec V9.
- Table columns: `Field | Required | Where to obtain` — lists every key declared in `plugin.json` `userConfig` together with the upstream URL or value-format hint.
- Add a 2-sentence note inside Method 3 / Option 3 (HTTP recommended) clarifying that HTTP transport is selected by overriding `mcpServers` in client settings, not via `userConfig` (which only feeds stdio mode).
- Drops the legacy `> **HTTP transport (Method 3)** is a separate install path` blockquote at the end of Method 1 / Option 1 since the new credential block + Method 3 note now carry that pointer.

## Test plan
- [x] `plugin.json` userConfig keys match the documented table 1:1
- [x] pre-commit passes (lint, type, JSON, diacritics, secret scan)
- [ ] CI green
- [ ] Marketplace install UX prompts match the documented fields

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>