### PR TITLE
fix: implement grok image edit capabilities

### DIFF
--- a/src/imagine_mcp/providers/grok.py
+++ b/src/imagine_mcp/providers/grok.py
@@ -114,6 +114,79 @@ def understand_image(
     }
 
 
+def edit(tier: str, image_url: str, prompt: str) -> dict[str, Any]:
+    """Edit an existing image using xAI /v1/images/edits."""
+    from imagine_mcp.media import get_ssrf_safe_client
+
+    model = get_model_id("grok", "generate", "image", tier)
+    headers = {"Authorization": f"Bearer {_api_key()}"}
+
+    # Download image securely and pass as base64 data URL to prevent backend SSRF
+    resp_img = get_ssrf_safe_client().get(image_url, follow_redirects=True, timeout=60)
+    img_b64 = base64.b64encode(resp_img.content).decode()
+    mime_type = resp_img.headers.get("content-type", "image/png")
+    data_url = f"data:{mime_type};base64,{img_b64}"
+
+    payload: dict[str, Any] = {
+        "model": model,
+        "prompt": prompt,
+        "image": {"url": data_url, "type": "image_url"},
+    }
+
+    resp = get_ssrf_safe_client().post(
+        f"{_BASE_URL}/images/edits",
+        json=payload,
+        headers=headers,
+        timeout=120,
+        follow_redirects=True,
+    )
+    if resp.status_code != 200:
+        raise ProviderAPIError(
+            f"Grok image edit failed: {resp.text}",
+            status_code=resp.status_code,
+        )
+
+    data = resp.json()
+    # Handle both {data: [{url: ...}]} and {url: ...} formats
+    img_url = None
+    img_b64 = None
+    if data.get("data"):
+        img_b64 = data["data"][0].get("b64_json")
+        if not img_b64:
+            img_url = data["data"][0].get("url")
+    else:
+        img_url = data.get("url")
+
+    if not img_b64 and img_url:
+        img_b64 = base64.b64encode(
+            get_ssrf_safe_client()
+            .get(img_url, follow_redirects=True, timeout=60)
+            .content
+        ).decode()
+
+    if not img_b64:
+        raise ProviderAPIError(f"Grok edit returned no image: {data}", status_code=500)
+
+    img_bytes = base64.b64decode(img_b64)
+    out_dir = Path(platformdirs.user_cache_dir("imagine-mcp")) / "generations"
+    out_dir.mkdir(parents=True, exist_ok=True)
+    out_path = out_dir / f"{uuid.uuid4().hex}.png"
+    out_path.write_bytes(img_bytes)
+
+    return {
+        "image_path": str(out_path),
+        "image_base64": img_b64,
+        "model": model,
+        "provider": "grok",
+        "tier": tier,
+    }
+
+
+def video_status(tier: str, job_id: str) -> dict[str, Any]:
+    """Poll for video status (proxy for generate_video with job_id)."""
+    return generate_video(prompt="", tier=tier, job_id=job_id)
+
+
 def understand_video(
     url: str, prompt: str, tier: str, max_tokens: int = 2048
 ) -> dict[str, Any]:

--- a/tests/test_providers_grok.py
+++ b/tests/test_providers_grok.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import base64
 from unittest.mock import MagicMock
 
 import pytest
@@ -45,3 +46,41 @@ def test_understand_image_mocked(
     assert result["text"] == "a parrot"
     assert result["model"] == "grok-4.20-0309-reasoning"
     assert result["provider"] == "grok"
+
+
+def test_video_status_calls_generate_video(monkeypatch: pytest.MonkeyPatch) -> None:
+    mock_gen = MagicMock(return_value={"status": "done"})
+    monkeypatch.setattr(provider, "generate_video", mock_gen)
+
+    result = provider.video_status("rich", "job123")
+    assert result == {"status": "done"}
+    mock_gen.assert_called_once_with(prompt="", tier="rich", job_id="job123")
+
+
+def test_edit_mocked(monkeypatch: pytest.MonkeyPatch) -> None:
+    mock_client = MagicMock()
+
+    # Mock GET for initial image download
+    mock_resp_get = MagicMock()
+    mock_resp_get.content = b"initial-image"
+    mock_resp_get.headers = {"content-type": "image/png"}
+
+    # Mock POST for edit request
+    mock_resp_post = MagicMock()
+    mock_resp_post.status_code = 200
+    mock_resp_post.json.return_value = {
+        "data": [{"b64_json": base64.b64encode(b"edited-image").decode()}]
+    }
+
+    mock_client.get.return_value = mock_resp_get
+    mock_client.post.return_value = mock_resp_post
+
+    monkeypatch.setattr("imagine_mcp.media.get_ssrf_safe_client", lambda: mock_client)
+    monkeypatch.setattr(provider, "_api_key", lambda: "fake-key")
+
+    result = provider.edit(
+        tier="poor", image_url="https://example.com/in.png", prompt="make it blue"
+    )
+    assert "image_path" in result
+    assert result["image_base64"] == base64.b64encode(b"edited-image").decode()
+    assert result["model"] == "grok-imagine-image"

--- a/uv.lock
+++ b/uv.lock
@@ -549,7 +549,7 @@ wheels = [
 
 [[package]]
 name = "imagine-mcp"
-version = "1.5.0"
+version = "1.5.1"
 source = { editable = "." }
 dependencies = [
     { name = "diskcache" },


### PR DESCRIPTION
Implement Grok image edit capabilities by adding the `edit` function using the `/v1/images/edits` endpoint and `video_status` for polling. This fix addresses the missing functionality in the Grok provider.

### Changes:
- Added `edit(tier, image_url, prompt)` to `src/imagine_mcp/providers/grok.py`.
- Added `video_status(tier, job_id)` to `src/imagine_mcp/providers/grok.py`.
- Added unit tests for these functions in `tests/test_providers_grok.py`.
- Verified all tests pass.

---
*PR created automatically by Jules for task [17735716779473163084](https://jules.google.com/task/17735716779473163084) started by @n24q02m*