### PR TITLE
perf: ⚡ bolt: optimize merge_ranks with dictionary lookups

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -16,3 +16,7 @@
 ## 2026-05-27 - Request-Scoped ContextVar Caching for I/O Heavy Credentials
 **Learning:** In a multi-user HTTP architecture where credentials are encrypted and stored per user (sub), resolving credentials via `PerPluginStore.load()` triggered expensive file reads, AES-GCM decryption, and JSON parsing on *every* API lookup (e.g. `_default_provider`, `_api_key`). Caching this lookup on a per-request basis using `contextvars.ContextVar` eliminates these redundant operations. However, because `ContextVar` instances inherit state in sequentially executed asyncio test tasks (running in the same OS thread), the cache must be explicitly reset using an `autouse=True` fixture in `conftest.py` to prevent state leakage and isolated test failures.
 **Action:** Use `contextvars.ContextVar` for request-scoped caching to eliminate redundant disk/crypto operations per API request. When doing so, always ensure test suites have an `autouse` fixture to manually reset the contextvar to maintain test isolation.
+
+## 2024-05-18 - Optimize merge_ranks list comprehensions
+**Learning:** `merge_ranks` in `scripts/fetch_leaderboards.py` used nested list comprehensions to find matching model ranks, yielding an O(N²) time complexity. Pre-computing lookup dictionaries for ranks reduces this process to an O(N) complexity for dictionary lookups inside a single loop iteration.
+**Action:** Replace nested loops that search for matching elements in lists with single loops utilizing pre-computed O(1) dictionary lookups.

--- a/scripts/fetch_leaderboards.py
+++ b/scripts/fetch_leaderboards.py
@@ -215,12 +215,18 @@ def merge_ranks(rows_aa: list[LBRow], rows_lmarena: list[LBRow]) -> dict[str, in
     """Return {canonical_model_id: quality_rank} using min(rank_aa, rank_lmarena)."""
     result: dict[str, int] = {}
     all_ids = {r.model_id for r in rows_aa} | {r.model_id for r in rows_lmarena}
+
+    # O(N) lookup dictionaries
+    aa_ranks = {r.model_id: r.rank for r in rows_aa}
+    lm_ranks = {r.model_id: r.rank for r in rows_lmarena}
+
     for model_id in all_ids:
         ranks: list[int] = []
-        for rows in (rows_aa, rows_lmarena):
-            match = next((r for r in rows if r.model_id == model_id), None)
-            if match:
-                ranks.append(match.rank)
+        if model_id in aa_ranks:
+            ranks.append(aa_ranks[model_id])
+        if model_id in lm_ranks:
+            ranks.append(lm_ranks[model_id])
+
         result[model_id] = min(ranks) if ranks else 999
     return result
 

--- a/uv.lock
+++ b/uv.lock
@@ -549,7 +549,7 @@ wheels = [
 
 [[package]]
 name = "imagine-mcp"
-version = "1.5.4b2"
+version = "1.5.4"
 source = { editable = "." }
 dependencies = [
     { name = "diskcache" },


### PR DESCRIPTION
💡 **What**: The nested list comprehension used in `scripts/fetch_leaderboards.py` for matching model ranks has been replaced with dictionary-based lookup approach.

🎯 **Why**: The nested list logic was resulting in O(N²) time complexity. Optimizing it via dictionaries reduces the lookup time to O(1), minimizing the overall operation complexity to O(N).

📊 **Impact**: Faster execution when merging rank data from multiple leaderboard sources. 

🔬 **Measurement**: Verified the change passed formatting (`uv run ruff format .`), linting (`uv run ruff check .`), and testing (`uv run pytest tests/`).

---
*PR created automatically by Jules for task [5217516902592585760](https://jules.google.com/task/5217516902592585760) started by @n24q02m*