### PR TITLE
[FIX] N+1 sequential media type detection

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,3 +1,6 @@
 ## 2024-05-18 - Optimize default_provider_for lookups
 **Learning:** `default_provider_for` in `src/imagine_mcp/models.py` performs an O(N log N) filtering and sorting of `MODELS` on every call. Since the parameter space (`action`, `media`, `tier`) is very small and bounded, caching the result yields a ~25x performance improvement. Standard lru_cache works perfectly for this use case.
 **Action:** Use `@functools.lru_cache(maxsize=32)` to optimize functions that perform expensive queries or sorting over static lists when their parameter space is small and bounded.
+## 2026-05-07 - Parallelize media type detection in dispatch_understand
+**Learning:** Sequential `detect_media_type` calls for multiple URLs in `dispatch_understand` created an N+1 network bottleneck. Parallelizing these calls using a `ThreadPoolExecutor` reduces latency from O(N) to O(1) (relative to the slowest request) for small batches of URLs.
+**Action:** Use `ThreadPoolExecutor` to concurrently perform independent network-bound validation and detection tasks for collections of user-provided URLs.

--- a/src/imagine_mcp/dispatcher.py
+++ b/src/imagine_mcp/dispatcher.py
@@ -180,10 +180,18 @@ def dispatch_understand(
     _validate(provider, tier)
     if not media_urls:
         raise InvalidMediaTypeError("media_urls is empty")
-    for i, u in enumerate(media_urls):
-        _validate_url(u, f"media_urls[{i}]")
 
-    media_types = [detect_media_type(u) for u in media_urls]
+    def _validate_and_detect(i: int, url: str) -> str:
+        _validate_url(url, f"media_urls[{i}]")
+        return detect_media_type(url)
+
+    with concurrent.futures.ThreadPoolExecutor(
+        max_workers=min(len(media_urls), 16), thread_name_prefix="media_detector"
+    ) as executor:
+        # Using list() to force evaluation and catch exceptions
+        media_types = list(
+            executor.map(_validate_and_detect, range(len(media_urls)), media_urls)
+        )
     has_video = "video" in media_types
 
     if has_video:

--- a/tests/test_dispatcher.py
+++ b/tests/test_dispatcher.py
@@ -305,3 +305,44 @@ def test_validate_url_blocks_cgnat() -> None:
     # but is considered not global by is_global. Our updated validation must block it.
     with pytest.raises(InvalidURLError, match="URL resolves to an internal/private IP"):
         _validate_url("http://100.64.0.1/test", "test_param")
+
+
+def test_dispatch_understand_parallel_detection(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import time
+
+    calls = []
+
+    def mock_detect(url: str) -> str:
+        calls.append(url)
+        time.sleep(0.3)
+        return "image"
+
+    monkeypatch.setattr("imagine_mcp.dispatcher.detect_media_type", mock_detect)
+    # Mock _validate_url to do nothing fast
+    monkeypatch.setattr("imagine_mcp.dispatcher._validate_url", lambda u, p: None)
+    # Mock _default_provider and _validate
+    monkeypatch.setattr("imagine_mcp.dispatcher._default_provider", lambda: "gemini")
+    monkeypatch.setattr("imagine_mcp.dispatcher._validate", lambda p, t: None)
+    # Mock get_model_id
+    monkeypatch.setattr("imagine_mcp.dispatcher.get_model_id", lambda *args: "model-id")
+
+    # Mock _load_provider
+    class MockMod:
+        @staticmethod
+        def understand_multimodal(
+            urls: list[str], prompt: str, tier: str, max_tokens: int = 2048
+        ) -> dict:
+            return {"ok": True, "provider": "gemini"}
+
+    monkeypatch.setattr("imagine_mcp.dispatcher._load_provider", lambda p: MockMod)
+
+    urls = ["http://ex1.com", "http://ex2.com", "http://ex3.com"]
+    start = time.time()
+    dispatch_understand(urls, "prompt", "gemini", "poor")
+    duration = time.time() - start
+
+    # If sequential, it should take ~0.9s. If parallel, it should take ~0.3s.
+    # Allow some overhead, so < 0.6s is safe.
+    assert duration < 0.6

--- a/uv.lock
+++ b/uv.lock
@@ -531,7 +531,7 @@ wheels = [
 
 [[package]]
 name = "imagine-mcp"
-version = "1.2.0"
+version = "1.3.0"
 source = { editable = "." }
 dependencies = [
     { name = "diskcache" },


### PR DESCRIPTION
The `dispatch_understand` function previously performed sequential `detect_media_type` calls for each URL in `media_urls`. This created an N+1 network call pattern, especially when URLs required HEAD requests to determine their type.

This commit introduces a `ThreadPoolExecutor` to run `_validate_url` and `detect_media_type` concurrently for all `media_urls`. This reduces the overall latency from O(N) to O(1) relative to the slowest network request.

A new test case `test_dispatch_understand_parallel_detection` has been added to `tests/test_dispatcher.py` to verify the concurrent behavior.

Impact:
- Significantly reduced latency for `understand` calls with multiple URLs.
- Maintains existing exception handling and SSRF validation logic.
- Performance improvement verified via unit tests with simulated network delay.

---
*PR created automatically by Jules for task [12591483517000251023](https://jules.google.com/task/12591483517000251023) started by @n24q02m*