### PR TITLE
fix: 🛡️ sentinel: url-encode job_id to prevent path traversal

### DIFF
--- a/src/imagine_mcp/providers/grok.py
+++ b/src/imagine_mcp/providers/grok.py
@@ -239,7 +239,8 @@ def generate_video(
         }
 
     import urllib.parse
-    safe_job_id = urllib.parse.quote(job_id, safe='')
+
+    safe_job_id = urllib.parse.quote(job_id, safe="")
 
     from imagine_mcp.media import get_ssrf_safe_client
 

--- a/src/imagine_mcp/providers/grok.py
+++ b/src/imagine_mcp/providers/grok.py
@@ -238,10 +238,13 @@ def generate_video(
             "tier": tier,
         }
 
+    import urllib.parse
+    safe_job_id = urllib.parse.quote(job_id, safe='')
+
     from imagine_mcp.media import get_ssrf_safe_client
 
     resp = get_ssrf_safe_client().get(
-        f"{_BASE_URL}/videos/generations/{job_id}",
+        f"{_BASE_URL}/videos/generations/{safe_job_id}",
         headers=headers,
         timeout=30,
         follow_redirects=True,

--- a/uv.lock
+++ b/uv.lock
@@ -549,7 +549,7 @@ wheels = [
 
 [[package]]
 name = "imagine-mcp"
-version = "1.5.0b1"
+version = "1.5.0"
 source = { editable = "." }
 dependencies = [
     { name = "diskcache" },


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: User-supplied `job_id` was being directly interpolated into a REST API path (`/videos/generations/{job_id}`) without URL-encoding in the Grok provider.
🎯 Impact: An attacker could potentially inject special characters like `/`, `?`, or `#` into the `job_id` to manipulate the API request path, leading to path traversal or SSRF vulnerabilities against the backend API.
🔧 Fix: URL-encode the `job_id` using `urllib.parse.quote(job_id, safe='')` prior to interpolating it into the URL.
✅ Verification: Ran `uv run pytest` to ensure tests continue to pass and `uv run ruff check .` to ensure no linting issues. Reviewed `git diff` to ensure encoding logic is applied correctly to the parameter.

---
*PR created automatically by Jules for task [8446577165946904992](https://jules.google.com/task/8446577165946904992) started by @n24q02m*