### PR TITLE
fix: duplicated UUID path generation for media cache

### DIFF
--- a/src/imagine_mcp/media.py
+++ b/src/imagine_mcp/media.py
@@ -6,11 +6,13 @@ import concurrent.futures
 import ipaddress
 import os
 import socket
+import uuid
 from pathlib import Path
 from typing import Literal
 from urllib.parse import urlparse
 
 import httpx
+import platformdirs
 
 from imagine_mcp.errors import InvalidURLError, MediaDetectError
 
@@ -164,6 +166,16 @@ def _extract_extension(url: str) -> str:
     path = url.split("?", 1)[0].split("#", 1)[0]
     _, ext = os.path.splitext(path)
     return ext.lower()
+
+
+def get_temp_media_path(extension: str, sub_dir: str = "generations") -> Path:
+    """Generate a unique path for temporary media storage.
+
+    Ensures the directory exists.
+    """
+    out_dir = Path(platformdirs.user_cache_dir("imagine-mcp")) / sub_dir
+    out_dir.mkdir(parents=True, exist_ok=True)
+    return out_dir / f"{uuid.uuid4().hex}.{extension.lstrip('.')}"
 
 
 def download_to_path(url: str, dest: Path) -> Path:

--- a/src/imagine_mcp/providers/gemini.py
+++ b/src/imagine_mcp/providers/gemini.py
@@ -4,14 +4,12 @@ from __future__ import annotations
 
 import base64
 import os
-import uuid
 from pathlib import Path
 from typing import Any
 
-import platformdirs
-
 from imagine_mcp.config import settings
 from imagine_mcp.errors import CredentialMissingError, ProviderAPIError
+from imagine_mcp.media import get_temp_media_path
 from imagine_mcp.models import get_model_id
 
 _CLIENT: Any = None
