### PR TITLE
🛡️ Sentinel: [HIGH] Fix potential SSRF via redirects in Grok provider

### DIFF
--- a/src/imagine_mcp/providers/grok.py
+++ b/src/imagine_mcp/providers/grok.py
@@ -12,7 +12,6 @@ import uuid
 from pathlib import Path
 from typing import Any
 
-import httpx
 import platformdirs
 
 from imagine_mcp.config import settings
@@ -145,11 +144,12 @@ def generate_image(
         data_url = f"data:{mime_type};base64,{img_b64}"
         payload["reference_image"] = data_url
 
-    resp = httpx.post(
+    resp = get_ssrf_safe_client().post(
         f"{_BASE_URL}/images/generations",
         json=payload,
         headers=headers,
         timeout=120,
+        follow_redirects=True,
     )
     if resp.status_code != 200:
         raise ProviderAPIError(
@@ -212,11 +212,12 @@ def generate_video(
             data_url = f"data:{mime_type};base64,{img_b64}"
             payload["source_image"] = data_url
 
-        resp = httpx.post(
+        resp = get_ssrf_safe_client().post(
             f"{_BASE_URL}/videos/generations",
             json=payload,
             headers=headers,
             timeout=60,
+            follow_redirects=True,
         )
         if resp.status_code != 200:
             raise ProviderAPIError(
@@ -233,10 +234,11 @@ def generate_video(
             "tier": tier,
         }
 
-    resp = httpx.get(
+    resp = get_ssrf_safe_client().get(
         f"{_BASE_URL}/videos/generations/{job_id}",
         headers=headers,
         timeout=30,
+        follow_redirects=True,
     )
     if resp.status_code != 200:
         raise ProviderAPIError(


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: The Grok provider previously utilized standard `httpx` methods for internal image and video generation endpoints without tracking redirects safely. While the initial request is to a trusted host (`api.x.ai`), malicious redirection could lead to a Server-Side Request Forgery (SSRF).
🎯 Impact: An attacker could potentially bypass intended network segmentation and perform unauthorized network requests from the backend if a trusted target was coerced into redirecting requests to private or malicious IP ranges.
🔧 Fix: Upgraded the HTTP requests in `generate_image` and `generate_video` to leverage `get_ssrf_safe_client()` (with `follow_redirects=True`), which implements DNS pinning and rejects redirects to local/private IP address ranges.
✅ Verification: Tested the changes by running `uv run pytest` to ensure no functionality is broken, and linted the code successfully using `uv run ruff check .`.

---
*PR created automatically by Jules for task [1250068401780545757](https://jules.google.com/task/1250068401780545757) started by @n24q02m*