### PR TITLE
⚡ Bolt: prevent redundant media type detection in Gemini multimodal

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,3 +1,6 @@
 ## 2024-05-18 - Optimize default_provider_for lookups
 **Learning:** `default_provider_for` in `src/imagine_mcp/models.py` performs an O(N log N) filtering and sorting of `MODELS` on every call. Since the parameter space (`action`, `media`, `tier`) is very small and bounded, caching the result yields a ~25x performance improvement. Standard lru_cache works perfectly for this use case.
 **Action:** Use `@functools.lru_cache(maxsize=32)` to optimize functions that perform expensive queries or sorting over static lists when their parameter space is small and bounded.
+## 2024-05-18 - Prevent redundant media type detection in Gemini multimodal
+**Learning:** The dispatcher correctly pre-calculates `media_types` via `detect_media_type` to validate inputs and route the request. However, `understand_multimodal` in the Gemini provider re-calculated this type for every URL in its loop, resulting in a redundant synchronous HEAD request per URL when processing media lacking clear file extensions. This is an N+1 validation problem.
+**Action:** When validating a list of items requires network requests or expensive computation before routing, pass that pre-calculated state down to the execution provider to prevent duplicating the effort.

--- a/src/imagine_mcp/dispatcher.py
+++ b/src/imagine_mcp/dispatcher.py
@@ -195,7 +195,9 @@ def dispatch_understand(
 
     # Gemini native multimodal can accept many URLs in one call
     if provider == "gemini" and len(media_urls) > 1:
-        return mod.understand_multimodal(media_urls, prompt, tier, max_tokens)
+        return mod.understand_multimodal(
+            media_urls, prompt, tier, max_tokens, media_types=media_types
+        )
 
     url = media_urls[0]
     primary = media_types[0]

--- a/src/imagine_mcp/providers/gemini.py
+++ b/src/imagine_mcp/providers/gemini.py
@@ -119,7 +119,11 @@ def understand_video(
 
 
 def understand_multimodal(
-    urls: list[str], prompt: str, tier: str, max_tokens: int = 2048
+    urls: list[str],
+    prompt: str,
+    tier: str,
+    max_tokens: int = 2048,
+    media_types: list[str] | None = None,
 ) -> dict[str, Any]:
     """Gemini native multimodal: mixed image+video URLs in a single call."""
     from google.genai import types
@@ -128,8 +132,8 @@ def understand_multimodal(
 
     model = get_model_id("gemini", "understand", "image", tier)
     parts: list[Any] = [prompt]
-    for u in urls:
-        mt = detect_media_type(u)
+    for i, u in enumerate(urls):
+        mt = media_types[i] if media_types else detect_media_type(u)
         mime = "image/png" if mt == "image" else "video/mp4"
         parts.append(types.Part.from_uri(file_uri=u, mime_type=mime))
     resp = _client().models.generate_content(


### PR DESCRIPTION
💡 **What**: Added an optional `media_types` argument to the `understand_multimodal` function in the Gemini provider and passed the pre-calculated array from the dispatcher.
🎯 **Why**: To fix an N+1 validation problem where `detect_media_type` was unnecessarily re-calculated for every URL inside the provider, causing redundant synchronous network (HEAD) requests for URLs lacking file extensions.
📊 **Impact**: Eliminates 1 synchronous HTTP HEAD request per URL during native multimodal execution when extensions are missing, reducing latency by hundreds of milliseconds per affected media item.
🔬 **Measurement**: Verified via `pytest` that existing tests still pass and the routing continues to function normally. Documented the N+1 validation learning in `.jules/bolt.md`.

---
*PR created automatically by Jules for task [13076996301608329785](https://jules.google.com/task/13076996301608329785) started by @n24q02m*