### PR TITLE
[SECURITY] TOCTOU SSRF in DNS Resolution for URL Validation

### DIFF
--- a/src/imagine_mcp/dispatcher.py
+++ b/src/imagine_mcp/dispatcher.py
@@ -2,22 +2,17 @@
 
 from __future__ import annotations
 
-import concurrent.futures
 import importlib
-import ipaddress
-import socket
 from typing import Any
-from urllib.parse import urlparse
 
 from imagine_mcp.errors import (
     CredentialMissingError,
     InvalidMediaTypeError,
     InvalidProviderError,
     InvalidTierError,
-    InvalidURLError,
     ProviderUnsupportedError,
 )
-from imagine_mcp.media import detect_media_type
+from imagine_mcp.media import detect_media_type, validate_url_and_get_ip
 from imagine_mcp.models import UNSUPPORTED, get_model_id
 
 VALID_PROVIDERS = ["gemini", "openai", "grok"]
@@ -52,63 +47,13 @@ _UNSUPPORTED_HINTS: dict[tuple[str, str, str], str] = {
 }
 
 
-_ALLOWED_URL_SCHEMES = frozenset({"http", "https"})
-
-_DNS_RESOLVER_POOL = concurrent.futures.ThreadPoolExecutor(
-    max_workers=4, thread_name_prefix="dns_resolver"
-)
-
-
 def _validate_url(url: str, param: str) -> None:
-    """Reject non-http(s) URLs to prevent SSRF and local file inclusion.
+    """Reject non-http(s) URLs and internal IPs to prevent SSRF.
 
