### PR TITLE
[FIX] Implement Gemini image edit capabilities

### DIFF
--- a/src/imagine_mcp/providers/gemini.py
+++ b/src/imagine_mcp/providers/gemini.py
@@ -174,7 +174,10 @@ def generate_image(
     resp = _client().models.generate_content(
         model=model,
         contents=contents,
-        config=types.GenerateContentConfig(response_modalities=["IMAGE"], image_config=types.ImageConfig(aspect_ratio=aspect_ratio)),
+        config=types.GenerateContentConfig(
+            response_modalities=["IMAGE"],
+            image_config=types.ImageConfig(aspect_ratio=aspect_ratio),
+        ),
     )
     image_data: bytes | None = None
     for part in resp.candidates[0].content.parts:

--- a/src/imagine_mcp/providers/gemini.py
+++ b/src/imagine_mcp/providers/gemini.py
@@ -146,6 +146,16 @@ def understand_multimodal(
     }
 
 
+def edit(tier: str, image_url: str, prompt: str) -> dict[str, Any]:
+    """Gemini image edit (inpainting/editing)."""
+    return generate_image(prompt, tier, reference_image_url=image_url)
+
+
+def video_status(tier: str, job_id: str) -> dict[str, Any]:
+    """Poll Gemini video job status."""
+    return generate_video(prompt="", tier=tier, job_id=job_id)
+
+
 def generate_image(
     prompt: str,
     tier: str,
@@ -164,7 +174,7 @@ def generate_image(
     resp = _client().models.generate_content(
         model=model,
         contents=contents,
-        config=types.GenerateContentConfig(response_modalities=["IMAGE"]),
+        config=types.GenerateContentConfig(response_modalities=["IMAGE"], image_config=types.ImageConfig(aspect_ratio=aspect_ratio)),
     )
     image_data: bytes | None = None
     for part in resp.candidates[0].content.parts:

--- a/tests/test_providers_gemini.py
+++ b/tests/test_providers_gemini.py
@@ -55,6 +55,7 @@ def test_understand_image_live() -> None:
     )
     assert "cat" in result["text"].lower()
 
+
 def test_edit_implementation(monkeypatch, tmp_path):
     fake_client = MagicMock()
     fake_resp = MagicMock()
@@ -71,23 +72,26 @@ def test_edit_implementation(monkeypatch, tmp_path):
         prompt="make it blue",
         tier="poor",
         reference_image_url="http://example.com/img.png",
-        aspect_ratio="16:9"
+        aspect_ratio="16:9",
     )
 
     assert "image_path" in res
     assert res["provider"] == "gemini"
 
     # Verify generate_content call
-    _ , kwargs = fake_client.models.generate_content.call_args
+    _, kwargs = fake_client.models.generate_content.call_args
     assert kwargs["model"] == "gemini-3.1-flash-image-preview"
     assert len(kwargs["contents"]) == 2
     assert kwargs["config"].response_modalities == ["IMAGE"]
     assert kwargs["config"].image_config.aspect_ratio == "16:9"
 
     # 2. Test edit function
-    res_edit = gemini.edit(tier="poor", image_url="http://example.com/img.png", prompt="make it blue")
+    res_edit = gemini.edit(
+        tier="poor", image_url="http://example.com/img.png", prompt="make it blue"
+    )
     assert "image_path" in res_edit
     assert res_edit["provider"] == "gemini"
+
 
 def test_video_status(monkeypatch):
     fake_client = MagicMock()

--- a/tests/test_providers_gemini.py
+++ b/tests/test_providers_gemini.py
@@ -54,3 +54,49 @@ def test_understand_image_live() -> None:
         tier="poor",
     )
     assert "cat" in result["text"].lower()
+
+def test_edit_implementation(monkeypatch, tmp_path):
+    fake_client = MagicMock()
+    fake_resp = MagicMock()
+    fake_part = MagicMock()
+    fake_part.inline_data.data = b"fake_image_bytes"
+    fake_resp.candidates = [MagicMock(content=MagicMock(parts=[fake_part]))]
+    fake_client.models.generate_content.return_value = fake_resp
+
+    monkeypatch.setattr(gemini, "_client", lambda: fake_client)
+    monkeypatch.setattr("platformdirs.user_cache_dir", lambda _: str(tmp_path))
+
+    # 1. Test generate_image with reference_image_url
+    res = gemini.generate_image(
+        prompt="make it blue",
+        tier="poor",
+        reference_image_url="http://example.com/img.png",
+        aspect_ratio="16:9"
+    )
+
+    assert "image_path" in res
+    assert res["provider"] == "gemini"
+
+    # Verify generate_content call
+    _ , kwargs = fake_client.models.generate_content.call_args
+    assert kwargs["model"] == "gemini-3.1-flash-image-preview"
+    assert len(kwargs["contents"]) == 2
+    assert kwargs["config"].response_modalities == ["IMAGE"]
+    assert kwargs["config"].image_config.aspect_ratio == "16:9"
+
+    # 2. Test edit function
+    res_edit = gemini.edit(tier="poor", image_url="http://example.com/img.png", prompt="make it blue")
+    assert "image_path" in res_edit
+    assert res_edit["provider"] == "gemini"
+
+def test_video_status(monkeypatch):
+    fake_client = MagicMock()
+    fake_op = MagicMock()
+    fake_op.done = False
+    fake_client.operations.get.return_value = fake_op
+
+    monkeypatch.setattr(gemini, "_client", lambda: fake_client)
+
+    res = gemini.video_status(tier="poor", job_id="job123")
+    assert res["status"] == "pending"
+    assert res["job_id"] == "job123"

--- a/uv.lock
+++ b/uv.lock
@@ -531,7 +531,7 @@ wheels = [
 
 [[package]]
 name = "imagine-mcp"
-version = "1.2.0"
+version = "1.3.0"
 source = { editable = "." }
 dependencies = [
     { name = "diskcache" },


### PR DESCRIPTION
Implement Gemini image edit capabilities in the Gemini provider.

Key changes:
- Added `edit(tier, image_url, prompt)` to `src/imagine_mcp/providers/gemini.py` as a proxy for `generate_image`.
- Added `video_status(tier, job_id)` to `src/imagine_mcp/providers/gemini.py` for polling video jobs.
- Enhanced `generate_image` in `src/imagine_mcp/providers/gemini.py` to properly handle `reference_image_url` and use `types.ImageConfig(aspect_ratio=...)` for the Imagen 3 models in the `google-genai` SDK.
- Added comprehensive unit tests in `tests/test_providers_gemini.py` to verify the implementation.

---
*PR created automatically by Jules for task [5448428256219730686](https://jules.google.com/task/5448428256219730686) started by @n24q02m*