### PR TITLE
Fix SSRF evasion via CGNAT in URL validation

### DIFF
--- a/src/imagine_mcp/dispatcher.py
+++ b/src/imagine_mcp/dispatcher.py
@@ -97,13 +97,7 @@ def _validate_url(url: str, param: str) -> None:
             if ip_obj.version == 6 and ip_obj.ipv4_mapped:
                 ip_obj = ip_obj.ipv4_mapped
 
-            if (
-                ip_obj.is_loopback
-                or ip_obj.is_private
-                or ip_obj.is_link_local
-                or ip_obj.is_multicast
-                or ip_obj.is_unspecified
-            ):
+            if not ip_obj.is_global or ip_obj.is_multicast:
                 raise InvalidURLError(
                     f"Invalid {param}: URL resolves to an internal/private IP."
                 )

--- a/tests/test_dispatcher.py
+++ b/tests/test_dispatcher.py
@@ -296,3 +296,12 @@ def test_understand_rejects_dns_timeout(monkeypatch: pytest.MonkeyPatch) -> None
         )
     duration = time.time() - start
     assert duration < 2.5, f"DNS timeout block took too long: {duration}s"
+
+
+def test_validate_url_blocks_cgnat() -> None:
+    from imagine_mcp.dispatcher import _validate_url
+
+    # 100.64.0.1 is part of Carrier-Grade NAT, which is not considered private by is_private,
+    # but is considered not global by is_global. Our updated validation must block it.
+    with pytest.raises(InvalidURLError, match="URL resolves to an internal/private IP"):
+        _validate_url("http://100.64.0.1/test", "test_param")

--- a/uv.lock
+++ b/uv.lock
@@ -531,7 +531,7 @@ wheels = [
 
 [[package]]
 name = "imagine-mcp"
-version = "1.2.0b8"
+version = "1.2.0"
 source = { editable = "." }
 dependencies = [
     { name = "diskcache" },


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: The URL validation logic in `_validate_url` used `ip_obj.is_private`, `ip_obj.is_loopback`, `ip_obj.is_link_local`, `ip_obj.is_multicast`, and `ip_obj.is_unspecified` to determine if an IP was safe to fetch. This failed to account for Carrier-Grade NAT (CGNAT) blocks such as `100.64.0.0/10`, which are not classified as `is_private` in Python's `ipaddress` module.
🎯 Impact: Attackers could provide URLs like `http://100.64.0.1` causing the application to issue requests to internal services that might reside on those IP ranges in certain environments, leading to SSRF.
🔧 Fix: Updated the check to use the explicit whitelist condition `not ip_obj.is_global or ip_obj.is_multicast` ensuring only routable, global addresses are permitted, effectively blocking all internal subnets including CGNAT.
✅ Verification: Added `test_validate_url_blocks_cgnat` in `tests/test_dispatcher.py` to assert that `http://100.64.0.1` throws an `InvalidURLError`.

---
*PR created automatically by Jules for task [14671884280954742840](https://jules.google.com/task/14671884280954742840) started by @n24q02m*