### PR TITLE
[FIX] Implement OpenAI image edit capabilities

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,3 +1,7 @@
 ## 2024-05-18 - Optimize default_provider_for lookups
 **Learning:** `default_provider_for` in `src/imagine_mcp/models.py` performs an O(N log N) filtering and sorting of `MODELS` on every call. Since the parameter space (`action`, `media`, `tier`) is very small and bounded, caching the result yields a ~25x performance improvement. Standard lru_cache works perfectly for this use case.
 **Action:** Use `@functools.lru_cache(maxsize=32)` to optimize functions that perform expensive queries or sorting over static lists when their parameter space is small and bounded.
+
+## 2026-04-24 - OpenAI Image Edit Implementation
+**Learning:** OpenAI's `images.edit` endpoint currently only supports the `dall-e-2` model; `dall-e-3` and newer models do not support inpainting/editing via this specific API. Additionally, the input image must be a square PNG with an alpha channel (RGBA).
+**Action:** When implementing image editing for OpenAI, pin the model to `dall-e-2` and use Pillow to pre-process the reference image (convert to RGBA and resize to square, e.g., 1024x1024) to ensure API compatibility.

--- a/src/imagine_mcp/providers/openai.py
+++ b/src/imagine_mcp/providers/openai.py
@@ -3,12 +3,14 @@
 from __future__ import annotations
 
 import base64
+import io
 import os
 import uuid
 from pathlib import Path
 from typing import Any
 
 import platformdirs
