### PR TITLE
fix: implement openai image edit capabilities

### DIFF
--- a/src/imagine_mcp/providers/openai.py
+++ b/src/imagine_mcp/providers/openai.py
@@ -24,6 +24,49 @@ _CLIENT: Any = None
 _SUB_CLIENTS: dict[str, Any] = {}
 
 
+def edit(tier: str, image_url: str, prompt: str) -> dict[str, Any]:
+    """OpenAI image edit (DALL-E 2)."""
+    from imagine_mcp.media import get_ssrf_safe_client
+
+    img_bytes = (
+        get_ssrf_safe_client().get(image_url, follow_redirects=True, timeout=60).content
+    )
+
+    # DALL-E 2 is the primary model for SDK edit() calls
+    model = "dall-e-2"
+    resp = _client().images.edit(
+        model=model,
+        image=img_bytes,
+        prompt=prompt,
+        n=1,
+        size="1024x1024",
+        response_format="b64_json",
+    )
+
+    img_b64 = resp.data[0].b64_json
+    if not img_b64:
+        raise ProviderAPIError("OpenAI returned no image", status_code=500)
+    img_bytes_out = base64.b64decode(img_b64)
+
+    out_dir = Path(platformdirs.user_cache_dir("imagine-mcp")) / "generations"
+    out_dir.mkdir(parents=True, exist_ok=True)
+    out_path = out_dir / f"{uuid.uuid4().hex}.png"
+    out_path.write_bytes(img_bytes_out)
+
+    return {
+        "image_path": str(out_path),
+        "image_base64": img_b64,
+        "model": model,
+        "provider": "openai",
+        "tier": tier,
+    }
+
+
+def video_status(tier: str, job_id: str) -> dict[str, Any]:
+    """OpenAI video status (unsupported)."""
+    return generate_video("", tier, job_id=job_id)
+
+
 def _resolve_api_key() -> str | None:
     """Return OPENAI_API_KEY for the current request scope (per-sub or env)."""
     from imagine_mcp.credential_state import (
@@ -125,23 +168,14 @@ def generate_image(
     reference_image_url: str | None = None,
     aspect_ratio: str = "1:1",
 ) -> dict[str, Any]:
+    if reference_image_url:
+        return edit(tier, reference_image_url, prompt)
+
     model = get_model_id("openai", "generate", "image", tier)
     size_map = {"1:1": "1024x1024", "16:9": "1792x1024", "9:16": "1024x1792"}
     size = size_map.get(aspect_ratio, "1024x1024")
 
-    if reference_image_url:
-        from imagine_mcp.media import get_ssrf_safe_client
-
-        img_bytes = (
-            get_ssrf_safe_client()
-            .get(reference_image_url, follow_redirects=True, timeout=60)
-            .content
-        )
-        resp = _client().images.edit(
-            model=model, image=img_bytes, prompt=prompt, size=size
-        )
-    else:
-        resp = _client().images.generate(model=model, prompt=prompt, size=size, n=1)
+    resp = _client().images.generate(model=model, prompt=prompt, size=size, n=1)
 
     img_b64 = resp.data[0].b64_json
     if not img_b64:

--- a/tests/test_providers_openai.py
+++ b/tests/test_providers_openai.py
@@ -31,6 +31,48 @@ def test_generate_video_raises() -> None:
         provider.generate_video("a dog", "poor")
 
 
+def test_video_status_raises() -> None:
+    with pytest.raises(ProviderUnsupportedError):
+        provider.video_status("poor", "job_123")
+
+
+def test_edit_mocked(mock_media_fetch: None, monkeypatch: pytest.MonkeyPatch) -> None:
+    fake = MagicMock()
+    # Mock images.edit response
+    mock_image = MagicMock()
+    mock_image.b64_json = "ZmFrZS1pbWFnZS1ieXRlcw=="  # "fake-image-bytes" in base64
+    fake.images.edit.return_value = MagicMock(data=[mock_image])
+    monkeypatch.setattr(provider, "_client", lambda: fake)
+
+    result = provider.edit(
+        tier="poor", image_url="https://example.com/cat.png", prompt="make it blue"
+    )
+    assert "generations" in result["image_path"]
+    assert result["image_base64"] == "ZmFrZS1pbWFnZS1ieXRlcw=="
+    assert result["model"] == "dall-e-2"
+    assert result["provider"] == "openai"
+
+
+def test_generate_image_delegates_to_edit(
+    mock_media_fetch: None, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    fake = MagicMock()
+    # Mock images.edit response
+    mock_image = MagicMock()
+    mock_image.b64_json = "ZmFrZS1pbWFnZS1ieXRlcw=="
+    fake.images.edit.return_value = MagicMock(data=[mock_image])
+    monkeypatch.setattr(provider, "_client", lambda: fake)
+
+    # Calling generate_image with reference_image_url should trigger edit
+    result = provider.generate_image(
+        prompt="make it blue",
+        tier="poor",
+        reference_image_url="https://example.com/cat.png",
+    )
+    assert result["model"] == "dall-e-2"
+    assert result["provider"] == "openai"
+
+
 def test_understand_image_mocked(
     mock_media_fetch: None, monkeypatch: pytest.MonkeyPatch
 ) -> None:

--- a/uv.lock
+++ b/uv.lock
@@ -549,7 +549,7 @@ wheels = [
 
 [[package]]
 name = "imagine-mcp"
-version = "1.5.0"
+version = "1.5.1"
 source = { editable = "." }
 dependencies = [
     { name = "diskcache" },


### PR DESCRIPTION
Implemented OpenAI image edit capabilities in the OpenAI provider.

Key changes:
- Added `edit` function to `src/imagine_mcp/providers/openai.py` which uses the `dall-e-2` model for image editing.
- Added `video_status` function to `src/imagine_mcp/providers/openai.py` (OpenAI does not support video, so it correctly raises `ProviderUnsupportedError` via `generate_video`).
- Refactored `generate_image` to delegate to `edit` when a `reference_image_url` is provided.
- Added unit tests in `tests/test_providers_openai.py` to verify the new `edit` and `video_status` functions and ensure proper delegation in `generate_image`.
- Ensured SSRF safety by using the centralized `get_ssrf_safe_client()` for image downloads.

All tests passed and code is formatted.

---
*PR created automatically by Jules for task [2527790136568791137](https://jules.google.com/task/2527790136568791137) started by @n24q02m*