### PR TITLE
[TEST] Add missing error handling test for reset_credentials

### DIFF
--- a/tests/test_per_plugin_storage_migration.py
+++ b/tests/test_per_plugin_storage_migration.py
@@ -114,3 +114,14 @@ def test_relay_setup_reset_not_found(tmp_path, monkeypatch):
     importlib.reload(rs)
     result = rs.reset_credentials()
     assert result["status"] == "not_found"
+
+
+def test_relay_setup_reset_error(monkeypatch):
+    import imagine_mcp.relay_setup as rs
+    def mock_init(*args, **kwargs):
+        raise Exception("forced failure")
+
+    monkeypatch.setattr(rs, "PerPluginStore", mock_init)
+    result = rs.reset_credentials()
+    assert result["status"] == "error"
+    assert result["error"] == "forced failure"

--- a/uv.lock
+++ b/uv.lock
@@ -531,7 +531,7 @@ wheels = [
 
 [[package]]
 name = "imagine-mcp"
-version = "1.2.0"
+version = "1.3.0"
 source = { editable = "." }
 dependencies = [
     { name = "diskcache" },


### PR DESCRIPTION
This PR adds missing test coverage for the error handling block in `relay_setup.reset_credentials`.

By using `monkeypatch` to mock `PerPluginStore` and force an exception, we verify that:
1. The `except Exception` block in `reset_credentials` is correctly triggered.
2. The function returns a dictionary with `"status": "error"`.
3. The original exception message is included in the response.

This change improves the robustness of the relay setup logic by ensuring failure modes are tested.

---
*PR created automatically by Jules for task [13817472269857955315](https://jules.google.com/task/13817472269857955315) started by @n24q02m*