### PR TITLE
[FIX] Long function: build_app

### DIFF
--- a/src/imagine_mcp/server.py
+++ b/src/imagine_mcp/server.py
@@ -94,6 +94,142 @@ def _set_runtime(key: str | None, value: str | None) -> dict[str, Any]:
     }
 
 
+def understand_tool(
+    media_urls: list[str],
+    prompt: str,
+    provider: str | None = None,
+    tier: str = "poor",
+    max_tokens: int = 2048,
+) -> dict[str, Any]:
+    """Understand image/video content with a prompt."""
+    if len(media_urls) > settings.max_media_urls:
+        raise ValueError(
+            f"Too many media_urls ({len(media_urls)}). Max: {settings.max_media_urls}."
+        )
+    return dispatch_understand(media_urls, prompt, provider, tier, max_tokens)
+
+
+def generate_tool(
+    media_type: Literal["image", "video"],
+    prompt: str,
+    provider: str | None = None,
+    tier: str = "poor",
+    reference_image_url: str | None = None,
+    job_id: str | None = None,
+    output_mode: Literal["base64", "path", "both"] = "both",
+    aspect_ratio: str = "16:9",
+    duration_seconds: int = 8,
+) -> dict[str, Any]:
+    """Generate image or video."""
+    return dispatch_generate(
+        media_type,
+        prompt,
+        provider,
+        tier,
+        reference_image_url,
+        job_id,
+        aspect_ratio,
+        duration_seconds,
+    )
+
+
+def config_tool(
+    action: str,
+    key: str | None = None,
+    value: str | None = None,
+) -> dict[str, Any]:
+    """Server config and credential management."""
+    from imagine_mcp import relay_setup
+
+    match action:
+        case "open_relay":
+            import asyncio
+
+            result = asyncio.run(relay_setup.ensure_config(force=True))
+            if result is None:
+                return {
+                    "status": "degraded",
+                    "message": (
+                        "No credentials loaded. Set MCP_RELAY_URL and retry, "
+                        "or run the server in `http local relay mode` (default)."
+                    ),
+                }
+            return {
+                "status": "saved",
+                "providers_configured": _providers_configured(),
+            }
+        case "relay_status":
+            # Derive providers from live PerPluginStore + env so status
+            # is accurate even when env vars were not populated at startup.
+            _live_providers = _providers_configured_live()
+            return {
+                "status": "configured" if _live_providers else "pending",
+                "providers_configured": _live_providers,
+            }
+        case "relay_complete":
+            _live_providers = _providers_configured_live()
+            return {
+                "status": "saved" if _live_providers else "no_credentials",
+                "providers_configured": _live_providers,
+            }
+        case "relay_skip":
+            # Only claim "using env vars" when env vars are actually set.
+            _env_providers = _providers_configured()
+            if not _env_providers:
+                return {
+                    "status": "needs_setup",
+                    "message": "No env vars set. Run config(action='open_relay') to configure via browser.",
+                }
+            return {
+                "status": "using_env",
+                "providers": _env_providers,
+            }
+        case "relay_reset":
+            return relay_setup.reset_credentials()
+        case "warmup":
+            return {
+                "status": "ok",
+                "message": "No heavy resources to warm up in v1.",
+            }
+        case "status":
+            return {
+                "version": _get_version(),
+                "credentials_state": _creds_state(),
+                "providers_configured": _providers_configured(),
+                "default_provider": settings.default_provider,
+                "default_tier": settings.default_tier,
+                "cache_ttl_seconds": settings.cache_ttl_seconds,
+            }
+        case "set":
+            return _set_runtime(key, value)
+        case "cache_clear":
+            from imagine_mcp.cache import ResponseCache
+
+            cache = ResponseCache(
+                path=Path(platformdirs.user_cache_dir("imagine-mcp")) / "cache",
+                default_ttl=settings.cache_ttl_seconds,
+            )
+            cache.clear()
+            return {"status": "ok", "message": "Cache cleared."}
+        case _:
+            return {
+                "status": "error",
+                "message": (
+                    f"Unknown action {action!r}. Valid: open_relay|relay_status|"
+                    "relay_skip|relay_reset|relay_complete|warmup|"
+                    "status|set|cache_clear"
+                ),
+            }
+
+
+def help_tool(topic: str = "understand") -> str:
+    """Load documentation for a specific tool or topic."""
+    if topic not in VALID_HELP_TOPICS:
+        return f"Unknown topic {topic!r}. Valid: {sorted(VALID_HELP_TOPICS)}"
+    doc_file = files("imagine_mcp.docs").joinpath(f"{topic}.md")
+    return doc_file.read_text(encoding="utf-8")
+
+
 def build_app() -> FastMCP:
     """Create FastMCP app with 4 tools registered."""
     app: FastMCP = FastMCP(
@@ -105,161 +241,36 @@ def build_app() -> FastMCP:
         ),
     )
 
-    @app.tool(
+    app.tool(
+        name="understand",
         description=(
             "Understand images and/or videos (multi-URL) with a prompt. "
             "Gemini supports mixed image+video in one call; "
             "OpenAI/Grok are image-only."
         ),
-    )
-    def understand(
-        media_urls: list[str],
-        prompt: str,
-        provider: str | None = None,
-        tier: str = "poor",
-        max_tokens: int = 2048,
-    ) -> dict[str, Any]:
-        """Understand image/video content with a prompt."""
-        if len(media_urls) > settings.max_media_urls:
-            raise ValueError(
-                f"Too many media_urls ({len(media_urls)}). "
-                f"Max: {settings.max_media_urls}."
-            )
-        return dispatch_understand(media_urls, prompt, provider, tier, max_tokens)
+    )(understand_tool)
 
