### PR TITLE
fix: duplicated base64 image conversion logic

### DIFF
--- a/src/imagine_mcp/media.py
+++ b/src/imagine_mcp/media.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import base64
 import concurrent.futures
 import ipaddress
 import os
@@ -179,3 +180,12 @@ def download_to_path(url: str, dest: Path) -> Path:
     except InvalidURLError as e:
         raise httpx.HTTPError(f"Download failed due to invalid redirect: {e}") from e
     return dest
+
+
+def download_as_data_url(url: str, timeout: int = 60) -> str:
+    """Download image securely and return as base64 data URL."""
+    resp = get_ssrf_safe_client().get(url, follow_redirects=True, timeout=timeout)
+    resp.raise_for_status()
+    img_b64 = base64.b64encode(resp.content).decode()
+    mime_type = resp.headers.get("content-type", "image/png")
+    return f"data:{mime_type};base64,{img_b64}"

--- a/src/imagine_mcp/providers/grok.py
+++ b/src/imagine_mcp/providers/grok.py
@@ -21,6 +21,7 @@ from imagine_mcp.errors import (
     ProviderAPIError,
     ProviderUnsupportedError,
 )
+from imagine_mcp.media import download_as_data_url, get_ssrf_safe_client
 from imagine_mcp.models import get_model_id
 
 _CLIENT: Any = None
@@ -83,15 +84,10 @@ def _reset_client() -> None:
 def understand_image(
     url: str, prompt: str, tier: str, max_tokens: int = 2048
 ) -> dict[str, Any]:
-    from imagine_mcp.media import get_ssrf_safe_client
 
     model = get_model_id("grok", "understand", "image", tier)
 
