### PR TITLE
perf: ⚡ bolt: propagate media_types to prevent redundant network I/O

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -5,3 +5,7 @@
 ## 2024-05-18 - Optimize media type detection concurrency
 **Learning:** `detect_media_type` in `dispatch_understand` involves sequential network requests per media URL, resulting in O(N) latency. By replacing the list comprehension with `_DISPATCH_POOL.map` (using a `ThreadPoolExecutor`), we can reduce latency to O(1) bounded by max_workers. Wrapping `map` in `list()` is critical to evaluate the generator immediately and preserve fail-fast error handling. We also need to keep URL validation sequential to prevent deadlocks with nested thread pools (like `_DNS_RESOLVER_POOL`).
 **Action:** Use `ThreadPoolExecutor.map` wrapped in `list()` to efficiently resolve concurrent I/O operations and carefully manage nested thread pools to avoid deadlocks.
+
+## 2024-05-18 - Optimize redundant network I/O in Gemini multi-URL processing
+**Learning:** In the `understand_multimodal` function of the Gemini provider, calculating `detect_media_type` for every URL redundantly duplicated the work already concurrently performed by `dispatch_understand` in the dispatcher. This led to O(N) sequential HTTP HEAD requests, creating a performance bottleneck for multi-URL prompts. By passing the pre-calculated `media_types` array from the dispatcher down to the provider, we converted this O(N) penalty into an O(1) bounded operation.
+**Action:** When a dispatcher or upstream caller computes expensive metadata (like media types) to make routing decisions, pass that pre-calculated data down to the provider to avoid duplicating expensive network requests.

--- a/src/imagine_mcp/dispatcher.py
+++ b/src/imagine_mcp/dispatcher.py
@@ -148,7 +148,10 @@ def dispatch_understand(
 
     # Gemini native multimodal can accept many URLs in one call
     if provider == "gemini" and len(media_urls) > 1:
-        return mod.understand_multimodal(media_urls, prompt, tier, max_tokens)
+        # Pass pre-computed media_types to prevent redundant network I/O in the provider
+        return mod.understand_multimodal(
+            media_urls, prompt, tier, max_tokens, media_types=media_types
+        )
 
     url = media_urls[0]
     primary = media_types[0]

--- a/src/imagine_mcp/providers/gemini.py
+++ b/src/imagine_mcp/providers/gemini.py
@@ -147,7 +147,11 @@ def understand_video(
 
 
 def understand_multimodal(
-    urls: list[str], prompt: str, tier: str, max_tokens: int = 2048
+    urls: list[str],
+    prompt: str,
+    tier: str,
+    max_tokens: int = 2048,
+    media_types: list[str] | None = None,
 ) -> dict[str, Any]:
     """Gemini native multimodal: mixed image+video URLs in a single call."""
     from google.genai import types
@@ -167,8 +171,12 @@ def understand_multimodal(
     tmp_dir.mkdir(parents=True, exist_ok=True)
 
     try:
-        for u in urls:
-            mt = detect_media_type(u)
+        for i, u in enumerate(urls):
+            # Performance optimization:
+            # Use pre-calculated media types if provided by the dispatcher
+            # This avoids O(N) sequential redundant network calls (HEAD requests)
+            # converting the latency to O(1) bounded by the dispatcher's thread pool.
+            mt = media_types[i] if media_types else detect_media_type(u)
             if mt == "image":
                 img_data = (
                     get_ssrf_safe_client()


### PR DESCRIPTION
💡 What: Optimized `gemini.understand_multimodal` by preventing it from redundantly executing sequential HTTP HEAD network requests through `detect_media_type` for every URL.

🎯 Why: In `dispatcher.py`, `dispatch_understand` concurrently detects the media type for all URLs. However, it was calling `gemini.understand_multimodal` without passing the pre-computed `media_types`, leading to the provider recalculating them sequentially. This duplicated expensive network I/O.

📊 Impact: Reduces latency from O(N) sequential HTTP HEAD network requests to O(1) concurrent bound. Passing the pre-computed `media_types` mitigates the overhead for multiple URLs processed together!

🔬 Measurement: Review `src/imagine_mcp/dispatcher.py` to see `media_types` being passed, and `src/imagine_mcp/providers/gemini.py` receiving it. Try providing an array of URLs to verify the impact.

---
*PR created automatically by Jules for task [11385722483655914536](https://jules.google.com/task/11385722483655914536) started by @n24q02m*