### PR TITLE
fix: implement OpenAI dall-e-3 / gpt-image-1 for image generation

### DIFF
--- a/src/imagine_mcp/providers/openai.py
+++ b/src/imagine_mcp/providers/openai.py
@@ -126,8 +126,28 @@ def generate_image(
     aspect_ratio: str = "1:1",
 ) -> dict[str, Any]:
     model = get_model_id("openai", "generate", "image", tier)
-    size_map = {"1:1": "1024x1024", "16:9": "1792x1024", "9:16": "1024x1792"}
+    is_gpt_image = isinstance(model, str) and model.startswith("gpt-image-")
+
+    # Quality mapping: GPT uses low/high; DALL-E uses standard/hd.
+    if is_gpt_image:
+        quality = "low" if tier == "poor" else "high"
+        size_map = {"1:1": "1024x1024", "16:9": "1536x1024", "9:16": "1024x1536"}
+    else:
+        quality = "standard" if tier == "poor" else "hd"
+        size_map = {"1:1": "1024x1024", "16:9": "1792x1024", "9:16": "1024x1792"}
+
     size = size_map.get(aspect_ratio, "1024x1024")
+
+    kwargs: dict[str, Any] = {
+        "model": model,
+        "prompt": prompt,
+        "size": size,
+        "quality": quality,
+    }
+
+    # GPT image models only support b64_json and may error if response_format is passed.
+    if not is_gpt_image:
+        kwargs["response_format"] = "b64_json"
 
     if reference_image_url:
         from imagine_mcp.media import get_ssrf_safe_client
@@ -137,16 +157,27 @@ def generate_image(
             .get(reference_image_url, follow_redirects=True, timeout=60)
             .content
         )
-        resp = _client().images.edit(
-            model=model, image=img_bytes, prompt=prompt, size=size
-        )
+        kwargs["image"] = img_bytes
+        resp = _client().images.edit(**kwargs)
     else:
-        resp = _client().images.generate(model=model, prompt=prompt, size=size, n=1)
+        kwargs["n"] = 1
+        resp = _client().images.generate(**kwargs)
 
     img_b64 = resp.data[0].b64_json
     if not img_b64:
-        raise ProviderAPIError("OpenAI returned no image", status_code=500)
-    img_bytes = base64.b64decode(img_b64)
+        img_url = resp.data[0].url
+        if not img_url:
+            raise ProviderAPIError("OpenAI returned no image data", status_code=500)
+        from imagine_mcp.media import get_ssrf_safe_client
+
+        img_bytes = (
+            get_ssrf_safe_client()
+            .get(img_url, follow_redirects=True, timeout=60)
+            .content
+        )
+        img_b64 = base64.b64encode(img_bytes).decode()
+    else:
+        img_bytes = base64.b64decode(img_b64)
 
     out_dir = Path(platformdirs.user_cache_dir("imagine-mcp")) / "generations"
     out_dir.mkdir(parents=True, exist_ok=True)

