### PR TITLE
fix: 🛡️ sentinel: resolve IPv6 addresses in SSRF protection

### DIFF
--- a/src/imagine_mcp/media.py
+++ b/src/imagine_mcp/media.py
@@ -79,7 +79,7 @@ def validate_url_and_get_ip(url: str, param: str) -> str:
         # to prevent DoS attacks via malicious DNS servers.
         # Note: parsed.port may be None, which is fine for getaddrinfo.
         future = _DNS_RESOLVER_POOL.submit(
-            socket.getaddrinfo, hostname, parsed.port, socket.AF_INET
+            socket.getaddrinfo, hostname, parsed.port, socket.AF_UNSPEC
         )
         # Short timeout to fail fast on tarpit DNS
         addr_info = future.result(timeout=2.0)


### PR DESCRIPTION
🚨 Severity: CRITICAL
💡 Vulnerability: SSRF Filter Bypass / DoS via hardcoded IPv4 address family in pre-flight IP resolution.
🎯 Impact: Attackers could cause application errors or potentially bypass SSRF protections by using IPv6 URLs, as they were not checked properly due to a hardcoded `AF_INET` family flag.
🔧 Fix: Updated `getaddrinfo` to use `socket.AF_UNSPEC`, allowing resolution of both IPv4 and IPv6 addresses. `ipaddress.is_global` already correctly checks for valid public IPv6 configurations.
✅ Verification: Pass all automated unit tests (`uv run pytest`) and verified resolution using manual tests of known IPv6 endpoints.

---
*PR created automatically by Jules for task [3333647369420532525](https://jules.google.com/task/3333647369420532525) started by @n24q02m*