### PR TITLE
⚡ Bolt: Parallelize media validation and detection in dispatcher

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,3 +1,7 @@
 ## 2024-05-18 - Optimize default_provider_for lookups
 **Learning:** `default_provider_for` in `src/imagine_mcp/models.py` performs an O(N log N) filtering and sorting of `MODELS` on every call. Since the parameter space (`action`, `media`, `tier`) is very small and bounded, caching the result yields a ~25x performance improvement. Standard lru_cache works perfectly for this use case.
 **Action:** Use `@functools.lru_cache(maxsize=32)` to optimize functions that perform expensive queries or sorting over static lists when their parameter space is small and bounded.
+
+## 2024-05-18 - Optimize media URL validation and detection in dispatch
+**Learning:** In `dispatch_understand`, checking media types (which can involve blocking HTTP HEAD requests or DNS resolutions via `_validate_url`) creates an O(N) bottleneck when processing multiple URLs sequentially. Parallelizing these high-level tasks using a `ThreadPoolExecutor` drastically reduces latency. However, it's critical to use a separate thread pool (e.g., `_DISPATCH_POOL`) from nested pools (like `_DNS_RESOLVER_POOL` in `media.py`) to avoid deadlocks. Furthermore, using `list(executor.map(...))` nicely maintains the required sequential failure behavior by immediately raising the first exception encountered.
+**Action:** Use a dedicated `ThreadPoolExecutor` for parallelizing independent network-bound operations across a collection. Ensure high-level thread pools are distinct from nested/lower-level thread pools to prevent deadlocks, and use `executor.map` to preserve sequential exception raising.

--- a/src/imagine_mcp/dispatcher.py
+++ b/src/imagine_mcp/dispatcher.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import importlib
+from concurrent.futures import ThreadPoolExecutor
 from typing import Any
 
 from imagine_mcp.errors import (
@@ -14,6 +15,11 @@ from imagine_mcp.errors import (
 )
 from imagine_mcp.media import detect_media_type, validate_url_and_get_ip
 from imagine_mcp.models import UNSUPPORTED, get_model_id
+
+# Use a separate thread pool for high-level tasks to avoid deadlocks
+# with the nested _DNS_RESOLVER_POOL used for DNS resolution inside _validate_url.
+# This parallelizes network calls to avoid O(N) latency when processing multiple URLs.
+_DISPATCH_POOL = ThreadPoolExecutor(max_workers=16, thread_name_prefix="dispatch_pool")
 
 VALID_PROVIDERS = ["gemini", "openai", "grok"]
 VALID_TIERS = ["poor", "rich"]
@@ -125,10 +131,15 @@ def dispatch_understand(
     _validate(provider, tier)
     if not media_urls:
         raise InvalidMediaTypeError("media_urls is empty")
-    for i, u in enumerate(media_urls):
-        _validate_url(u, f"media_urls[{i}]")
 
-    media_types = [detect_media_type(u) for u in media_urls]
+    def _validate_and_detect(i: int, url: str) -> str:
+        _validate_url(url, f"media_urls[{i}]")
+        return detect_media_type(url)
+
+    # Process validation and detection concurrently, maintaining sequential failure behavior
+    media_types = list(
+        _DISPATCH_POOL.map(_validate_and_detect, range(len(media_urls)), media_urls)
+    )
     has_video = "video" in media_types
 
     if has_video:

--- a/uv.lock
+++ b/uv.lock
@@ -531,7 +531,7 @@ wheels = [
 
 [[package]]
 name = "imagine-mcp"
-version = "1.3.0"
+version = "1.4.0"
 source = { editable = "." }
 dependencies = [
     { name = "diskcache" },


### PR DESCRIPTION
💡 What: Refactored `dispatch_understand` to use `ThreadPoolExecutor.map` for running `_validate_url` and `detect_media_type` concurrently across multiple URLs.
🎯 Why: Previously, processing multiple media URLs triggered O(N) sequential HTTP HEAD requests and DNS lookups, blocking the main thread and creating a significant latency bottleneck.
📊 Impact: Reduces processing latency for multi-URL requests from O(N) to O(1) (up to max pool size of 16).
🔬 Measurement: Verify by executing `dispatch_understand` with an array of multiple distinct URLs and comparing the elapsed execution time against the previous implementation.

---
*PR created automatically by Jules for task [4217037916825781](https://jules.google.com/task/4217037916825781) started by @n24q02m*