### PR TITLE
fix: 🛡️ sentinel: support ipv6 resolution in ssrf filter

### DIFF
--- a/src/imagine_mcp/media.py
+++ b/src/imagine_mcp/media.py
@@ -79,7 +79,7 @@ def validate_url_and_get_ip(url: str, param: str) -> str:
         # to prevent DoS attacks via malicious DNS servers.
         # Note: parsed.port may be None, which is fine for getaddrinfo.
         future = _DNS_RESOLVER_POOL.submit(
-            socket.getaddrinfo, hostname, parsed.port, socket.AF_INET
+            socket.getaddrinfo, hostname, parsed.port, socket.AF_UNSPEC
         )
         # Short timeout to fail fast on tarpit DNS
         addr_info = future.result(timeout=2.0)


### PR DESCRIPTION
🚨 Severity: MEDIUM
💡 Vulnerability: The custom `SSRFSafeTransport` failed to resolve and validate IPv6-only hostnames due to hardcoding `socket.AF_INET` (IPv4) in `socket.getaddrinfo`. This resulted in `socket.gaierror`, effectively causing denial of service when users attempted to pass URLs hosted on IPv6 and could lead to inconsistent states.
🎯 Impact: Breaks legitimate functionality for URLs hosted on IPv6 environments while attempting to protect against SSRF.
🔧 Fix: Changed `socket.AF_INET` to `socket.AF_UNSPEC` in `src/imagine_mcp/media.py` to allow resolution of both IPv4 and IPv6 addresses. `ipaddress` already natively supports both address families for local/private range validation.
✅ Verification: Tested via existing test suite; changes lint cleanly and code reviewer approved the modification as safe and required.

Added a corresponding learning journal entry to `.jules/sentinel.md`.

---
*PR created automatically by Jules for task [8673173601091848781](https://jules.google.com/task/8673173601091848781) started by @n24q02m*