### PR TITLE
fix: 🧪 add missing sorting tests for list_models

### DIFF
--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -126,3 +126,35 @@ def test_default_provider_for_rank_1() -> None:
 def test_default_provider_fallback_when_only_unsupported() -> None:
     # openai has UNSUPPORTED for video understand; default_provider should fall back to gemini
     assert default_provider_for("understand", "video", "poor") == "gemini"
+
+
+def test_list_models_sorted_by_provider() -> None:
+    group = list_models(
+        filter_fn=lambda e: (
+            e.action == "understand" and e.media == "image" and e.tier == "poor"
+        ),
+        sort_by="provider",
+    )
+    providers = [e.provider for e in group]
+    # Providers are gemini, openai, grok. Alphabetical: gemini, grok, openai.
+    assert providers == sorted(providers)
+    assert providers == ["gemini", "grok", "openai"]
+
+
+def test_list_models_sorted_by_cost() -> None:
+    # generate.video.poor has gemini (low) and grok (medium).
+    # openai is also low but UNSUPPORTED, so we filter it out to see the sort.
+    group = list_models(
+        filter_fn=lambda e: (
+            e.action == "generate"
+            and e.media == "video"
+            and e.tier == "poor"
+            and e.model_id is not UNSUPPORTED
+        ),
+        sort_by="cost",
+    )
+    costs = [e.cost_tier for e in group]
+    cost_order = {"low": 0, "medium": 1, "high": 2}
+    cost_values = [cost_order[c] for c in costs]
+    assert cost_values == sorted(cost_values)
+    assert costs == ["low", "medium"]

--- a/uv.lock
+++ b/uv.lock
@@ -549,7 +549,7 @@ wheels = [
 
 [[package]]
 name = "imagine-mcp"
-version = "1.5.0"
+version = "1.5.1"
 source = { editable = "." }
 dependencies = [
     { name = "diskcache" },


### PR DESCRIPTION
This PR adds missing edge case tests for the `list_models` function in `src/imagine_mcp/models.py`. 

Specifically, it addresses the lack of coverage for the `provider` and `cost` sorting options.

### Changes:
- Added `test_list_models_sorted_by_provider`: Ensures models are sorted alphabetically by provider within their respective action/media/tier groups.
- Added `test_list_models_sorted_by_cost`: Ensures models are sorted by cost tier (low < medium < high) using the internal cost mapping.

These tests ensure the sorting logic is robust and behaves as expected when users query for models with specific ordering preferences.

---
*PR created automatically by Jules for task [13170148715894282515](https://jules.google.com/task/13170148715894282515) started by @n24q02m*