### PR TITLE
perf: ⚡ bolt: optimize O(N^2) loop in merge_ranks

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -16,3 +16,9 @@
 ## 2026-05-27 - Request-Scoped ContextVar Caching for I/O Heavy Credentials
 **Learning:** In a multi-user HTTP architecture where credentials are encrypted and stored per user (sub), resolving credentials via `PerPluginStore.load()` triggered expensive file reads, AES-GCM decryption, and JSON parsing on *every* API lookup (e.g. `_default_provider`, `_api_key`). Caching this lookup on a per-request basis using `contextvars.ContextVar` eliminates these redundant operations. However, because `ContextVar` instances inherit state in sequentially executed asyncio test tasks (running in the same OS thread), the cache must be explicitly reset using an `autouse=True` fixture in `conftest.py` to prevent state leakage and isolated test failures.
 **Action:** Use `contextvars.ContextVar` for request-scoped caching to eliminate redundant disk/crypto operations per API request. When doing so, always ensure test suites have an `autouse` fixture to manually reset the contextvar to maintain test isolation.
+
+## 2025-05-15 - [Optimization of leaderboard rank merging]
+
+**Vulnerability:** Inefficient O(N^2) loop merging ranks from multiple leaderboard lists in `scripts/fetch_leaderboards.py`.
+**Learning:** Replacing nested list searches with dictionary-based O(1) lookups reduces time complexity from O(N^2) to O(N).
+**Prevention:** Use dictionaries for frequent lookups or when merging datasets by unique keys.

--- a/scripts/fetch_leaderboards.py
+++ b/scripts/fetch_leaderboards.py
@@ -213,14 +213,19 @@ def parse_leaderboard(url: str, html: str) -> list[LBRow]:
 
 def merge_ranks(rows_aa: list[LBRow], rows_lmarena: list[LBRow]) -> dict[str, int]:
     """Return {canonical_model_id: quality_rank} using min(rank_aa, rank_lmarena)."""
+    # Performance optimization: Convert lists to dicts for O(1) lookups.
+    # This reduces time complexity from O(N^2) to O(N).
+    aa_ranks = {r.model_id: r.rank for r in rows_aa}
+    lm_ranks = {r.model_id: r.rank for r in rows_lmarena}
+
+    all_ids = set(aa_ranks.keys()) | set(lm_ranks.keys())
     result: dict[str, int] = {}
-    all_ids = {r.model_id for r in rows_aa} | {r.model_id for r in rows_lmarena}
     for model_id in all_ids:
         ranks: list[int] = []
-        for rows in (rows_aa, rows_lmarena):
-            match = next((r for r in rows if r.model_id == model_id), None)
-            if match:
-                ranks.append(match.rank)
+        if (r_aa := aa_ranks.get(model_id)) is not None:
+            ranks.append(r_aa)
+        if (r_lm := lm_ranks.get(model_id)) is not None:
+            ranks.append(r_lm)
         result[model_id] = min(ranks) if ranks else 999
     return result
 


### PR DESCRIPTION
💡 What
Refactored the `merge_ranks` function in `scripts/fetch_leaderboards.py` to use dictionary-based lookups instead of nested list iteration.

🎯 Why
The original implementation had O(N^2) time complexity because it performed a linear search (`next()`) through both input lists for every unique `model_id`. This is inefficient as the number of models grows.

📊 Impact
- Reduced time complexity from O(N^2) to O(N).
- Improved performance of the leaderboard fetching and merging script.
- Cleaner and more idiomatic Python code.

🔬 Measurement
- Verified with existing tests in `tests/test_fetch_leaderboards.py`.
- Logic remains identical while execution time for the merge step is now linear with respect to the number of models.

---
*PR created automatically by Jules for task [4204782275222805407](https://jules.google.com/task/4204782275222805407) started by @n24q02m*