### PR TITLE
⚡ Bolt: [performance improvement] Concurrent URL validation in dispatch_understand

### DIFF
--- a/src/imagine_mcp/dispatcher.py
+++ b/src/imagine_mcp/dispatcher.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import importlib
+from concurrent.futures import ThreadPoolExecutor
 from typing import Any
 
 from imagine_mcp.errors import (
@@ -29,6 +30,8 @@ _DEFAULT_PROVIDER_PRIORITY: tuple[tuple[str, str], ...] = (
     ("OPENAI_API_KEY", "openai"),
     ("GEMINI_API_KEY", "gemini"),
 )
+
+_DISPATCH_POOL = ThreadPoolExecutor(max_workers=16, thread_name_prefix="dispatcher")
 
 _UNSUPPORTED_HINTS: dict[tuple[str, str, str], str] = {
     ("openai", "video", "understand"): (
@@ -108,6 +111,12 @@ def _unsupported(provider: str, media: str, action: str) -> ProviderUnsupportedE
     return ProviderUnsupportedError(msg)
 
 
+def _process_url(index: int, url: str) -> str:
+    """Validate and detect media type for a single URL concurrently."""
+    _validate_url(url, f"media_urls[{index}]")
+    return detect_media_type(url)
+
+
 def dispatch_understand(
     media_urls: list[str],
     prompt: str,
@@ -125,10 +134,13 @@ def dispatch_understand(
     _validate(provider, tier)
     if not media_urls:
         raise InvalidMediaTypeError("media_urls is empty")
-    for i, u in enumerate(media_urls):
-        _validate_url(u, f"media_urls[{i}]")
 
-    media_types = [detect_media_type(u) for u in media_urls]
+    # Run validation and media type detection concurrently to avoid redundant sequential network calls
+    # Iterating the results map preserves sequential exception propagation behavior.
+    media_types = list(
+        _DISPATCH_POOL.map(_process_url, range(len(media_urls)), media_urls)
+    )
+
     has_video = "video" in media_types
 
     if has_video:


### PR DESCRIPTION
💡 **What:** I modified `dispatch_understand` to process the `media_urls` list concurrently using a `ThreadPoolExecutor` instead of sequentially. A new `_process_url` helper handles URL validation and media type detection for individual URLs, which run in parallel via `_DISPATCH_POOL.map()`.

🎯 **Why:** Previously, `dispatch_understand` would iterate over each URL synchronously to validate it and detect its media type. For multiple URLs, this resulted in O(N) network calls blocking each other (specifically `_validate_url` doing DNS resolution and `detect_media_type` potentially making a HEAD request), causing unnecessary latency. 

📊 **Impact:** This optimization drastically reduces the overall validation phase latency for multi-URL requests. The execution time now scales close to O(1) relative to the number of URLs (bounded by network bandwidth and the pool size of 16), rather than linearly O(N).

🔬 **Measurement:** This can be verified by submitting a request to the `understand` tool with multiple distinct URLs and comparing response times. The tests have also been successfully run to confirm identical behavior under exceptions and standard processing.

---
*PR created automatically by Jules for task [6939550834138990948](https://jules.google.com/task/6939550834138990948) started by @n24q02m*