### PR TITLE
fix: add caching for repeated markdown documentation file reads

### DIFF
--- a/src/imagine_mcp/server.py
+++ b/src/imagine_mcp/server.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import os
+from functools import cache
 from importlib.resources import files
 from pathlib import Path
 from typing import Any, Literal
@@ -92,6 +93,13 @@ def _set_runtime(key: str | None, value: str | None) -> dict[str, Any]:
         "status": "ok",
         "message": f"Set {key}={value} (runtime only; persistent via mcp-core).",
     }
+
+
+@cache
+def _get_help_content(topic: str) -> str:
+    """Read markdown documentation file from package resources."""
+    doc_file = files("imagine_mcp.docs").joinpath(f"{topic}.md")
+    return doc_file.read_text(encoding="utf-8")
 
 
 def build_app() -> FastMCP:
@@ -258,8 +266,7 @@ def build_app() -> FastMCP:
         """Load documentation for a specific tool or topic."""
         if topic not in VALID_HELP_TOPICS:
             return f"Unknown topic {topic!r}. Valid: {sorted(VALID_HELP_TOPICS)}"
-        doc_file = files("imagine_mcp.docs").joinpath(f"{topic}.md")
-        return doc_file.read_text(encoding="utf-8")
+        return _get_help_content(topic)
 
     # mcp-core >=1.13: register_open_relay_tool takes public_url (str | None).
     # In stdio mode PUBLIC_URL is unset → tool returns ``stdio_unsupported``.

--- a/tests/test_help_caching.py
+++ b/tests/test_help_caching.py
@@ -1,0 +1,35 @@
+import asyncio
+from unittest.mock import MagicMock, patch
+
+from imagine_mcp.server import _get_help_content, build_app
+
+
+def test_help_caching():
+    # Clear cache if it exists (for repeated test runs in same process, though unlikely here)
+    _get_help_content.cache_clear()
+
+    with patch("imagine_mcp.server.files") as mock_files:
+        mock_path = MagicMock()
+        mock_path.joinpath.return_value.read_text.return_value = "cached content"
+        mock_files.return_value = mock_path
+
+        app = build_app()
+
+        # Call help twice
+        # FastMCP tools can be called directly if we find them
+        help_tool = None
+        for tool in asyncio.run(app.list_tools()):
+            if tool.name == "help":
+                help_tool = tool.fn
+                break
+
+        assert help_tool is not None
+
+        res1 = help_tool("understand")
+        res2 = help_tool("understand")
+
+        assert res1 == "cached content"
+        assert res2 == "cached content"
+
+        # Verify read_text was called only once due to caching
+        assert mock_path.joinpath.return_value.read_text.call_count == 1

--- a/uv.lock
+++ b/uv.lock
@@ -549,7 +549,7 @@ wheels = [
 
 [[package]]
 name = "imagine-mcp"
-version = "1.5.4b2"
+version = "1.5.4"
 source = { editable = "." }
 dependencies = [
     { name = "diskcache" },


### PR DESCRIPTION
Reading a static markdown file synchronously on every call is inefficient. This change adds caching using `functools.cache` to the documentation reading logic in `src/imagine_mcp/server.py`. 

Key changes:
- Imported `cache` from `functools` in `src/imagine_mcp/server.py`.
- Extracted documentation reading logic into a cached `_get_help_content` function.
- Updated the `help` tool to use `_get_help_content`.
- Added `tests/test_help_caching.py` to verify caching functionality and ensure no regressions.

---
*PR created automatically by Jules for task [3566398841532309234](https://jules.google.com/task/3566398841532309234) started by @n24q02m*