@@ -122,9 +120,7 @@ def understand_video(
     model = get_model_id("gemini", "understand", "video", tier)
 
     # Download video securely and upload to Gemini
-    tmp_dir = Path(platformdirs.user_cache_dir("imagine-mcp")) / "tmp"
-    tmp_dir.mkdir(parents=True, exist_ok=True)
-    tmp_path = tmp_dir / f"{uuid.uuid4().hex}.mp4"
+    tmp_path = get_temp_media_path(".mp4", sub_dir="tmp")
     download_to_path(url, tmp_path)
 
     try:
@@ -167,9 +163,6 @@ def understand_multimodal(
     parts: list[Any] = [prompt]
     tmp_files: list[Path] = []
 
-    tmp_dir = Path(platformdirs.user_cache_dir("imagine-mcp")) / "tmp"
-    tmp_dir.mkdir(parents=True, exist_ok=True)
-
     try:
         for i, u in enumerate(urls):
             # Performance optimization:
@@ -187,7 +180,7 @@ def understand_multimodal(
                     types.Part.from_bytes(data=img_data, mime_type="image/png")
                 )
             else:
-                tmp_path = tmp_dir / f"{uuid.uuid4().hex}.mp4"
+                tmp_path = get_temp_media_path(".mp4", sub_dir="tmp")
                 download_to_path(u, tmp_path)
                 tmp_files.append(tmp_path)
                 parts.append(client.files.upload(file=tmp_path))
@@ -246,9 +239,7 @@ def generate_image(
     if not image_data:
         raise ProviderAPIError("Gemini returned no image", status_code=500)
 
-    out_dir = Path(platformdirs.user_cache_dir("imagine-mcp")) / "generations"
-    out_dir.mkdir(parents=True, exist_ok=True)
-    out_path = out_dir / f"{uuid.uuid4().hex}.png"
+    out_path = get_temp_media_path(".png")
     out_path.write_bytes(image_data)
 
     return {
@@ -302,9 +293,7 @@ def generate_video(
         raise ProviderAPIError(f"Gemini job error: {op.error}", status_code=500)
 
     video = op.response.generated_videos[0]
-    out_dir = Path(platformdirs.user_cache_dir("imagine-mcp")) / "generations"
-    out_dir.mkdir(parents=True, exist_ok=True)
-    out_path = out_dir / f"{uuid.uuid4().hex}.mp4"
+    out_path = get_temp_media_path(".mp4")
     client.files.download(file=video.video)
     video.video.save(str(out_path))
 

--- a/src/imagine_mcp/providers/grok.py
+++ b/src/imagine_mcp/providers/grok.py
@@ -9,11 +9,7 @@ from __future__ import annotations
 import base64
 import os
 import urllib.parse
-import uuid
-from pathlib import Path
 from typing import Any
-
-import platformdirs
 
 from imagine_mcp.config import settings
 from imagine_mcp.errors import (
@@ -21,6 +17,7 @@ from imagine_mcp.errors import (
     ProviderAPIError,
     ProviderUnsupportedError,
 )
+from imagine_mcp.media import get_temp_media_path
 from imagine_mcp.models import get_model_id
 
 _CLIENT: Any = None
@@ -171,9 +168,7 @@ def generate_image(
         ).decode()
 
     img_bytes = base64.b64decode(img_b64)
-    out_dir = Path(platformdirs.user_cache_dir("imagine-mcp")) / "generations"
-    out_dir.mkdir(parents=True, exist_ok=True)
-    out_path = out_dir / f"{uuid.uuid4().hex}.png"
+    out_path = get_temp_media_path(".png")
     out_path.write_bytes(img_bytes)
 
     return {
@@ -275,9 +270,7 @@ def generate_video(
         .content
     )
 
-    out_dir = Path(platformdirs.user_cache_dir("imagine-mcp")) / "generations"
-    out_dir.mkdir(parents=True, exist_ok=True)
-    out_path = out_dir / f"{uuid.uuid4().hex}.mp4"
+    out_path = get_temp_media_path(".mp4")
     out_path.write_bytes(video_bytes)
 
     return {

--- a/src/imagine_mcp/providers/openai.py
+++ b/src/imagine_mcp/providers/openai.py
@@ -4,11 +4,7 @@ from __future__ import annotations
 
 import base64
 import os
-import uuid
-from pathlib import Path
 from typing import Any
-
-import platformdirs
 
 from imagine_mcp.config import settings
 from imagine_mcp.errors import (
@@ -16,6 +12,7 @@ from imagine_mcp.errors import (
     ProviderAPIError,
     ProviderUnsupportedError,
 )
+from imagine_mcp.media import get_temp_media_path
 from imagine_mcp.models import get_model_id
 
 _CLIENT: Any = None
@@ -148,9 +145,7 @@ def generate_image(
         raise ProviderAPIError("OpenAI returned no image", status_code=500)
     img_bytes = base64.b64decode(img_b64)
 
-    out_dir = Path(platformdirs.user_cache_dir("imagine-mcp")) / "generations"
-    out_dir.mkdir(parents=True, exist_ok=True)
-    out_path = out_dir / f"{uuid.uuid4().hex}.png"
+    out_path = get_temp_media_path(".png")
     out_path.write_bytes(img_bytes)
 
     return {

--- a/uv.lock
+++ b/uv.lock
@@ -549,7 +549,7 @@ wheels = [
 
 [[package]]
 name = "imagine-mcp"
-version = "1.5.0"
+version = "1.5.1"
 source = { editable = "." }
 dependencies = [
     { name = "diskcache" },


### PR DESCRIPTION
### [FIX] Duplicated UUID Path Generation for Media Cache

This PR addresses the duplication of UUID path generation logic across the `gemini`, `openai`, and `grok` providers.

**Changes:**
- Introduced `get_temp_media_path(extension: str, sub_dir: str = "generations")` in `src/imagine_mcp/media.py`.
- Refactored `gemini.py`, `openai.py`, and `grok.py` to use the new utility function.
- Removed redundant imports of `uuid` and `platformdirs` from the provider files.

**Verification:**
- Ran `ruff format` and `ruff check`.
- All tests passed: `tests/test_media.py`, `tests/test_providers_gemini.py`, `tests/test_providers_openai.py`, and `tests/test_providers_grok.py`.
- Verified the utility function with a dedicated temporary test script.

---
*PR created automatically by Jules for task [5159453041301792279](https://jules.google.com/task/5159453041301792279) started by @n24q02m*