### PR TITLE
fix: add missing error test for ProviderAPIError on missing image data

### DIFF
--- a/tests/test_providers_gemini_generate.py
+++ b/tests/test_providers_gemini_generate.py
@@ -1,0 +1,51 @@
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from imagine_mcp.errors import ProviderAPIError
+from imagine_mcp.providers import gemini
+
+
+def test_generate_image_missing_data(monkeypatch: pytest.MonkeyPatch) -> None:
+    fake_client = MagicMock()
+    fake_response = MagicMock()
+
+    # Mocking resp.candidates[0].content.parts
+    # We'll make it return a part that doesn't have inline_data
+    fake_part = MagicMock()
+    if hasattr(fake_part, "inline_data"):
+        del fake_part.inline_data  # Ensure hasattr(part, "inline_data") is False
+
+    fake_response.candidates = [MagicMock()]
+    fake_response.candidates[0].content.parts = [fake_part]
+
+    fake_client.models.generate_content.return_value = fake_response
+    monkeypatch.setattr(gemini, "_client", lambda: fake_client)
+
+    with pytest.raises(ProviderAPIError, match="Gemini returned no image") as exc_info:
+        gemini.generate_image(prompt="a sunset", tier="poor")
+
+    assert exc_info.value.status_code == 500
+
+
+def test_generate_image_empty_inline_data(monkeypatch: pytest.MonkeyPatch) -> None:
+    fake_client = MagicMock()
+    fake_response = MagicMock()
+
+    # Mocking resp.candidates[0].content.parts
+    # We'll make it return a part that has empty inline_data
+    fake_part = MagicMock()
+    fake_part.inline_data = None
+
+    fake_response.candidates = [MagicMock()]
+    fake_response.candidates[0].content.parts = [fake_part]
+
+    fake_client.models.generate_content.return_value = fake_response
+    monkeypatch.setattr(gemini, "_client", lambda: fake_client)
+
+    with pytest.raises(ProviderAPIError, match="Gemini returned no image") as exc_info:
+        gemini.generate_image(prompt="a sunset", tier="poor")
+
+    assert exc_info.value.status_code == 500

--- a/uv.lock
+++ b/uv.lock
@@ -549,7 +549,7 @@ wheels = [
 
 [[package]]
 name = "imagine-mcp"
-version = "1.5.0"
+version = "1.5.1"
 source = { editable = "." }
 dependencies = [
     { name = "diskcache" },


### PR DESCRIPTION
This PR adds unit tests to verify that `gemini.generate_image` correctly handles cases where the Gemini API returns a response without image data. 

Specifically, it covers:
- When a response part lacks the `inline_data` attribute.
- When `inline_data` is present but empty (`None`).

In both cases, the code should raise a `ProviderAPIError` with a 500 status code and the message "Gemini returned no image".

Added file:
- `tests/test_providers_gemini_generate.py`

---
*PR created automatically by Jules for task [11787791345937289012](https://jules.google.com/task/11787791345937289012) started by @n24q02m*