-    Providers pass URLs to SDKs / HEAD requests that honour file://, ftp://,
-    gopher://, etc. Restrict to http/https at the dispatch boundary so every
-    downstream call inherits the check.
-
-    Also verify that the resolved hostname does not point to a local/private IP.
-    Note: This is a best-effort defense against SSRF. Because we pass the URL string
-    to downstream SDKs rather than managing the HTTP client ourselves, this check
-    remains vulnerable to Time-Of-Check to Time-Of-Use (TOCTOU) DNS rebinding attacks.
+    This function calls the centralized validation utility which ensures
+    the URL uses an allowed scheme and resolves to a public, non-multicast IP.
     """
-    parsed = urlparse(url)
-    scheme = parsed.scheme.lower()
-    if scheme not in _ALLOWED_URL_SCHEMES:
-        raise InvalidURLError(
-            f"Invalid {param} scheme {scheme!r}. Only http/https are allowed."
-        )
-
-    hostname = parsed.hostname
-    if not hostname:
-        raise InvalidURLError(f"Invalid {param}: missing hostname.")
-
-    try:
-        # Wrap the blocking getaddrinfo in a thread with a short timeout
-        # to prevent DoS attacks via malicious DNS servers.
-        future = _DNS_RESOLVER_POOL.submit(socket.getaddrinfo, hostname, None)
-        # Short timeout to fail fast on tarpit DNS
-        addr_info = future.result(timeout=2.0)
-
-        for res in addr_info:
-            ip_str = res[4][0]
-            ip_obj = ipaddress.ip_address(ip_str)
-
-            # Extract underlying IPv4 if it's an IPv4-mapped IPv6 address (e.g. ::ffff:127.0.0.1)
-            if ip_obj.version == 6 and ip_obj.ipv4_mapped:
-                ip_obj = ip_obj.ipv4_mapped
-
-            if not ip_obj.is_global or ip_obj.is_multicast:
-                raise InvalidURLError(
-                    f"Invalid {param}: URL resolves to an internal/private IP."
-                )
-    except concurrent.futures.TimeoutError as e:
-        raise InvalidURLError(
-            f"Invalid {param}: DNS resolution timed out for {hostname!r}."
-        ) from e
-    except socket.gaierror as e:
-        raise InvalidURLError(
-            f"Invalid {param}: Could not resolve hostname {hostname!r}."
-        ) from e
+    validate_url_and_get_ip(url, param)
 
 
 def _validate(provider: str, tier: str) -> None:

--- a/src/imagine_mcp/media.py
+++ b/src/imagine_mcp/media.py
@@ -2,15 +2,25 @@
 
 from __future__ import annotations
 
+import concurrent.futures
+import ipaddress
 import os
+import socket
 from pathlib import Path
 from typing import Literal
+from urllib.parse import urlparse
 
 import httpx
 
 from imagine_mcp.errors import InvalidURLError, MediaDetectError
 
 MediaType = Literal["image", "video"]
+
+_DNS_RESOLVER_POOL = concurrent.futures.ThreadPoolExecutor(
+    max_workers=4, thread_name_prefix="dns_resolver"
+)
+
+_SAFE_URL_SCHEMES = frozenset({"http", "https"})
 
 _IMAGE_EXT = {".png", ".jpg", ".jpeg", ".gif", ".webp", ".bmp", ".tiff", ".svg"}
 _VIDEO_EXT = {".mp4", ".webm", ".mov", ".avi", ".mkv", ".flv", ".m4v"}
@@ -20,13 +30,86 @@ _VIDEO_MIME_PREFIX = "video/"
 
 
 class SSRFSafeTransport(httpx.HTTPTransport):
-    """Custom transport that validates redirect locations against SSRF checks."""
+    """Custom transport that implements DNS pinning to prevent TOCTOU SSRF.
+
+    It resolves the hostname, validates the IP against local/private ranges,
+    and then rewrites the request URL to use the IP address directly.
+    """
 
     def handle_request(self, request: httpx.Request) -> httpx.Response:
-        from imagine_mcp.dispatcher import _validate_url
+        url = request.url
+        if url.scheme.lower() not in _SAFE_URL_SCHEMES:
+            return super().handle_request(request)
 
-        _validate_url(str(request.url), "redirect_url")
+        host = url.host
+        ip = validate_url_and_get_ip(str(url), "redirect_url")
+
+        # Pin the request to the validated IP to prevent TOCTOU DNS rebinding.
+        request.url = request.url.copy_with(host=ip)
+
+        # Ensure Host header is set for virtual hosting.
+        if "Host" not in request.headers:
+            request.headers["Host"] = host
+
+        # Set SNI extension for TLS.
+        request.extensions["sni_hostname"] = host
+
         return super().handle_request(request)
+
+
+def validate_url_and_get_ip(url: str, param: str) -> str:
+    """Verify URL scheme and resolve hostname to a public IP.
+
+    Returns the first validated IP address string.
+    Raises InvalidURLError if the URL is unsafe.
+    """
+    parsed = urlparse(url)
+    scheme = parsed.scheme.lower()
+    if scheme not in _SAFE_URL_SCHEMES:
+        raise InvalidURLError(
+            f"Invalid {param} scheme {scheme!r}. Only http/https are allowed."
+        )
+
+    hostname = parsed.hostname
+    if not hostname:
+        raise InvalidURLError(f"Invalid {param}: missing hostname.")
+
+    try:
+        # Wrap the blocking getaddrinfo in a thread with a short timeout
+        # to prevent DoS attacks via malicious DNS servers.
+        future = _DNS_RESOLVER_POOL.submit(
+            socket.getaddrinfo, hostname, parsed.port, socket.AF_INET
+        )
+        # Short timeout to fail fast on tarpit DNS
+        addr_info = future.result(timeout=2.0)
+
+        for res in addr_info:
+            ip_str = res[4][0]
+            ip_obj = ipaddress.ip_address(ip_str)
+
+            # Extract underlying IPv4 if it's an IPv4-mapped IPv6 address (e.g. ::ffff:127.0.0.1)
+            if ip_obj.version == 6 and ip_obj.ipv4_mapped:
+                ip_obj = ip_obj.ipv4_mapped
+
+            # Strictly allow only public, non-multicast IPs.
+            if not ip_obj.is_global or ip_obj.is_multicast:
+                raise InvalidURLError(
+                    f"Invalid {param}: URL resolves to an internal/private IP."
+                )
+
+            # Return the first safe IP
+            return ip_str
+
+        raise InvalidURLError(f"Invalid {param}: No valid IP found for {hostname!r}.")
+
+    except concurrent.futures.TimeoutError as e:
+        raise InvalidURLError(
+            f"Invalid {param}: DNS resolution timed out for {hostname!r}."
+        ) from e
+    except socket.gaierror as e:
+        raise InvalidURLError(
+            f"Invalid {param}: Could not resolve hostname {hostname!r}."
+        ) from e
 
 
 _CLIENT: httpx.Client | None = None

--- a/src/imagine_mcp/media.py
+++ b/src/imagine_mcp/media.py
@@ -77,6 +77,7 @@ def validate_url_and_get_ip(url: str, param: str) -> str:
     try:
         # Wrap the blocking getaddrinfo in a thread with a short timeout
         # to prevent DoS attacks via malicious DNS servers.
+        # Note: parsed.port may be None, which is fine for getaddrinfo.
         future = _DNS_RESOLVER_POOL.submit(
             socket.getaddrinfo, hostname, parsed.port, socket.AF_INET
         )
@@ -84,7 +85,9 @@ def validate_url_and_get_ip(url: str, param: str) -> str:
         addr_info = future.result(timeout=2.0)
 
         for res in addr_info:
-            ip_str = res[4][0]
+            # res[4] is the sockaddr tuple. The first element is the IP string.
+            # Explicitly stringify to satisfy type checkers.
+            ip_str = str(res[4][0])
             ip_obj = ipaddress.ip_address(ip_str)
 
             # Extract underlying IPv4 if it's an IPv4-mapped IPv6 address (e.g. ::ffff:127.0.0.1)

--- a/src/imagine_mcp/providers/gemini.py
+++ b/src/imagine_mcp/providers/gemini.py
@@ -85,10 +85,22 @@ def understand_image(
 ) -> dict[str, Any]:
     from google.genai import types
 
+    from imagine_mcp.media import get_ssrf_safe_client
+
+    client = _client()
     model = get_model_id("gemini", "understand", "image", tier)
-    resp = _client().models.generate_content(
+
+    # Download image securely to prevent backend SSRF
+    img_data = (
+        get_ssrf_safe_client().get(url, follow_redirects=True, timeout=60).content
+    )
+
+    resp = client.models.generate_content(
         model=model,
-        contents=[prompt, types.Part.from_uri(file_uri=url, mime_type="image/png")],
+        contents=[
+            prompt,
+            types.Part.from_bytes(data=img_data, mime_type="image/png"),
+        ],
         config=types.GenerateContentConfig(max_output_tokens=max_tokens),
     )
     return {
@@ -104,12 +116,28 @@ def understand_video(
 ) -> dict[str, Any]:
     from google.genai import types
 
+    from imagine_mcp.media import download_to_path
+
+    client = _client()
     model = get_model_id("gemini", "understand", "video", tier)
-    resp = _client().models.generate_content(
-        model=model,
-        contents=[prompt, types.Part.from_uri(file_uri=url, mime_type="video/mp4")],
-        config=types.GenerateContentConfig(max_output_tokens=max_tokens),
-    )
+
+    # Download video securely and upload to Gemini
+    tmp_dir = Path(platformdirs.user_cache_dir("imagine-mcp")) / "tmp"
+    tmp_dir.mkdir(parents=True, exist_ok=True)
+    tmp_path = tmp_dir / f"{uuid.uuid4().hex}.mp4"
+    download_to_path(url, tmp_path)
+
+    try:
+        gfile = client.files.upload(file=tmp_path)
+        resp = client.models.generate_content(
+            model=model,
+            contents=[prompt, gfile],
+            config=types.GenerateContentConfig(max_output_tokens=max_tokens),
+        )
+    finally:
+        if tmp_path.exists():
+            tmp_path.unlink()
+
     return {
         "text": resp.text,
         "model": model,
@@ -124,19 +152,48 @@ def understand_multimodal(
     """Gemini native multimodal: mixed image+video URLs in a single call."""
     from google.genai import types
 
-    from imagine_mcp.media import detect_media_type
+    from imagine_mcp.media import (
+        detect_media_type,
+        download_to_path,
+        get_ssrf_safe_client,
+    )
 
+    client = _client()
     model = get_model_id("gemini", "understand", "image", tier)
     parts: list[Any] = [prompt]
-    for u in urls:
-        mt = detect_media_type(u)
-        mime = "image/png" if mt == "image" else "video/mp4"
-        parts.append(types.Part.from_uri(file_uri=u, mime_type=mime))
-    resp = _client().models.generate_content(
-        model=model,
-        contents=parts,
-        config=types.GenerateContentConfig(max_output_tokens=max_tokens),
-    )
+    tmp_files: list[Path] = []
+
+    tmp_dir = Path(platformdirs.user_cache_dir("imagine-mcp")) / "tmp"
+    tmp_dir.mkdir(parents=True, exist_ok=True)
+
+    try:
+        for u in urls:
+            mt = detect_media_type(u)
+            if mt == "image":
+                img_data = (
+                    get_ssrf_safe_client()
+                    .get(u, follow_redirects=True, timeout=60)
+                    .content
+                )
+                parts.append(
+                    types.Part.from_bytes(data=img_data, mime_type="image/png")
+                )
+            else:
+                tmp_path = tmp_dir / f"{uuid.uuid4().hex}.mp4"
+                download_to_path(u, tmp_path)
+                tmp_files.append(tmp_path)
+                parts.append(client.files.upload(file=tmp_path))
+
+        resp = client.models.generate_content(
+            model=model,
+            contents=parts,
+            config=types.GenerateContentConfig(max_output_tokens=max_tokens),
+        )
+    finally:
+        for f in tmp_files:
+            if f.exists():
+                f.unlink()
+
     return {
         "text": resp.text,
         "model": model,
@@ -154,14 +211,21 @@ def generate_image(
 ) -> dict[str, Any]:
     from google.genai import types
 
+    from imagine_mcp.media import get_ssrf_safe_client
+
+    client = _client()
     model = get_model_id("gemini", "generate", "image", tier)
     contents: list[Any] = [prompt]
-    if reference_image_url:
-        contents.append(
-            types.Part.from_uri(file_uri=reference_image_url, mime_type="image/png")
-        )
 
-    resp = _client().models.generate_content(
+    if reference_image_url:
+        img_data = (
+            get_ssrf_safe_client()
+            .get(reference_image_url, follow_redirects=True, timeout=60)
+            .content
+        )
+        contents.append(types.Part.from_bytes(data=img_data, mime_type="image/png"))
+
+    resp = client.models.generate_content(
         model=model,
         contents=contents,
         config=types.GenerateContentConfig(response_modalities=["IMAGE"]),
@@ -202,6 +266,8 @@ def generate_video(
     client = _client()
 
     if job_id is None:
+        # Original code did not use reference_image_url here.
+        # Keeping it consistent for now but ensuring we don't pass it to the backend.
         op = client.models.generate_videos(
             model=model,
             prompt=prompt,

--- a/src/imagine_mcp/providers/grok.py
+++ b/src/imagine_mcp/providers/grok.py
@@ -83,7 +83,16 @@ def _reset_client() -> None:
 def understand_image(
     url: str, prompt: str, tier: str, max_tokens: int = 2048
 ) -> dict[str, Any]:
+    from imagine_mcp.media import get_ssrf_safe_client
+
     model = get_model_id("grok", "understand", "image", tier)
+
+    # Download image securely and pass as base64 data URL to prevent backend SSRF
+    resp_img = get_ssrf_safe_client().get(url, follow_redirects=True, timeout=60)
+    img_b64 = base64.b64encode(resp_img.content).decode()
+    mime_type = resp_img.headers.get("content-type", "image/png")
+    data_url = f"data:{mime_type};base64,{img_b64}"
+
     resp = _openai_compat_client().chat.completions.create(
         model=model,
         messages=[
@@ -91,7 +100,7 @@ def understand_image(
                 "role": "user",
                 "content": [
                     {"type": "text", "text": prompt},
-                    {"type": "image_url", "image_url": {"url": url}},
+                    {"type": "image_url", "image_url": {"url": data_url}},
                 ],
             }
         ],
@@ -120,11 +129,21 @@ def generate_image(
     reference_image_url: str | None = None,
     aspect_ratio: str = "1:1",
 ) -> dict[str, Any]:
+    from imagine_mcp.media import get_ssrf_safe_client
+
     model = get_model_id("grok", "generate", "image", tier)
     headers = {"Authorization": f"Bearer {_api_key()}"}
     payload: dict[str, Any] = {"model": model, "prompt": prompt, "n": 1}
+
     if reference_image_url:
-        payload["reference_image"] = reference_image_url
+        # Download reference image and pass as base64 data URL
+        resp_img = get_ssrf_safe_client().get(
+            reference_image_url, follow_redirects=True, timeout=60
+        )
+        img_b64 = base64.b64encode(resp_img.content).decode()
+        mime_type = resp_img.headers.get("content-type", "image/png")
+        data_url = f"data:{mime_type};base64,{img_b64}"
+        payload["reference_image"] = data_url
 
     resp = httpx.post(
         f"{_BASE_URL}/images/generations",
@@ -141,8 +160,6 @@ def generate_image(
     data = resp.json()
     img_b64 = data["data"][0].get("b64_json")
     if not img_b64:
-        from imagine_mcp.media import get_ssrf_safe_client
-
         img_url = data["data"][0].get("url")
         img_b64 = base64.b64encode(
             get_ssrf_safe_client()
@@ -173,6 +190,8 @@ def generate_video(
     aspect_ratio: str = "16:9",
     duration_seconds: int = 8,
 ) -> dict[str, Any]:
+    from imagine_mcp.media import get_ssrf_safe_client
+
     model = get_model_id("grok", "generate", "video", tier)
     headers = {"Authorization": f"Bearer {_api_key()}"}
 
@@ -184,7 +203,15 @@ def generate_video(
             "aspect_ratio": aspect_ratio,
         }
         if reference_image_url:
-            payload["source_image"] = reference_image_url
+            # Download source image and pass as base64 data URL
+            resp_img = get_ssrf_safe_client().get(
+                reference_image_url, follow_redirects=True, timeout=60
+            )
+            img_b64 = base64.b64encode(resp_img.content).decode()
+            mime_type = resp_img.headers.get("content-type", "image/png")
+            data_url = f"data:{mime_type};base64,{img_b64}"
+            payload["source_image"] = data_url
+
         resp = httpx.post(
             f"{_BASE_URL}/videos/generations",
             json=payload,
@@ -230,8 +257,6 @@ def generate_video(
             f"Grok video generation failed: {data.get('error', 'unknown')}",
             status_code=500,
         )
-
-    from imagine_mcp.media import get_ssrf_safe_client
 
     video_url = data["video_url"]
     video_bytes = (

--- a/src/imagine_mcp/providers/openai.py
+++ b/src/imagine_mcp/providers/openai.py
@@ -79,7 +79,16 @@ def _reset_client() -> None:
 def understand_image(
     url: str, prompt: str, tier: str, max_tokens: int = 2048
 ) -> dict[str, Any]:
+    from imagine_mcp.media import get_ssrf_safe_client
+
     model = get_model_id("openai", "understand", "image", tier)
+
+    # Download image securely and pass as base64 data URL to prevent backend SSRF
+    resp_img = get_ssrf_safe_client().get(url, follow_redirects=True, timeout=60)
+    img_b64 = base64.b64encode(resp_img.content).decode()
+    mime_type = resp_img.headers.get("content-type", "image/png")
+    data_url = f"data:{mime_type};base64,{img_b64}"
+
     resp = _client().responses.create(
         model=model,
         input=[
@@ -87,7 +96,7 @@ def understand_image(
                 "role": "user",
                 "content": [
                     {"type": "input_text", "text": prompt},
-                    {"type": "input_image", "image_url": url},
+                    {"type": "input_image", "image_url": data_url},
                 ],
             }
         ],

--- a/tests/test_providers_gemini.py
+++ b/tests/test_providers_gemini.py
@@ -8,7 +8,23 @@ import pytest
 from imagine_mcp.providers import gemini
 
 
-def test_understand_image_mocked(monkeypatch: pytest.MonkeyPatch) -> None:
+@pytest.fixture
+def mock_media_fetch(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Mock get_ssrf_safe_client and download_to_path to avoid real network calls."""
+    mock_resp = MagicMock()
+    mock_resp.content = b"fake-image-bytes"
+    mock_resp.headers = {"content-type": "image/png"}
+
+    mock_client = MagicMock()
+    mock_client.get.return_value = mock_resp
+
+    monkeypatch.setattr("imagine_mcp.media.get_ssrf_safe_client", lambda: mock_client)
+    monkeypatch.setattr("imagine_mcp.media.download_to_path", lambda url, dest: dest)
+
+
+def test_understand_image_mocked(
+    mock_media_fetch: None, monkeypatch: pytest.MonkeyPatch
+) -> None:
     fake_client = MagicMock()
     fake_response = MagicMock()
     fake_response.text = "a cat on a mat"
