### PR TITLE
fix: 🛡️ sentinel: implement Grok video status polling

### DIFF
--- a/src/imagine_mcp/providers/grok.py
+++ b/src/imagine_mcp/providers/grok.py
@@ -289,3 +289,13 @@ def generate_video(
         "provider": "grok",
         "tier": tier,
     }
+
+
+def edit(tier: str, image_url: str, prompt: str) -> dict[str, Any]:
+    """Proxy for generate_image with reference_image_url."""
+    return generate_image(prompt=prompt, tier=tier, reference_image_url=image_url)
+
+
+def video_status(tier: str, job_id: str) -> dict[str, Any]:
+    """Proxy for generate_video with job_id (polling)."""
+    return generate_video(prompt="", tier=tier, job_id=job_id)

--- a/tests/test_providers_grok.py
+++ b/tests/test_providers_grok.py
@@ -45,3 +45,42 @@ def test_understand_image_mocked(
     assert result["text"] == "a parrot"
     assert result["model"] == "grok-4.20-0309-reasoning"
     assert result["provider"] == "grok"
+
+
+def test_edit_proxies_to_generate_image(monkeypatch: pytest.MonkeyPatch) -> None:
+    calls = []
+
+    def mock_generate_image(prompt, tier, reference_image_url):
+        calls.append((prompt, tier, reference_image_url))
+        return {"status": "ok"}
+
+    monkeypatch.setattr(provider, "generate_image", mock_generate_image)
+
+    result = provider.edit(
+        tier="rich", image_url="https://example.com/img.png", prompt="make it blue"
+    )
+    assert result == {"status": "ok"}
+    assert calls == [("make it blue", "rich", "https://example.com/img.png")]
+
+
+def test_video_status_proxies_to_generate_video(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    calls = []
+
+    def mock_generate_video(
+        prompt,
+        tier,
+        reference_image_url=None,
+        job_id=None,
+        aspect_ratio="16:9",
+        duration_seconds=8,
+    ):
+        calls.append((prompt, tier, job_id))
+        return {"status": "pending"}
+
+    monkeypatch.setattr(provider, "generate_video", mock_generate_video)
+
+    result = provider.video_status(tier="poor", job_id="job-123")
+    assert result == {"status": "pending"}
+    assert calls == [("", "poor", "job-123")]

--- a/uv.lock
+++ b/uv.lock
@@ -549,7 +549,7 @@ wheels = [
 
 [[package]]
 name = "imagine-mcp"
-version = "1.5.0"
+version = "1.5.1"
 source = { editable = "." }
 dependencies = [
     { name = "diskcache" },


### PR DESCRIPTION
Implemented `edit` and `video_status` in `src/imagine_mcp/providers/grok.py`.
- `edit` proxies to `generate_image` with a mandatory `reference_image_url`.
- `video_status` proxies to `generate_video` for status polling via `job_id`.
Added unit tests in `tests/test_providers_grok.py` to verify the proxy logic.
Verified that all 160 project tests pass.

---
*PR created automatically by Jules for task [8841072145667573629](https://jules.google.com/task/8841072145667573629) started by @n24q02m*