### PR TITLE
⚡ Bolt: Parallelize media type detection in dispatch_understand

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,3 +1,6 @@
 ## 2024-05-18 - Optimize default_provider_for lookups
 **Learning:** `default_provider_for` in `src/imagine_mcp/models.py` performs an O(N log N) filtering and sorting of `MODELS` on every call. Since the parameter space (`action`, `media`, `tier`) is very small and bounded, caching the result yields a ~25x performance improvement. Standard lru_cache works perfectly for this use case.
 **Action:** Use `@functools.lru_cache(maxsize=32)` to optimize functions that perform expensive queries or sorting over static lists when their parameter space is small and bounded.
+## 2024-05-18 - Optimize media type detection in dispatch_understand
+**Learning:** `detect_media_type` might perform synchronous HTTP HEAD requests to figure out the content type if the file extension isn't in its known list. When processing multiple `media_urls` in `dispatch_understand`, sequential execution creates a significant performance bottleneck.
+**Action:** Use `ThreadPoolExecutor.map` wrapped in `list()` to parallelize network-bound operations over collections, ensuring the generator is fully evaluated to maintain fail-fast error handling.

--- a/src/imagine_mcp/dispatcher.py
+++ b/src/imagine_mcp/dispatcher.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import importlib
+from concurrent.futures import ThreadPoolExecutor
 from typing import Any
 
 from imagine_mcp.errors import (
@@ -18,6 +19,8 @@ from imagine_mcp.models import UNSUPPORTED, get_model_id
 VALID_PROVIDERS = ["gemini", "openai", "grok"]
 VALID_TIERS = ["poor", "rich"]
 VALID_MEDIA_TYPES = ["image", "video"]
+
+_DISPATCH_POOL = ThreadPoolExecutor(max_workers=16, thread_name_prefix="dispatch_pool")
 
 # Auto-fallback priority when caller does not pin a provider. Order is
 # (XAI, OpenAI, Gemini): Gemini stays last because Google AI Studio
@@ -128,7 +131,10 @@ def dispatch_understand(
     for i, u in enumerate(media_urls):
         _validate_url(u, f"media_urls[{i}]")
 
-    media_types = [detect_media_type(u) for u in media_urls]
+    # Optimization: Parallelize media type detection which may perform synchronous HTTP HEAD
+    # requests to figure out the content type if the file extension isn't in its known list.
+    # We wrap the map in a list to evaluate the generator fully, failing fast on exceptions.
+    media_types = list(_DISPATCH_POOL.map(detect_media_type, media_urls))
     has_video = "video" in media_types
 
     if has_video:

--- a/uv.lock
+++ b/uv.lock
@@ -531,7 +531,7 @@ wheels = [
 
 [[package]]
 name = "imagine-mcp"
-version = "1.4.0"
+version = "1.3.0"
 source = { editable = "." }
 dependencies = [
     { name = "diskcache" },

--- a/uv.lock
+++ b/uv.lock
@@ -531,7 +531,7 @@ wheels = [
 
 [[package]]
 name = "imagine-mcp"
-version = "1.3.0"
+version = "1.4.0"
 source = { editable = "." }
 dependencies = [
     { name = "diskcache" },


### PR DESCRIPTION
💡 What: Replaced the sequential list comprehension for `detect_media_type` with a parallel execution using `ThreadPoolExecutor.map`.
🎯 Why: `detect_media_type` can perform synchronous HTTP HEAD requests to figure out content types if the extension isn't mapped. When multiple media URLs are given, doing these requests sequentially represents a massive bottleneck.
📊 Impact: Reduces total latency of `dispatch_understand` when processing multiple URLs. Time bounded by max(request) instead of sum(requests) when extensions are absent.
🔬 Measurement: Can be verified by using URLs that require HEAD requests and checking how total execution time scales (it should now scale minimally relative to the longest request, vs summing the duration of all requests).

---
*PR created automatically by Jules for task [10778825384055949324](https://jules.google.com/task/10778825384055949324) started by @n24q02m*