-    @app.tool(
+    app.tool(
+        name="generate",
         description=(
             "Generate an image or video from a text prompt. "
             "Video is async: first call returns job_id; call again with job_id to poll."
         ),
-    )
-    def generate(
-        media_type: Literal["image", "video"],
-        prompt: str,
-        provider: str | None = None,
-        tier: str = "poor",
-        reference_image_url: str | None = None,
-        job_id: str | None = None,
-        output_mode: Literal["base64", "path", "both"] = "both",
-        aspect_ratio: str = "16:9",
-        duration_seconds: int = 8,
-    ) -> dict[str, Any]:
-        """Generate image or video."""
-        return dispatch_generate(
-            media_type,
-            prompt,
-            provider,
-            tier,
-            reference_image_url,
-            job_id,
-            aspect_ratio,
-            duration_seconds,
-        )
+    )(generate_tool)
 
-    @app.tool(
+    app.tool(
+        name="config",
         description=(
             "Server config + credential setup (MERGED). Actions: "
             "(relay) open_relay|relay_status|relay_skip|relay_reset|"
             "relay_complete|warmup; (runtime) status|set|cache_clear."
         ),
-    )
-    def config(
-        action: str,
-        key: str | None = None,
-        value: str | None = None,
-    ) -> dict[str, Any]:
-        """Server config and credential management."""
-        from imagine_mcp import relay_setup
+    )(config_tool)
 
-        match action:
-            case "open_relay":
-                import asyncio
-
-                result = asyncio.run(relay_setup.ensure_config(force=True))
-                if result is None:
-                    return {
-                        "status": "degraded",
-                        "message": (
-                            "No credentials loaded. Set MCP_RELAY_URL and retry, "
-                            "or run the server in `http local relay mode` (default)."
-                        ),
-                    }
-                return {
-                    "status": "saved",
-                    "providers_configured": _providers_configured(),
-                }
-            case "relay_status":
-                # Derive providers from live PerPluginStore + env so status
-                # is accurate even when env vars were not populated at startup.
-                _live_providers = _providers_configured_live()
-                return {
-                    "status": "configured" if _live_providers else "pending",
-                    "providers_configured": _live_providers,
-                }
-            case "relay_complete":
-                _live_providers = _providers_configured_live()
-                return {
-                    "status": "saved" if _live_providers else "no_credentials",
-                    "providers_configured": _live_providers,
-                }
-            case "relay_skip":
-                # Only claim "using env vars" when env vars are actually set.
-                _env_providers = _providers_configured()
-                if not _env_providers:
-                    return {
-                        "status": "needs_setup",
-                        "message": "No env vars set. Run config(action='open_relay') to configure via browser.",
-                    }
-                return {
-                    "status": "using_env",
-                    "providers": _env_providers,
-                }
-            case "relay_reset":
-                return relay_setup.reset_credentials()
-            case "warmup":
-                return {
-                    "status": "ok",
-                    "message": "No heavy resources to warm up in v1.",
-                }
-            case "status":
-                return {
-                    "version": _get_version(),
-                    "credentials_state": _creds_state(),
-                    "providers_configured": _providers_configured(),
-                    "default_provider": settings.default_provider,
-                    "default_tier": settings.default_tier,
-                    "cache_ttl_seconds": settings.cache_ttl_seconds,
-                }
-            case "set":
-                return _set_runtime(key, value)
-            case "cache_clear":
-                from imagine_mcp.cache import ResponseCache
-
-                cache = ResponseCache(
-                    path=Path(platformdirs.user_cache_dir("imagine-mcp")) / "cache",
-                    default_ttl=settings.cache_ttl_seconds,
-                )
-                cache.clear()
-                return {"status": "ok", "message": "Cache cleared."}
-            case _:
-                return {
-                    "status": "error",
-                    "message": (
-                        f"Unknown action {action!r}. Valid: open_relay|relay_status|"
-                        "relay_skip|relay_reset|relay_complete|warmup|"
-                        "status|set|cache_clear"
-                    ),
-                }
-
-    @app.tool(
+    app.tool(
+        name="help",
         description=("Full documentation. Topics: understand | generate | config."),
-    )
-    def help(topic: str = "understand") -> str:
-        """Load documentation for a specific tool or topic."""
-        if topic not in VALID_HELP_TOPICS:
-            return f"Unknown topic {topic!r}. Valid: {sorted(VALID_HELP_TOPICS)}"
-        doc_file = files("imagine_mcp.docs").joinpath(f"{topic}.md")
-        return doc_file.read_text(encoding="utf-8")
+    )(help_tool)
 
     # mcp-core >=1.13: register_open_relay_tool takes public_url (str | None).
     # In stdio mode PUBLIC_URL is unset → tool returns ``stdio_unsupported``.

--- a/uv.lock
+++ b/uv.lock
@@ -531,7 +531,7 @@ wheels = [
 
 [[package]]
 name = "imagine-mcp"
-version = "1.2.0"
+version = "1.3.0"
 source = { editable = "." }
 dependencies = [
     { name = "diskcache" },


### PR DESCRIPTION
This PR refactors the `build_app` function in `src/imagine_mcp/server.py` to improve maintainability and readability. The nested tool handlers (`understand`, `generate`, `config`, and `help`) have been extracted into top-level functions (`understand_tool`, `generate_tool`, `config_tool`, and `help_tool`).

`build_app` now registers these handlers using the `app.tool(name=..., description=...)(handler_func)` pattern.

All tests passed, and code style has been verified with Ruff.

---
*PR created automatically by Jules for task [11780652795883399953](https://jules.google.com/task/11780652795883399953) started by @n24q02m*