--- a/tests/test_providers_openai.py
+++ b/tests/test_providers_openai.py
@@ -44,3 +44,102 @@ def test_understand_image_mocked(
     assert result["text"] == "a dog"
     assert result["model"] == "gpt-5.4-mini"
     assert result["provider"] == "openai"
+
+
+def test_generate_image_gpt_poor(monkeypatch: pytest.MonkeyPatch) -> None:
+    fake_client = MagicMock()
+    fake_response = MagicMock()
+    fake_response.data = [MagicMock(b64_json="ZmFrZS1iNjQtZGF0YQ==")]  # "fake-b64-data"
+    fake_client.images.generate.return_value = fake_response
+    monkeypatch.setattr(provider, "_client", lambda: fake_client)
+
+    # Mock get_model_id to return a GPT model
+    monkeypatch.setattr(
+        "imagine_mcp.providers.openai.get_model_id",
+        lambda p, a, m, t: "gpt-image-1-mini",
+    )
+
+    result = provider.generate_image(prompt="a cat", tier="poor", aspect_ratio="1:1")
+
+    fake_client.images.generate.assert_called_once_with(
+        model="gpt-image-1-mini",
+        prompt="a cat",
+        size="1024x1024",
+        quality="low",
+        n=1,
+    )
+    assert result["image_base64"] == "ZmFrZS1iNjQtZGF0YQ=="
+
+
+def test_generate_image_gpt_rich_16_9(monkeypatch: pytest.MonkeyPatch) -> None:
+    fake_client = MagicMock()
+    fake_response = MagicMock()
+    fake_response.data = [MagicMock(b64_json="ZmFrZS1iNjQtZGF0YQ==")]
+    fake_client.images.generate.return_value = fake_response
+    monkeypatch.setattr(provider, "_client", lambda: fake_client)
+
+    monkeypatch.setattr(
+        "imagine_mcp.providers.openai.get_model_id", lambda p, a, m, t: "gpt-image-1.5"
+    )
+
+    provider.generate_image(prompt="a dog", tier="rich", aspect_ratio="16:9")
+
+    fake_client.images.generate.assert_called_once_with(
+        model="gpt-image-1.5",
+        prompt="a dog",
+        size="1536x1024",
+        quality="high",
+        n=1,
+    )
+
+
+def test_generate_image_dalle_rich_16_9(monkeypatch: pytest.MonkeyPatch) -> None:
+    fake_client = MagicMock()
+    fake_response = MagicMock()
+    fake_response.data = [MagicMock(b64_json="ZmFrZS1iNjQtZGF0YQ==")]
+    fake_client.images.generate.return_value = fake_response
+    monkeypatch.setattr(provider, "_client", lambda: fake_client)
+
+    monkeypatch.setattr(
+        "imagine_mcp.providers.openai.get_model_id", lambda p, a, m, t: "dall-e-3"
+    )
+
+    provider.generate_image(prompt="a bird", tier="rich", aspect_ratio="16:9")
+
+    fake_client.images.generate.assert_called_once_with(
+        model="dall-e-3",
+        prompt="a bird",
+        size="1792x1024",
+        quality="hd",
+        response_format="b64_json",
+        n=1,
+    )
+
+
+def test_generate_image_gpt_edit(
+    mock_media_fetch: None, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    fake_client = MagicMock()
+    fake_response = MagicMock()
+    fake_response.data = [MagicMock(b64_json="ZmFrZS1iNjQtZGF0YQ==")]
+    fake_client.images.edit.return_value = fake_response
+    monkeypatch.setattr(provider, "_client", lambda: fake_client)
+
+    monkeypatch.setattr(
+        "imagine_mcp.providers.openai.get_model_id", lambda p, a, m, t: "gpt-image-1.5"
+    )
+
+    provider.generate_image(
+        prompt="make it blue",
+        tier="rich",
+        reference_image_url="https://example.com/img.png",
+        aspect_ratio="9:16",
+    )
+
+    fake_client.images.edit.assert_called_once_with(
+        model="gpt-image-1.5",
+        image=b"fake-image-bytes",
+        prompt="make it blue",
+        size="1024x1536",
+        quality="high",
+    )

--- a/uv.lock
+++ b/uv.lock
@@ -549,7 +549,7 @@ wheels = [
 
 [[package]]
 name = "imagine-mcp"
-version = "1.5.0"
+version = "1.5.1"
 source = { editable = "." }
 dependencies = [
     { name = "diskcache" },


### PR DESCRIPTION
This PR implements full support for OpenAI's GPT image models and DALL-E 3. It correctly maps the quality tiers ('low', 'high' for GPT; 'standard', 'hd' for DALL-E) and optimizes sizes for different aspect ratios. It also ensures 'response_format' is only passed when supported (non-GPT models) and adds a fallback for URL-based responses. Comprehensive tests have been added to verify these mappings.

---
*PR created automatically by Jules for task [17432188633835427854](https://jules.google.com/task/17432188633835427854) started by @n24q02m*