### PR TITLE
fix: remove unused _reset_client function in OpenAI provider

### DIFF
--- a/src/imagine_mcp/providers/openai.py
+++ b/src/imagine_mcp/providers/openai.py
@@ -70,12 +70,6 @@ def _client() -> Any:
     return _CLIENT
 
 
-def _reset_client() -> None:
-    global _CLIENT
-    _CLIENT = None
-    _SUB_CLIENTS.clear()
-
-
 def understand_image(
     url: str, prompt: str, tier: str, max_tokens: int = 2048
 ) -> dict[str, Any]:

--- a/uv.lock
+++ b/uv.lock
@@ -549,7 +549,7 @@ wheels = [
 
 [[package]]
 name = "imagine-mcp"
-version = "1.5.0"
+version = "1.5.1"
 source = { editable = "." }
 dependencies = [
     { name = "diskcache" },


### PR DESCRIPTION
Removed the unused `_reset_client` function from the OpenAI provider module as it is dead code. Only `gemini._reset_client` is used in tests for client isolation. Verified with full test suite and linting.

---
*PR created automatically by Jules for task [12360396515835664612](https://jules.google.com/task/12360396515835664612) started by @n24q02m*