@@ -24,7 +40,9 @@ def test_understand_image_mocked(monkeypatch: pytest.MonkeyPatch) -> None:
     assert result["tier"] == "poor"
 
 
-def test_understand_video_mocked(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_understand_video_mocked(
+    mock_media_fetch: None, monkeypatch: pytest.MonkeyPatch
+) -> None:
     fake_client = MagicMock()
     fake_response = MagicMock()
     fake_response.text = "a cat jumping"

--- a/tests/test_providers_grok.py
+++ b/tests/test_providers_grok.py
@@ -8,12 +8,27 @@ from imagine_mcp.errors import ProviderUnsupportedError
 from imagine_mcp.providers import grok as provider
 
 
+@pytest.fixture
+def mock_media_fetch(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Mock get_ssrf_safe_client to avoid real network calls."""
+    mock_resp = MagicMock()
+    mock_resp.content = b"fake-image-bytes"
+    mock_resp.headers = {"content-type": "image/png"}
+
+    mock_client = MagicMock()
+    mock_client.get.return_value = mock_resp
+
+    monkeypatch.setattr("imagine_mcp.media.get_ssrf_safe_client", lambda: mock_client)
+
+
 def test_understand_video_raises() -> None:
     with pytest.raises(ProviderUnsupportedError):
         provider.understand_video("https://example.com/x.mp4", "describe", "poor")
 
 
-def test_understand_image_mocked(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_understand_image_mocked(
+    mock_media_fetch: None, monkeypatch: pytest.MonkeyPatch
+) -> None:
     fake_client = MagicMock()
     msg = MagicMock()
     msg.content = "a parrot"

--- a/tests/test_providers_openai.py
+++ b/tests/test_providers_openai.py
@@ -8,6 +8,19 @@ from imagine_mcp.errors import ProviderUnsupportedError
 from imagine_mcp.providers import openai as provider
 
 
+@pytest.fixture
+def mock_media_fetch(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Mock get_ssrf_safe_client to avoid real network calls."""
+    mock_resp = MagicMock()
+    mock_resp.content = b"fake-image-bytes"
+    mock_resp.headers = {"content-type": "image/png"}
+
+    mock_client = MagicMock()
+    mock_client.get.return_value = mock_resp
+
+    monkeypatch.setattr("imagine_mcp.media.get_ssrf_safe_client", lambda: mock_client)
+
+
 def test_understand_video_raises() -> None:
     with pytest.raises(ProviderUnsupportedError):
         provider.understand_video("https://example.com/x.mp4", "describe", "poor")
@@ -18,7 +31,9 @@ def test_generate_video_raises() -> None:
         provider.generate_video("a dog", "poor")
 
 
-def test_understand_image_mocked(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_understand_image_mocked(
+    mock_media_fetch: None, monkeypatch: pytest.MonkeyPatch
+) -> None:
     fake = MagicMock()
     fake.responses.create.return_value = MagicMock(output_text="a dog")
     monkeypatch.setattr(provider, "_client", lambda: fake)

--- a/tests/test_security_pinning.py
+++ b/tests/test_security_pinning.py
@@ -10,7 +10,7 @@ from imagine_mcp.media import SSRFSafeTransport, validate_url_and_get_ip
 
 
 def test_validate_url_and_get_ip_success(monkeypatch):
-    def mock_getaddrinfo(host, port, family):
+    def mock_getaddrinfo(host, port, family=0, type=0, proto=0, flags=0):
         return [(socket.AF_INET, socket.SOCK_STREAM, 6, "", ("93.184.215.14", 80))]
 
     monkeypatch.setattr(socket, "getaddrinfo", mock_getaddrinfo)
@@ -20,7 +20,7 @@ def test_validate_url_and_get_ip_success(monkeypatch):
 
 
 def test_validate_url_and_get_ip_private(monkeypatch):
-    def mock_getaddrinfo(host, port, family):
+    def mock_getaddrinfo(host, port, family=0, type=0, proto=0, flags=0):
         return [(socket.AF_INET, socket.SOCK_STREAM, 6, "", ("127.0.0.1", 80))]
 
     monkeypatch.setattr(socket, "getaddrinfo", mock_getaddrinfo)
@@ -31,7 +31,7 @@ def test_validate_url_and_get_ip_private(monkeypatch):
 
 def test_ssrf_safe_transport_pinning(monkeypatch):
     # This test verifies that handle_request rewrites the URL and sets headers.
-    def mock_getaddrinfo(host, port, family):
+    def mock_getaddrinfo(host, port, family=0, type=0, proto=0, flags=0):
         return [(socket.AF_INET, socket.SOCK_STREAM, 6, "", ("93.184.215.14", 80))]
 
     monkeypatch.setattr(socket, "getaddrinfo", mock_getaddrinfo)
@@ -59,7 +59,7 @@ def test_ssrf_safe_transport_pinning(monkeypatch):
 
 
 def test_ssrf_safe_transport_blocks_private(monkeypatch):
-    def mock_getaddrinfo(host, port, family):
+    def mock_getaddrinfo(host, port, family=0, type=0, proto=0, flags=0):
         return [(socket.AF_INET, socket.SOCK_STREAM, 6, "", ("192.168.1.1", 80))]
 
     monkeypatch.setattr(socket, "getaddrinfo", mock_getaddrinfo)

--- a/tests/test_security_pinning.py
+++ b/tests/test_security_pinning.py
@@ -1,0 +1,68 @@
+from __future__ import annotations
+import pytest
+import httpx
+import socket
+from imagine_mcp.media import SSRFSafeTransport, validate_url_and_get_ip
+from imagine_mcp.errors import InvalidURLError
+
+
+def test_validate_url_and_get_ip_success(monkeypatch):
+    def mock_getaddrinfo(host, port, family):
+        return [(socket.AF_INET, socket.SOCK_STREAM, 6, "", ("93.184.215.14", 80))]
+
+    monkeypatch.setattr(socket, "getaddrinfo", mock_getaddrinfo)
+
+    ip = validate_url_and_get_ip("http://example.com/", "test")
+    assert ip == "93.184.215.14"
+
+
+def test_validate_url_and_get_ip_private(monkeypatch):
+    def mock_getaddrinfo(host, port, family):
+        return [(socket.AF_INET, socket.SOCK_STREAM, 6, "", ("127.0.0.1", 80))]
+
+    monkeypatch.setattr(socket, "getaddrinfo", mock_getaddrinfo)
+
+    with pytest.raises(InvalidURLError, match="internal/private IP"):
+        validate_url_and_get_ip("http://example.com/", "test")
+
+
+def test_ssrf_safe_transport_pinning(monkeypatch):
+    # This test verifies that handle_request rewrites the URL and sets headers.
+    def mock_getaddrinfo(host, port, family):
+        return [(socket.AF_INET, socket.SOCK_STREAM, 6, "", ("93.184.215.14", 80))]
+
+    monkeypatch.setattr(socket, "getaddrinfo", mock_getaddrinfo)
+
+    # Mocking the actual network call so we don't need real internet
+    class MockTransport(httpx.HTTPTransport):
+        def handle_request(self, request):
+            return httpx.Response(200, content=b"ok", request=request)
+
+    transport = SSRFSafeTransport()
+    # We need to reach super().handle_request, so we patch HTTPTransport.handle_request
+    monkeypatch.setattr(
+        httpx.HTTPTransport,
+        "handle_request",
+        lambda self, req: httpx.Response(200, content=b"ok", request=req),
+    )
+
+    request = httpx.Request("GET", "https://example.com/foo")
+    transport.handle_request(request)
+
+    # Verification
+    assert str(request.url) == "https://93.184.215.14/foo"
+    assert request.headers["Host"] == "example.com"
+    assert request.extensions["sni_hostname"] == "example.com"
+
+
+def test_ssrf_safe_transport_blocks_private(monkeypatch):
+    def mock_getaddrinfo(host, port, family):
+        return [(socket.AF_INET, socket.SOCK_STREAM, 6, "", ("192.168.1.1", 80))]
+
+    monkeypatch.setattr(socket, "getaddrinfo", mock_getaddrinfo)
+
+    transport = SSRFSafeTransport()
+    request = httpx.Request("GET", "http://internal.service/foo")
+
+    with pytest.raises(InvalidURLError, match="internal/private IP"):
+        transport.handle_request(request)

--- a/tests/test_security_pinning.py
+++ b/tests/test_security_pinning.py
@@ -1,9 +1,12 @@
 from __future__ import annotations
-import pytest
-import httpx
+
 import socket
-from imagine_mcp.media import SSRFSafeTransport, validate_url_and_get_ip
+
+import httpx
+import pytest
+
 from imagine_mcp.errors import InvalidURLError
+from imagine_mcp.media import SSRFSafeTransport, validate_url_and_get_ip
 
 
 def test_validate_url_and_get_ip_success(monkeypatch):

--- a/uv.lock
+++ b/uv.lock
@@ -531,7 +531,7 @@ wheels = [
 
 [[package]]
 name = "imagine-mcp"
-version = "1.2.0"
+version = "1.3.0"
 source = { editable = "." }
 dependencies = [
     { name = "diskcache" },


### PR DESCRIPTION
This PR addresses a Time-Of-Check to Time-Of-Use (TOCTOU) SSRF vulnerability in the URL validation logic.

Key changes:
1. **DNS Pinning in SSRFSafeTransport**: The custom transport now resolves the hostname, validates the IP against internal/private ranges, and pins the request by rewriting the URL to use the validated IP address. It also ensures the `Host` header and SNI extension are correctly set.
2. **Secure Media Fetching in Providers**: Providers (Gemini, OpenAI, Grok) have been updated to download media securely using the safe client before passing data to third-party SDKs or APIs. This prevents the provider backends from fetching potentially unvalidated user-provided URLs.
3. **Centralized DNS Validation**: DNS resolution and validation logic has been moved to a shared utility in `media.py` for consistency.
4. **Security Tests**: Added new tests to verify DNS pinning and SSRF protection.
5. **Documentation**: Recorded the vulnerability and prevention strategy in `.jules/sentinel.md`.

---
*PR created automatically by Jules for task [3178187665878696452](https://jules.google.com/task/3178187665878696452) started by @n24q02m*