### PR TITLE
fix: detect real image mime type for Gemini vision

### DIFF
--- a/src/imagine_mcp/media.py
+++ b/src/imagine_mcp/media.py
@@ -28,6 +28,50 @@ _VIDEO_EXT = {".mp4", ".webm", ".mov", ".avi", ".mkv", ".flv", ".m4v"}
 _IMAGE_MIME_PREFIX = "image/"
 _VIDEO_MIME_PREFIX = "video/"
 
+# Most image hosts serve JPEG, so it is the safest fallback when neither the
+# Content-Type header nor the magic bytes identify the format.
+_IMAGE_FALLBACK_MIME = "image/jpeg"
+
+
+def sniff_image_mime(data: bytes) -> str | None:
+    """Return an ``image/*`` mime type by sniffing magic bytes, or None.
+
+    Recognizes PNG, JPEG, WEBP, GIF, and the HEIC/HEIF ISO-BMFF families.
+    """
+    if data.startswith(b"\x89PNG"):
+        return "image/png"
+    if data.startswith(b"\xff\xd8\xff"):
+        return "image/jpeg"
+    if data.startswith(b"RIFF") and data[8:12] == b"WEBP":
+        return "image/webp"
+    if data.startswith(b"GIF8"):
+        return "image/gif"
+    # HEIC/HEIF: ISO-BMFF box with an ``ftyp`` brand at offset 4.
+    if data[4:8] == b"ftyp":
+        brand = data[8:12]
+        if brand in (b"heic", b"heix", b"hevc", b"hevx"):
+            return "image/heic"
+        if brand in (b"heif", b"mif1", b"msf1"):
+            return "image/heif"
+    return None
+
+
+def resolve_image_mime(content_type: str | None, data: bytes) -> str:
+    """Resolve the mime type for fetched image bytes.
+
+    Precedence: a real ``image/*`` Content-Type header (params stripped,
+    lowercased) wins; otherwise magic-byte sniffing; otherwise the JPEG
+    fallback (the most common web image format).
+    """
+    if content_type:
+        ctype = content_type.split(";", 1)[0].strip().lower()
+        if ctype.startswith(_IMAGE_MIME_PREFIX):
+            return ctype
+    sniffed = sniff_image_mime(data)
+    if sniffed is not None:
+        return sniffed
+    return _IMAGE_FALLBACK_MIME
+
 
 class SSRFSafeTransport(httpx.HTTPTransport):
     """Custom transport that implements DNS pinning to prevent TOCTOU SSRF.

--- a/src/imagine_mcp/providers/gemini.py
+++ b/src/imagine_mcp/providers/gemini.py
@@ -85,21 +85,21 @@ def understand_image(
 ) -> dict[str, Any]:
     from google.genai import types
 
-    from imagine_mcp.media import get_ssrf_safe_client
+    from imagine_mcp.media import get_ssrf_safe_client, resolve_image_mime
 
     client = _client()
     model = get_model_id("gemini", "understand", "image", tier)
 
     # Download image securely to prevent backend SSRF
-    img_data = (
-        get_ssrf_safe_client().get(url, follow_redirects=True, timeout=60).content
-    )
+    img_resp = get_ssrf_safe_client().get(url, follow_redirects=True, timeout=60)
+    img_data = img_resp.content
+    mime_type = resolve_image_mime(img_resp.headers.get("content-type"), img_data)
 
     resp = client.models.generate_content(
         model=model,
         contents=[
             prompt,
-            types.Part.from_bytes(data=img_data, mime_type="image/png"),
+            types.Part.from_bytes(data=img_data, mime_type=mime_type),
         ],
         config=types.GenerateContentConfig(max_output_tokens=max_tokens),
     )
@@ -160,6 +160,7 @@ def understand_multimodal(
         detect_media_type,
         download_to_path,
         get_ssrf_safe_client,
+        resolve_image_mime,
     )
 
     client = _client()
@@ -178,14 +179,14 @@ def understand_multimodal(
             # converting the latency to O(1) bounded by the dispatcher's thread pool.
             mt = media_types[i] if media_types else detect_media_type(u)
             if mt == "image":
-                img_data = (
-                    get_ssrf_safe_client()
-                    .get(u, follow_redirects=True, timeout=60)
-                    .content
+                img_resp = get_ssrf_safe_client().get(
+                    u, follow_redirects=True, timeout=60
                 )
-                parts.append(
-                    types.Part.from_bytes(data=img_data, mime_type="image/png")
+                img_data = img_resp.content
+                mime_type = resolve_image_mime(
+                    img_resp.headers.get("content-type"), img_data
                 )
+                parts.append(types.Part.from_bytes(data=img_data, mime_type=mime_type))
             else:
                 tmp_path = tmp_dir / f"{uuid.uuid4().hex}.mp4"
                 download_to_path(u, tmp_path)
@@ -219,19 +220,19 @@ def generate_image(
 ) -> dict[str, Any]:
     from google.genai import types
 
-    from imagine_mcp.media import get_ssrf_safe_client
+    from imagine_mcp.media import get_ssrf_safe_client, resolve_image_mime
 
     client = _client()
     model = get_model_id("gemini", "generate", "image", tier)
     contents: list[Any] = [prompt]
 
     if reference_image_url:
-        img_data = (
-            get_ssrf_safe_client()
-            .get(reference_image_url, follow_redirects=True, timeout=60)
-            .content
+        img_resp = get_ssrf_safe_client().get(
+            reference_image_url, follow_redirects=True, timeout=60
         )
-        contents.append(types.Part.from_bytes(data=img_data, mime_type="image/png"))
+        img_data = img_resp.content
+        mime_type = resolve_image_mime(img_resp.headers.get("content-type"), img_data)
+        contents.append(types.Part.from_bytes(data=img_data, mime_type=mime_type))
 
     resp = client.models.generate_content(
         model=model,

--- a/tests/test_media.py
+++ b/tests/test_media.py
@@ -5,7 +5,48 @@ from unittest.mock import MagicMock
 import pytest
 
 from imagine_mcp.errors import MediaDetectError
-from imagine_mcp.media import _extract_extension, detect_media_type
+from imagine_mcp.media import (
+    _extract_extension,
+    detect_media_type,
+    resolve_image_mime,
+    sniff_image_mime,
+)
+
+_PNG = b"\x89PNG\r\n\x1a\n" + b"\x00" * 16
+_JPEG = b"\xff\xd8\xff\xe0\x00\x10JFIF" + b"\x00" * 16
+_WEBP = b"RIFF\x24\x00\x00\x00WEBPVP8 " + b"\x00" * 16
+_GIF = b"GIF89a" + b"\x00" * 16
+_HEIC = b"\x00\x00\x00\x18ftypheic\x00\x00\x00\x00" + b"\x00" * 8
+_HEIF = b"\x00\x00\x00\x18ftypmif1\x00\x00\x00\x00" + b"\x00" * 8
+
+
+def test_sniff_image_mime_magic_bytes() -> None:
+    assert sniff_image_mime(_PNG) == "image/png"
+    assert sniff_image_mime(_JPEG) == "image/jpeg"
+    assert sniff_image_mime(_WEBP) == "image/webp"
+    assert sniff_image_mime(_GIF) == "image/gif"
+    assert sniff_image_mime(_HEIC) == "image/heic"
+    assert sniff_image_mime(_HEIF) == "image/heif"
+    assert sniff_image_mime(b"not-an-image") is None
+
+
+def test_resolve_image_mime_content_type_precedence() -> None:
+    # Real image/* Content-Type wins even when bytes say PNG.
+    assert resolve_image_mime("image/jpeg", _PNG) == "image/jpeg"
+    # Params stripped and lowercased.
+    assert resolve_image_mime("Image/WEBP; charset=binary", _PNG) == "image/webp"
+
+
+def test_resolve_image_mime_sniff_when_header_unhelpful() -> None:
+    # Non-image Content-Type falls through to magic-byte sniffing.
+    assert resolve_image_mime("application/octet-stream", _JPEG) == "image/jpeg"
+    assert resolve_image_mime(None, _GIF) == "image/gif"
+    assert resolve_image_mime("", _WEBP) == "image/webp"
+
+
+def test_resolve_image_mime_unknown_falls_back_to_jpeg() -> None:
+    assert resolve_image_mime(None, b"garbage-bytes") == "image/jpeg"
+    assert resolve_image_mime("text/html", b"\x00\x01\x02\x03") == "image/jpeg"
 
 
 def test_detect_by_extension_image() -> None:


### PR DESCRIPTION
## Problem (Test B caught)

The Gemini vision path (the DEFAULT provider) rejected every non-PNG image with `400 Invalid base64-encoded image`.

## Root cause

`src/imagine_mcp/providers/gemini.py` passed downloaded image bytes to the Gemini SDK with a hardcoded `mime_type="image/png"` at all three `from_bytes(...)` sites that handle externally-fetched images:

- `understand_image`
- `understand_multimodal`
- `generate_image` (reference image)

When a URL served JPEG/WEBP/GIF/etc (very common), Gemini received raw bytes mislabeled as PNG and its decoder failed.

## Fix

Add `resolve_image_mime(content_type, data)` in `media.py`:

1. Prefer a real `image/*` Content-Type header (params stripped, lowercased).
2. Else magic-byte sniff: PNG / JPEG / WEBP / GIF / HEIC / HEIF.
3. Else fall back to `image/jpeg` (most common web image format).

Applied to all three externally-fetched-image sites. `understand_image` now captures the response object to read its Content-Type header. Generated-output writes stay `png`. No control-flow change beyond mime resolution.

## Test

New unit tests in `tests/test_media.py` cover magic-byte detection, Content-Type precedence, sniff fallback, and unknown -> jpeg fallback. No real Gemini call needed.

`uv run pytest -q` (166 passed), `uv run ruff check .`, `uv run ty check` all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)