### PR TITLE
fix: sync docs to current code

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,11 +13,11 @@ Production-grade MCP server for image/video understanding and generation across 
 
 ```python
 understand(media_urls: list[str], prompt: str,
-           provider: str = "gemini", tier: str = "poor",
+           provider: str | None = None, tier: str = "poor",
            max_tokens: int = 2048) -> dict
 
 generate(media_type: Literal["image", "video"], prompt: str,
-         provider: str = "gemini", tier: str = "poor",
+         provider: str | None = None, tier: str = "poor",
          reference_image_url: str | None = None,
          job_id: str | None = None,
          output_mode: Literal["base64", "path", "both"] = "both",
@@ -63,7 +63,7 @@ For the authoritative leaderboard-sorted table see [`docs/models.md`](docs/model
 
 3 API keys (all optional — server runs in degraded mode with missing creds):
 
-- `GOOGLE_AI_STUDIO_API_KEY`
+- `GEMINI_API_KEY`
 - `OPENAI_API_KEY`
 - `XAI_API_KEY`
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,11 +13,11 @@ Production-grade MCP server for image/video understanding and generation across 
 
 ```python
 understand(media_urls: list[str], prompt: str,
-           provider: str = "gemini", tier: str = "poor",
+           provider: str | None = None, tier: str = "poor",
            max_tokens: int = 2048) -> dict
 
 generate(media_type: Literal["image", "video"], prompt: str,
-         provider: str = "gemini", tier: str = "poor",
+         provider: str | None = None, tier: str = "poor",
          reference_image_url: str | None = None,
          job_id: str | None = None,
          output_mode: Literal["base64", "path", "both"] = "both",

--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ mcp-name: io.github.n24q02m/imagine-mcp
 >
 > Past months saw significant churn around credential handling and the daemon-bridge auto-spawn pattern. This caused multi-process races, browser tab spam, and inconsistent setup UX across plugins. **As of v<auto>, the architecture is stable**: 2 clean modes (stdio + HTTP), no daemon-bridge layer, no auto-spawn from stdio.
 >
-> Apologies for the instability period. If you encountered issues with prior versions, please update to v<auto>+ and follow the current `docs/setup-manual.md` -- most prior workarounds are no longer needed.
+> Apologies for the instability period. If you encountered issues with prior versions, please update to v<auto>+ and follow the current [Setup docs](https://mcp.n24q02m.com/servers/imagine-mcp/setup/) -- most prior workarounds are no longer needed.
 >
 > **Related plugins from the same author**:
 > - [wet-mcp](https://github.com/n24q02m/wet-mcp) -- Web search + content extraction


### PR DESCRIPTION
Docs-only. Each change traced to a verified code file:line.

| doc file:line | claimed | actual (code) | fix |
|---|---|---|---|
| README.md:80 | link `docs/setup-manual.md` | file deleted in 6f1f748 (consolidated to mcp.n24q02m.com) | point to hosted Setup URL (README:97) |
| CLAUDE.md:14 | `understand(provider: str = "gemini")` | `provider: str \| None = None` (server.py:118; auto-fallback dispatcher.py:71) | default None |
| CLAUDE.md:22 | `generate(provider: str = "gemini")` | `provider: str \| None = None` (server.py:139) | default None |
| AGENTS.md:16 | `understand(provider: str = "gemini")` | `provider: str \| None = None` (server.py:118) | default None |
| AGENTS.md:20 | `generate(provider: str = "gemini")` | `provider: str \| None = None` (server.py:139) | default None |
| AGENTS.md:66 | `GOOGLE_AI_STUDIO_API_KEY` | code reads `GEMINI_API_KEY` (config.py:22; renamed 2026-04-26) | rename to GEMINI_API_KEY |

No code changes. plugin.json untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)