### PR TITLE
⚡ Bolt: Concurrent media detection in dispatch_understand

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,3 +1,6 @@
 ## 2024-05-18 - Optimize default_provider_for lookups
 **Learning:** `default_provider_for` in `src/imagine_mcp/models.py` performs an O(N log N) filtering and sorting of `MODELS` on every call. Since the parameter space (`action`, `media`, `tier`) is very small and bounded, caching the result yields a ~25x performance improvement. Standard lru_cache works perfectly for this use case.
 **Action:** Use `@functools.lru_cache(maxsize=32)` to optimize functions that perform expensive queries or sorting over static lists when their parameter space is small and bounded.
+## 2024-05-18 - Preserve fail-fast semantics when parallelizing
+**Learning:** When parallelizing a pipeline using `ThreadPoolExecutor.map`, combining a fast, CPU-bound step (like URL validation) with a slow, IO-bound step (like media detection) in the mapped function changes the fail-fast semantics of the loop. This causes the code to wait for early slow steps to finish even if a later item is invalid, and causes unnecessary network operations. The original fast loop should be preserved, and only the slow IO step mapped.
+**Action:** Ensure that fail-fast loops are kept intact before passing the valid items to a concurrent pool. Map only the IO-bound slow functions.

--- a/src/imagine_mcp/dispatcher.py
+++ b/src/imagine_mcp/dispatcher.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import importlib
+from concurrent.futures import ThreadPoolExecutor
 from typing import Any
 
 from imagine_mcp.errors import (
@@ -18,6 +19,8 @@ from imagine_mcp.models import UNSUPPORTED, get_model_id
 VALID_PROVIDERS = ["gemini", "openai", "grok"]
 VALID_TIERS = ["poor", "rich"]
 VALID_MEDIA_TYPES = ["image", "video"]
+
+_DISPATCH_POOL = ThreadPoolExecutor(max_workers=16, thread_name_prefix="dispatch_pool")
 
 # Auto-fallback priority when caller does not pin a provider. Order is
 # (XAI, OpenAI, Gemini): Gemini stays last because Google AI Studio
@@ -128,7 +131,7 @@ def dispatch_understand(
     for i, u in enumerate(media_urls):
         _validate_url(u, f"media_urls[{i}]")
 
-    media_types = [detect_media_type(u) for u in media_urls]
+    media_types = list(_DISPATCH_POOL.map(detect_media_type, media_urls))
     has_video = "video" in media_types
 
     if has_video:

--- a/uv.lock
+++ b/uv.lock
@@ -531,7 +531,7 @@ wheels = [
 
 [[package]]
 name = "imagine-mcp"
-version = "1.3.0"
+version = "1.4.0b1"
 source = { editable = "." }
 dependencies = [
     { name = "diskcache" },


### PR DESCRIPTION
⚡ Bolt: Concurrent media detection in dispatch_understand

💡 What: Parallelize the execution of `detect_media_type` in `dispatch_understand` using a `ThreadPoolExecutor` while preserving the fast URL validation loop.
🎯 Why: `detect_media_type` makes network HEAD requests sequentially. Processing batches of media URLs synchronously is an unnecessary O(N) bottleneck.
📊 Impact: Changes performance from O(N) sequential HTTP calls to O(1) concurrent calls (bounded by the 16 worker limit), significantly reducing latency for multi-media prompts without sacrificing the fail-fast validation behavior.
🔬 Measurement: Verify by executing `dispatch_understand` with multiple URLs and observing the wall-clock execution time relative to a single URL.

---
*PR created automatically by Jules for task [5310124945086765708](https://jules.google.com/task/5310124945086765708) started by @n24q02m*