### PR TITLE
[TEST] Add tests for download_to_path in media.py

### DIFF
--- a/tests/test_media.py
+++ b/tests/test_media.py
@@ -1,11 +1,13 @@
 from __future__ import annotations
 
+from pathlib import Path
 from unittest.mock import MagicMock
 
+import httpx
 import pytest
 
-from imagine_mcp.errors import MediaDetectError
-from imagine_mcp.media import _extract_extension, detect_media_type
+from imagine_mcp.errors import InvalidURLError, MediaDetectError
+from imagine_mcp.media import _extract_extension, detect_media_type, download_to_path
 
 
 def test_detect_by_extension_image() -> None:
@@ -81,3 +83,63 @@ def test_extract_extension() -> None:
     assert _extract_extension("https://example.com/foo.PNG") == ".png"
     assert _extract_extension("https://example.com/foo.mp4?q=1") == ".mp4"
     assert _extract_extension("https://example.com/foo") == ""
+
+
+def test_download_to_path_success(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    dest = tmp_path / "sub" / "file.txt"
+    url = "https://example.com/file.txt"
+    content = [b"chunk1", b"chunk2"]
+
+    mock_response = MagicMock()
+    mock_response.iter_bytes.return_value = iter(content)
+    mock_response.raise_for_status = MagicMock()
+
+    mock_client = MagicMock()
+    mock_client.stream.return_value.__enter__.return_value = mock_response
+
+    monkeypatch.setattr("imagine_mcp.media.get_ssrf_safe_client", lambda: mock_client)
+
+    result = download_to_path(url, dest)
+
+    assert result == dest
+    assert dest.read_bytes() == b"".join(content)
+    assert dest.parent.exists()
+
+
+def test_download_to_path_invalid_url(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    dest = tmp_path / "file.txt"
+    url = "https://example.com/file.txt"
+
+    mock_client = MagicMock()
+    mock_client.stream.side_effect = InvalidURLError("Invalid URL")
+
+    monkeypatch.setattr("imagine_mcp.media.get_ssrf_safe_client", lambda: mock_client)
+
+    with pytest.raises(
+        httpx.HTTPError, match="Download failed due to invalid redirect: Invalid URL"
+    ):
+        download_to_path(url, dest)
+
+
+def test_download_to_path_http_error(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    dest = tmp_path / "file.txt"
+    url = "https://example.com/file.txt"
+
+    mock_response = MagicMock()
+    mock_response.raise_for_status.side_effect = httpx.HTTPStatusError(
+        "404 Not Found", request=MagicMock(), response=MagicMock()
+    )
+
+    mock_client = MagicMock()
+    mock_client.stream.return_value.__enter__.return_value = mock_response
+
+    monkeypatch.setattr("imagine_mcp.media.get_ssrf_safe_client", lambda: mock_client)
+
+    with pytest.raises(httpx.HTTPStatusError, match="404 Not Found"):
+        download_to_path(url, dest)

--- a/uv.lock
+++ b/uv.lock
@@ -531,7 +531,7 @@ wheels = [
 
 [[package]]
 name = "imagine-mcp"
-version = "1.2.0"
+version = "1.3.0"
 source = { editable = "." }
 dependencies = [
     { name = "diskcache" },


### PR DESCRIPTION
Added unit tests for the `download_to_path` function in `src/imagine_mcp/media.py`. The tests verify successful downloads (including directory creation and chunked writing), handle `InvalidURLError` by re-raising as `httpx.HTTPError`, and correctly propagate HTTP status errors. Mocking was used to simulate network responses and ensure isolation.

---
*PR created automatically by Jules for task [5292919821562438875](https://jules.google.com/task/5292919821562438875) started by @n24q02m*