### PR TITLE
fix(ci): add PR title check via amannn/action-semantic-pull-request

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,35 @@ permissions:
   pull-requests: write
 
 jobs:
+  pr-title:
+    name: Validate PR title (Conventional Commits subset)
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: read
+    steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40 # v2
+        with:
+          egress-policy: audit
+      - uses: amannn/action-semantic-pull-request@48f256284bd46cdaab1048c3721360e808335d50 # v6
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          # Per repo rule (feedback_commit_prefix.md): only feat: and fix:
+          # are allowed. Squash-merge uses the PR title as the commit
+          # message and bypasses the local enforce-commit pre-commit hook,
+          # so this server-side check is required to keep main history
+          # conformant. See historical violations on commits 2bc6657, 76,
+          # 77 (closed before this gate was wired).
+          types: |
+            fix
+            feat
+          requireScope: false
+          subjectPattern: ^(?![A-Z]).+$
+          subjectPatternError: |
+            The subject must not start with an uppercase character.
+
   lint-and-test:
     name: Lint & Test (${{ matrix.os }})
     if: github.event_name == 'pull_request' || github.event_name == 'push'


### PR DESCRIPTION
## Summary

- Add server-side PR title check (`amannn/action-semantic-pull-request@v6` SHA-pinned) blocking non-conformant prefixes at PR check time, before squash-merge can land them in main.
- Mirrors canonical pattern in `n24q02m/skret/.github/workflows/ci.yml`.

## Root cause

Local `scripts/enforce-commit.sh` runs only at `git commit` time. GitHub squash-merge uses the PR title as the commit message and skips `commit-msg` stage hooks. Three historical violations slipped through:

| Commit | Title | Issue |
|---|---|---|
| `2bc6657` | `[SECURITY] TOCTOU SSRF in DNS Resolution for URL Validation (#96)` | bracket prefix |
| `eb398a7` | `Sentinel: [CRITICAL/HIGH] Fix SSRF evasion via CGNAT bypassing is_private check (#76)` | bot emoji prefix |
| `038dc37` | `perf: cache default_provider_for lookups to avoid O(N log N) list traversal (#77)` | perf: not allowed |

## Decision on history

Historical commits accepted as-is. Force-push amend on released `v1.4.0` tag would shift SHAs and break any downstream pinned consumer. Per memory `feedback_pr_title_check_required.md` (2026-05-09 decision).

## Test plan

- [x] PR title `fix(ci): add PR title check ...` matches the new gate
- [ ] Workflow run will validate this PR (recursive — check expected to PASS)

🤖 Generated with [Claude Code](https://claude.com/claude-code)