### PR TITLE
[FIX] Redundant media type detection in Gemini provider

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,3 +1,6 @@
 ## 2024-05-18 - Optimize default_provider_for lookups
 **Learning:** `default_provider_for` in `src/imagine_mcp/models.py` performs an O(N log N) filtering and sorting of `MODELS` on every call. Since the parameter space (`action`, `media`, `tier`) is very small and bounded, caching the result yields a ~25x performance improvement. Standard lru_cache works perfectly for this use case.
 **Action:** Use `@functools.lru_cache(maxsize=32)` to optimize functions that perform expensive queries or sorting over static lists when their parameter space is small and bounded.
+## 2026-05-07 - Avoid redundant media type detection in Gemini multimodal
+**Learning:** `dispatch_understand` in `dispatcher.py` already computes media types for all URLs. Passing these pre-computed types to the provider's `understand_multimodal` function avoids redundant synchronous network calls (HEAD requests) for each URL in Gemini's multimodal path, improving latency and reducing outgoing requests.
+**Action:** Pass pre-computed media metadata from dispatchers to providers whenever possible to avoid duplicate IO-bound detection logic.

--- a/src/imagine_mcp/dispatcher.py
+++ b/src/imagine_mcp/dispatcher.py
@@ -195,7 +195,9 @@ def dispatch_understand(
 
     # Gemini native multimodal can accept many URLs in one call
     if provider == "gemini" and len(media_urls) > 1:
-        return mod.understand_multimodal(media_urls, prompt, tier, max_tokens)
+        return mod.understand_multimodal(
+            media_urls, prompt, tier, max_tokens, media_types
+        )
 
     url = media_urls[0]
     primary = media_types[0]

--- a/src/imagine_mcp/providers/gemini.py
+++ b/src/imagine_mcp/providers/gemini.py
@@ -119,7 +119,11 @@ def understand_video(
 
 
 def understand_multimodal(
-    urls: list[str], prompt: str, tier: str, max_tokens: int = 2048
+    urls: list[str],
+    prompt: str,
+    tier: str,
+    max_tokens: int = 2048,
+    media_types: list[str] | None = None,
 ) -> dict[str, Any]:
     """Gemini native multimodal: mixed image+video URLs in a single call."""
     from google.genai import types
@@ -128,8 +132,8 @@ def understand_multimodal(
 
     model = get_model_id("gemini", "understand", "image", tier)
     parts: list[Any] = [prompt]
-    for u in urls:
-        mt = detect_media_type(u)
+    for i, u in enumerate(urls):
+        mt = media_types[i] if media_types else detect_media_type(u)
         mime = "image/png" if mt == "image" else "video/mp4"
         parts.append(types.Part.from_uri(file_uri=u, mime_type=mime))
     resp = _client().models.generate_content(

--- a/tests/test_providers_gemini.py
+++ b/tests/test_providers_gemini.py
@@ -54,3 +54,45 @@ def test_understand_image_live() -> None:
         tier="poor",
     )
     assert "cat" in result["text"].lower()
+
+
+def test_understand_multimodal_mocked(monkeypatch: pytest.MonkeyPatch) -> None:
+    fake_client = MagicMock()
+    fake_response = MagicMock()
+    fake_response.text = "mixed content"
+    fake_client.models.generate_content.return_value = fake_response
+    monkeypatch.setattr(gemini, "_client", lambda: fake_client)
+
+    # Use a mock for detect_media_type to verify it is NOT called when media_types is provided
+    mock_detect = MagicMock()
+    monkeypatch.setattr("imagine_mcp.media.detect_media_type", mock_detect)
+
+    urls = ["https://example.com/cat.png", "https://example.com/dog.mp4"]
+    media_types = ["image", "video"]
+    result = gemini.understand_multimodal(
+        urls=urls, prompt="describe both", tier="poor", media_types=media_types
+    )
+
+    assert result["text"] == "mixed content"
+    assert result["multimodal"] is True
+    assert mock_detect.call_count == 0
+
+
+def test_understand_multimodal_fallback(monkeypatch: pytest.MonkeyPatch) -> None:
+    fake_client = MagicMock()
+    fake_response = MagicMock()
+    fake_response.text = "mixed content fallback"
+    fake_client.models.generate_content.return_value = fake_response
+    monkeypatch.setattr(gemini, "_client", lambda: fake_client)
+
+    # Use a mock for detect_media_type to verify it IS called when media_types is NOT provided
+    mock_detect = MagicMock(return_value="image")
+    monkeypatch.setattr("imagine_mcp.media.detect_media_type", mock_detect)
+
+    urls = ["https://example.com/cat.png", "https://example.com/dog.png"]
+    result = gemini.understand_multimodal(
+        urls=urls, prompt="describe both", tier="poor"
+    )
+
+    assert result["text"] == "mixed content fallback"
+    assert mock_detect.call_count == 2

--- a/uv.lock
+++ b/uv.lock
@@ -531,7 +531,7 @@ wheels = [
 
 [[package]]
 name = "imagine-mcp"
-version = "1.2.0"
+version = "1.3.0"
 source = { editable = "." }
 dependencies = [
     { name = "diskcache" },


### PR DESCRIPTION
This PR optimizes the Gemini provider's multimodal path by leveraging pre-computed media types from the dispatcher.

### Changes:
- **`src/imagine_mcp/providers/gemini.py`**: Updated `understand_multimodal` signature to accept `media_types`. Updated logic to use these types if provided, falling back to detection only if missing.
- **`src/imagine_mcp/dispatcher.py`**: Updated `dispatch_understand` to pass the `media_types` list it already computes to the Gemini provider.
- **`tests/test_providers_gemini.py`**: Added new tests to ensure `understand_multimodal` correctly uses passed `media_types` and skips redundant detection.

### Why:
The dispatcher already performs media type detection for all URLs to determine if video is present. Re-detecting them in the provider caused redundant synchronous network calls (HEAD requests), which increased latency and was inefficient.

### Impact:
Reduces the number of outgoing HEAD requests for multimodal Gemini calls and improves overall response time.

---
*PR created automatically by Jules for task [15088302030926426265](https://jules.google.com/task/15088302030926426265) started by @n24q02m*