### PR TITLE
fix: implement Gemini image edit capabilities

### DIFF
--- a/src/imagine_mcp/providers/gemini.py
+++ b/src/imagine_mcp/providers/gemini.py
@@ -316,3 +316,13 @@ def generate_video(
         "provider": "gemini",
         "tier": tier,
     }
+
+
+def edit(tier: str, image_url: str, prompt: str) -> dict[str, Any]:
+    """Edit image proxy (uses generate_image with reference_image_url)."""
+    return generate_image(prompt=prompt, tier=tier, reference_image_url=image_url)
+
+
+def video_status(tier: str, job_id: str) -> dict[str, Any]:
+    """Video status proxy (uses generate_video with job_id)."""
+    return generate_video(prompt="", tier=tier, job_id=job_id)

--- a/tests/test_providers_gemini.py
+++ b/tests/test_providers_gemini.py
@@ -72,3 +72,36 @@ def test_understand_image_live() -> None:
         tier="poor",
     )
     assert "cat" in result["text"].lower()
+
+
+def test_edit_proxy(mock_media_fetch: None, monkeypatch: pytest.MonkeyPatch) -> None:
+    fake_client = MagicMock()
+    # Mocking response from generate_content (called by generate_image)
+    fake_response = MagicMock()
+    fake_response.candidates = [MagicMock()]
+    fake_response.candidates[0].content.parts = [MagicMock()]
+    fake_response.candidates[0].content.parts[
+        0
+    ].inline_data.data = b"fake-edited-image-bytes"
+    fake_client.models.generate_content.return_value = fake_response
+    monkeypatch.setattr(gemini, "_client", lambda: fake_client)
+
+    result = gemini.edit(
+        tier="poor", image_url="https://example.com/input.png", prompt="make it blue"
+    )
+    assert result["provider"] == "gemini"
+    assert "image_path" in result
+    assert result["image_base64"] is not None
+
+
+def test_video_status_proxy(monkeypatch: pytest.MonkeyPatch) -> None:
+    fake_client = MagicMock()
+    # Mocking response from operations.get (called by generate_video)
+    fake_op = MagicMock()
+    fake_op.done = False
+    fake_client.operations.get.return_value = fake_op
+    monkeypatch.setattr(gemini, "_client", lambda: fake_client)
+
+    result = gemini.video_status(tier="poor", job_id="job-123")
+    assert result["job_id"] == "job-123"
+    assert result["status"] == "pending"

--- a/uv.lock
+++ b/uv.lock
@@ -549,7 +549,7 @@ wheels = [
 
 [[package]]
 name = "imagine-mcp"
-version = "1.5.0"
+version = "1.5.1"
 source = { editable = "." }
 dependencies = [
     { name = "diskcache" },


### PR DESCRIPTION
This PR implements the missing `edit` and `video_status` capabilities for the Gemini provider.

### Changes:
- **`src/imagine_mcp/providers/gemini.py`**:
    - Implemented `edit(tier, image_url, prompt)` as a proxy to `generate_image`.
    - Implemented `video_status(tier, job_id)` as a proxy to `generate_video`.
- **`tests/test_providers_gemini.py`**:
    - Added `test_edit_proxy` and `test_video_status_proxy` to verify the new functions.

### Rationale:
The Gemini provider already supported image-to-image generation via `generate_image` using the `generate_content` API with multimodal models. By adding these proxy functions, we align the provider's interface with expectations and provide clear entry points for editing and status polling.

Verified with 160 passing tests.

---
*PR created automatically by Jules for task [12522868542306172788](https://jules.google.com/task/12522868542306172788) started by @n24q02m*