-    # Download image securely and pass as base64 data URL to prevent backend SSRF
-    resp_img = get_ssrf_safe_client().get(url, follow_redirects=True, timeout=60)
-    img_b64 = base64.b64encode(resp_img.content).decode()
-    mime_type = resp_img.headers.get("content-type", "image/png")
-    data_url = f"data:{mime_type};base64,{img_b64}"
+    data_url = download_as_data_url(url)
 
     resp = _openai_compat_client().chat.completions.create(
         model=model,
@@ -129,23 +125,13 @@ def generate_image(
     reference_image_url: str | None = None,
     aspect_ratio: str = "1:1",
 ) -> dict[str, Any]:
-    from imagine_mcp.media import get_ssrf_safe_client
 
     model = get_model_id("grok", "generate", "image", tier)
     headers = {"Authorization": f"Bearer {_api_key()}"}
     payload: dict[str, Any] = {"model": model, "prompt": prompt, "n": 1}
 
     if reference_image_url:
-        # Download reference image and pass as base64 data URL
-        resp_img = get_ssrf_safe_client().get(
-            reference_image_url, follow_redirects=True, timeout=60
-        )
-        img_b64 = base64.b64encode(resp_img.content).decode()
-        mime_type = resp_img.headers.get("content-type", "image/png")
-        data_url = f"data:{mime_type};base64,{img_b64}"
-        payload["reference_image"] = data_url
-
-    from imagine_mcp.media import get_ssrf_safe_client
+        payload["reference_image"] = download_as_data_url(reference_image_url)
 
     resp = get_ssrf_safe_client().post(
         f"{_BASE_URL}/images/generations",
@@ -193,7 +179,6 @@ def generate_video(
     aspect_ratio: str = "16:9",
     duration_seconds: int = 8,
 ) -> dict[str, Any]:
-    from imagine_mcp.media import get_ssrf_safe_client
 
     model = get_model_id("grok", "generate", "video", tier)
     headers = {"Authorization": f"Bearer {_api_key()}"}
@@ -206,16 +191,7 @@ def generate_video(
             "aspect_ratio": aspect_ratio,
         }
         if reference_image_url:
-            # Download source image and pass as base64 data URL
-            resp_img = get_ssrf_safe_client().get(
-                reference_image_url, follow_redirects=True, timeout=60
-            )
-            img_b64 = base64.b64encode(resp_img.content).decode()
-            mime_type = resp_img.headers.get("content-type", "image/png")
-            data_url = f"data:{mime_type};base64,{img_b64}"
-            payload["source_image"] = data_url
-
-        from imagine_mcp.media import get_ssrf_safe_client
+            payload["source_image"] = download_as_data_url(reference_image_url)
 
         resp = get_ssrf_safe_client().post(
             f"{_BASE_URL}/videos/generations",
@@ -238,8 +214,6 @@ def generate_video(
             "provider": "grok",
             "tier": tier,
         }
-
-    from imagine_mcp.media import get_ssrf_safe_client
 
     safe_job_id = urllib.parse.quote(job_id, safe="")
     resp = get_ssrf_safe_client().get(

--- a/src/imagine_mcp/providers/openai.py
+++ b/src/imagine_mcp/providers/openai.py
@@ -16,6 +16,7 @@ from imagine_mcp.errors import (
     ProviderAPIError,
     ProviderUnsupportedError,
 )
+from imagine_mcp.media import download_as_data_url, get_ssrf_safe_client
 from imagine_mcp.models import get_model_id
 
 _CLIENT: Any = None
@@ -79,15 +80,10 @@ def _reset_client() -> None:
 def understand_image(
     url: str, prompt: str, tier: str, max_tokens: int = 2048
 ) -> dict[str, Any]:
-    from imagine_mcp.media import get_ssrf_safe_client
 
     model = get_model_id("openai", "understand", "image", tier)
 
-    # Download image securely and pass as base64 data URL to prevent backend SSRF
-    resp_img = get_ssrf_safe_client().get(url, follow_redirects=True, timeout=60)
-    img_b64 = base64.b64encode(resp_img.content).decode()
-    mime_type = resp_img.headers.get("content-type", "image/png")
-    data_url = f"data:{mime_type};base64,{img_b64}"
+    data_url = download_as_data_url(url)
 
     resp = _client().responses.create(
         model=model,
@@ -130,8 +126,6 @@ def generate_image(
     size = size_map.get(aspect_ratio, "1024x1024")
 
     if reference_image_url:
-        from imagine_mcp.media import get_ssrf_safe_client
-
         img_bytes = (
             get_ssrf_safe_client()
             .get(reference_image_url, follow_redirects=True, timeout=60)

--- a/tests/test_media.py
+++ b/tests/test_media.py
@@ -81,3 +81,23 @@ def test_extract_extension() -> None:
     assert _extract_extension("https://example.com/foo.PNG") == ".png"
     assert _extract_extension("https://example.com/foo.mp4?q=1") == ".mp4"
     assert _extract_extension("https://example.com/foo") == ""
+
+
+def test_download_as_data_url(monkeypatch: pytest.MonkeyPatch) -> None:
+    from imagine_mcp.media import download_as_data_url
+
+    mock_response = MagicMock()
+    mock_response.content = b"fake-image-content"
+    mock_response.headers = {"content-type": "image/png"}
+    mock_response.raise_for_status = MagicMock()
+
+    class MockClient:
+        def get(self, url, **kw):
+            return mock_response
+
+    monkeypatch.setattr("imagine_mcp.media.get_ssrf_safe_client", lambda: MockClient())
+
+    data_url = download_as_data_url("https://example.com/image.png")
+    assert data_url.startswith("data:image/png;base64,")
+    # b64encode(b"fake-image-content") -> ZmFrZS1pbWFnZS1jb250ZW50
+    assert "ZmFrZS1pbWFnZS1jb250ZW50" in data_url

--- a/uv.lock
+++ b/uv.lock
@@ -549,7 +549,7 @@ wheels = [
 
 [[package]]
 name = "imagine-mcp"
-version = "1.5.0"
+version = "1.5.1"
 source = { editable = "." }
 dependencies = [
     { name = "diskcache" },


### PR DESCRIPTION
Extracted base64 image conversion logic into a shared utility function download_as_data_url in src/imagine_mcp/media.py and refactored grok.py and openai.py to use it. This reduces code duplication and improves maintainability while ensuring consistent SSRF-safe downloads.

---
*PR created automatically by Jules for task [14819717176685562928](https://jules.google.com/task/14819717176685562928) started by @n24q02m*