+from PIL import Image
 
 from imagine_mcp.config import settings
 from imagine_mcp.errors import (
@@ -20,7 +22,7 @@ from imagine_mcp.models import get_model_id
 
 _CLIENT: Any = None
 # Per-sub client cache for HTTP multi-user mode. See providers/gemini.py
-# for rationale; module-level ``_CLIENT`` still serves stdio + single-user.
+# for rationale; module-level `_CLIENT` still serves stdio + single-user.
 _SUB_CLIENTS: dict[str, Any] = {}
 
 
@@ -110,29 +112,69 @@ def understand_video(
     )
 
 
+def edit(tier: str, image_url: str, prompt: str) -> dict[str, Any]:
+    """Edit an existing image (DALL-E 2)."""
+    from imagine_mcp.media import get_ssrf_safe_client
+
+    # DALL-E 2 only supports 256, 512, 1024 square.
+    size = "1024x1024"
+    model = "dall-e-2"
+
+    raw_bytes = (
+        get_ssrf_safe_client().get(image_url, follow_redirects=True, timeout=60).content
+    )
+
+    # DALL-E 2 requires PNG with alpha channel, and square.
+    with Image.open(io.BytesIO(raw_bytes)) as img:
+        img = img.convert("RGBA")
+        img = img.resize((1024, 1024))
+        buf = io.BytesIO()
+        img.save(buf, format="PNG")
+        png_bytes = buf.getvalue()
+
+    resp = _client().images.edit(
+        model=model,
+        image=png_bytes,
+        prompt=prompt,
+        size=size,
+        response_format="b64_json",
+    )
+
+    img_b64 = resp.data[0].b64_json
+    if not img_b64:
+        raise ProviderAPIError("OpenAI returned no image", status_code=500)
+    img_bytes = base64.b64decode(img_b64)
+
+    out_dir = Path(platformdirs.user_cache_dir("imagine-mcp")) / "generations"
+    out_dir.mkdir(parents=True, exist_ok=True)
+    out_path = out_dir / f"{uuid.uuid4().hex}.png"
+    out_path.write_bytes(img_bytes)
+
+    return {
+        "image_path": str(out_path),
+        "image_base64": img_b64,
+        "model": model,
+        "provider": "openai",
+        "tier": tier,
+    }
+
+
 def generate_image(
     prompt: str,
     tier: str,
     reference_image_url: str | None = None,
     aspect_ratio: str = "1:1",
 ) -> dict[str, Any]:
+    if reference_image_url:
+        return edit(tier, reference_image_url, prompt)
+
     model = get_model_id("openai", "generate", "image", tier)
     size_map = {"1:1": "1024x1024", "16:9": "1792x1024", "9:16": "1024x1792"}
     size = size_map.get(aspect_ratio, "1024x1024")
 
-    if reference_image_url:
-        from imagine_mcp.media import get_ssrf_safe_client
-
-        img_bytes = (
-            get_ssrf_safe_client()
-            .get(reference_image_url, follow_redirects=True, timeout=60)
-            .content
-        )
-        resp = _client().images.edit(
-            model=model, image=img_bytes, prompt=prompt, size=size
-        )
-    else:
-        resp = _client().images.generate(model=model, prompt=prompt, size=size, n=1)
+    resp = _client().images.generate(
+        model=model, prompt=prompt, size=size, n=1, response_format="b64_json"
+    )
 
     img_b64 = resp.data[0].b64_json
     if not img_b64:
@@ -163,5 +205,12 @@ def generate_video(
 ) -> dict[str, Any]:
     raise ProviderUnsupportedError(
         "openai.generate.video: Sora 2 API shutdown 2026-09-24. "
+        "Use provider='gemini' (Veo) or 'grok' (Grok Imagine)."
+    )
+
+
+def video_status(tier: str, job_id: str) -> dict[str, Any]:
+    raise ProviderUnsupportedError(
+        "openai.video_status: Sora 2 API shutdown 2026-09-24. "
         "Use provider='gemini' (Veo) or 'grok' (Grok Imagine)."
     )

--- a/tests/test_providers_openai.py
+++ b/tests/test_providers_openai.py
@@ -73,11 +73,15 @@ def test_generate_image_routes_to_edit(monkeypatch):
     monkeypatch.setattr(provider, "edit", mock_edit)
 
     result = provider.generate_image(
-        prompt="add a hat", tier="rich", reference_image_url="https://example.com/fox.png"
+        prompt="add a hat",
+        tier="rich",
+        reference_image_url="https://example.com/fox.png",
     )
 
     assert result == {"status": "edited"}
-    mock_edit.assert_called_once_with("rich", "https://example.com/fox.png", "add a hat")
+    mock_edit.assert_called_once_with(
+        "rich", "https://example.com/fox.png", "add a hat"
+    )
 
 
 def test_video_status_raises_unsupported():

--- a/tests/test_providers_openai.py
+++ b/tests/test_providers_openai.py
@@ -1,19 +1,25 @@
 from __future__ import annotations
-import io
+
 import base64
+import io
 from unittest.mock import MagicMock, patch
+
 import pytest
 from PIL import Image
+
 from imagine_mcp.errors import ProviderUnsupportedError
 from imagine_mcp.providers import openai as provider
+
 
 def test_understand_video_raises() -> None:
     with pytest.raises(ProviderUnsupportedError):
         provider.understand_video("https://example.com/x.mp4", "describe", "poor")
 
+
 def test_generate_video_raises() -> None:
     with pytest.raises(ProviderUnsupportedError):
         provider.generate_video("a dog", "poor")
+
 
 def test_understand_image_mocked(monkeypatch: pytest.MonkeyPatch) -> None:
     fake = MagicMock()
@@ -27,6 +33,7 @@ def test_understand_image_mocked(monkeypatch: pytest.MonkeyPatch) -> None:
     assert result["model"] == "gpt-5.4-mini"
     assert result["provider"] == "openai"
 
+
 def test_edit_logic(monkeypatch):
     # Mock client
     fake_client = MagicMock()
@@ -39,16 +46,14 @@ def test_edit_logic(monkeypatch):
     with patch("imagine_mcp.media.get_ssrf_safe_client") as mock_get_client:
         mock_http = MagicMock()
         # Create a real small PNG for PIL to open
-        img = Image.new('RGB', (100, 100), color='red')
+        img = Image.new("RGB", (100, 100), color="red")
         buf = io.BytesIO()
-        img.save(buf, format='PNG')
+        img.save(buf, format="PNG")
         mock_http.get.return_value.content = buf.getvalue()
         mock_get_client.return_value = mock_http
 
         result = provider.edit(
-            tier="rich",
-            image_url="https://example.com/fox.png",
-            prompt="add a hat"
+            tier="rich", image_url="https://example.com/fox.png", prompt="add a hat"
         )
 
         assert result["model"] == "dall-e-2"
@@ -56,10 +61,11 @@ def test_edit_logic(monkeypatch):
         assert "image_path" in result
 
         # Verify edit call
-        args, kwargs = fake_client.images.edit.call_args
+        _args, kwargs = fake_client.images.edit.call_args
         assert kwargs["model"] == "dall-e-2"
         assert kwargs["size"] == "1024x1024"
         assert kwargs["response_format"] == "b64_json"
+
 
 def test_generate_image_routes_to_edit(monkeypatch):
     # Mock the edit function itself
@@ -67,13 +73,12 @@ def test_generate_image_routes_to_edit(monkeypatch):
     monkeypatch.setattr(provider, "edit", mock_edit)
 
     result = provider.generate_image(
-        prompt="add a hat",
-        tier="rich",
-        reference_image_url="https://example.com/fox.png"
+        prompt="add a hat", tier="rich", reference_image_url="https://example.com/fox.png"
     )
 
     assert result == {"status": "edited"}
     mock_edit.assert_called_once_with("rich", "https://example.com/fox.png", "add a hat")
+
 
 def test_video_status_raises_unsupported():
     with pytest.raises(ProviderUnsupportedError) as exc:

--- a/tests/test_providers_openai.py
+++ b/tests/test_providers_openai.py
@@ -1,22 +1,19 @@
 from __future__ import annotations
-
-from unittest.mock import MagicMock
-
+import io
+import base64
+from unittest.mock import MagicMock, patch
 import pytest
-
+from PIL import Image
 from imagine_mcp.errors import ProviderUnsupportedError
 from imagine_mcp.providers import openai as provider
-
 
 def test_understand_video_raises() -> None:
     with pytest.raises(ProviderUnsupportedError):
         provider.understand_video("https://example.com/x.mp4", "describe", "poor")
 
-
 def test_generate_video_raises() -> None:
     with pytest.raises(ProviderUnsupportedError):
         provider.generate_video("a dog", "poor")
-
 
 def test_understand_image_mocked(monkeypatch: pytest.MonkeyPatch) -> None:
     fake = MagicMock()
@@ -29,3 +26,56 @@ def test_understand_image_mocked(monkeypatch: pytest.MonkeyPatch) -> None:
     assert result["text"] == "a dog"
     assert result["model"] == "gpt-5.4-mini"
     assert result["provider"] == "openai"
+
+def test_edit_logic(monkeypatch):
+    # Mock client
+    fake_client = MagicMock()
+    mock_resp = MagicMock()
+    mock_resp.data = [MagicMock(b64_json=base64.b64encode(b"new_image").decode())]
+    fake_client.images.edit.return_value = mock_resp
+    monkeypatch.setattr(provider, "_client", lambda: fake_client)
+
+    # Mock media.get_ssrf_safe_client
+    with patch("imagine_mcp.media.get_ssrf_safe_client") as mock_get_client:
+        mock_http = MagicMock()
+        # Create a real small PNG for PIL to open
+        img = Image.new('RGB', (100, 100), color='red')
+        buf = io.BytesIO()
+        img.save(buf, format='PNG')
+        mock_http.get.return_value.content = buf.getvalue()
+        mock_get_client.return_value = mock_http
+
+        result = provider.edit(
+            tier="rich",
+            image_url="https://example.com/fox.png",
+            prompt="add a hat"
+        )
+
+        assert result["model"] == "dall-e-2"
+        assert result["provider"] == "openai"
+        assert "image_path" in result
+
+        # Verify edit call
+        args, kwargs = fake_client.images.edit.call_args
+        assert kwargs["model"] == "dall-e-2"
+        assert kwargs["size"] == "1024x1024"
+        assert kwargs["response_format"] == "b64_json"
+
+def test_generate_image_routes_to_edit(monkeypatch):
+    # Mock the edit function itself
+    mock_edit = MagicMock(return_value={"status": "edited"})
+    monkeypatch.setattr(provider, "edit", mock_edit)
+
+    result = provider.generate_image(
+        prompt="add a hat",
+        tier="rich",
+        reference_image_url="https://example.com/fox.png"
+    )
+
+    assert result == {"status": "edited"}
+    mock_edit.assert_called_once_with("rich", "https://example.com/fox.png", "add a hat")
+
+def test_video_status_raises_unsupported():
+    with pytest.raises(ProviderUnsupportedError) as exc:
+        provider.video_status("poor", "job-123")
+    assert "video_status" in str(exc.value).lower()

--- a/uv.lock
+++ b/uv.lock
@@ -531,7 +531,7 @@ wheels = [
 
 [[package]]
 name = "imagine-mcp"
-version = "1.2.0"
+version = "1.3.0"
 source = { editable = "." }
 dependencies = [
     { name = "diskcache" },


### PR DESCRIPTION
This PR implements image editing capabilities for the OpenAI provider. 

Key changes:
- Implemented a dedicated `edit` function in `src/imagine_mcp/providers/openai.py` that uses the DALL-E 2 model (required for editing).
- Added image pre-processing using Pillow to ensure the input image is a square PNG with an alpha channel (RGBA), as mandated by the OpenAI API.
- Updated `generate_image` to route to the `edit` function when a `reference_image_url` is provided.
- Fixed a bug in the text-to-image path where `b64_json` was not explicitly requested but the code expected it in the response.
- Added a placeholder `video_status` function that raises `ProviderUnsupportedError`, aligning with the provider's capabilities.
- Added comprehensive unit tests in `tests/test_providers_openai.py` to verify these changes.

---
*PR created automatically by Jules for task [11322054592195178079](https://jules.google.com/task/11322054592195178079) started by @n24q02m*