### PR TITLE
fix: use specific imports for concurrent.futures in media.py

### DIFF
--- a/diff.patch
+++ b/diff.patch
@@ -1,0 +1,33 @@
+<<<<<<< SEARCH
+import concurrent.futures
+import ipaddress
+import os
+import socket
+from pathlib import Path
+=======
+import ipaddress
+import os
+import socket
+from concurrent.futures import ThreadPoolExecutor, TimeoutError
+from pathlib import Path
+>>>>>>> REPLACE
+<<<<<<< SEARCH
+_DNS_RESOLVER_POOL = concurrent.futures.ThreadPoolExecutor(
+    max_workers=4, thread_name_prefix="dns_resolver"
+)
+=======
+_DNS_RESOLVER_POOL = ThreadPoolExecutor(
+    max_workers=4, thread_name_prefix="dns_resolver"
+)
+>>>>>>> REPLACE
+<<<<<<< SEARCH
+    except concurrent.futures.TimeoutError as e:
+        raise InvalidURLError(
+            f"Invalid {param}: DNS resolution timed out for {hostname!r}."
+        ) from e
+=======
+    except TimeoutError as e:
+        raise InvalidURLError(
+            f"Invalid {param}: DNS resolution timed out for {hostname!r}."
+        ) from e
+>>>>>>> REPLACE

--- a/src/imagine_mcp/media.py
+++ b/src/imagine_mcp/media.py
@@ -2,10 +2,10 @@
 
 from __future__ import annotations
 
-import concurrent.futures
 import ipaddress
 import os
 import socket
+from concurrent.futures import ThreadPoolExecutor, TimeoutError
 from pathlib import Path
 from typing import Literal
 from urllib.parse import urlparse
@@ -16,7 +16,7 @@ from imagine_mcp.errors import InvalidURLError, MediaDetectError
 
 MediaType = Literal["image", "video"]
 
-_DNS_RESOLVER_POOL = concurrent.futures.ThreadPoolExecutor(
+_DNS_RESOLVER_POOL = ThreadPoolExecutor(
     max_workers=4, thread_name_prefix="dns_resolver"
 )
 
@@ -105,7 +105,7 @@ def validate_url_and_get_ip(url: str, param: str) -> str:
 
         raise InvalidURLError(f"Invalid {param}: No valid IP found for {hostname!r}.")
 
-    except concurrent.futures.TimeoutError as e:
+    except TimeoutError as e:
         raise InvalidURLError(
             f"Invalid {param}: DNS resolution timed out for {hostname!r}."
         ) from e

--- a/uv.lock
+++ b/uv.lock
@@ -549,7 +549,7 @@ wheels = [
 
 [[package]]
 name = "imagine-mcp"
-version = "1.5.0"
+version = "1.5.1"
 source = { editable = "." }
 dependencies = [
     { name = "diskcache" },


### PR DESCRIPTION
Changed `import concurrent.futures` to `from concurrent.futures import ThreadPoolExecutor, TimeoutError` in `src/imagine_mcp/media.py`. Updated all usages of `concurrent.futures.ThreadPoolExecutor` and `concurrent.futures.TimeoutError` to use the imported names directly.

Verified with:
- `uv run ruff check .`
- `uv run ruff format .`
- `uv run pytest` (all 158 tests passed)

---
*PR created automatically by Jules for task [6188570018714352668](https://jules.google.com/task/6188570018714352668) started by @n24q02m*