### PR TITLE
[FIX] Long function: generate_video

### DIFF
--- a/src/imagine_mcp/providers/grok.py
+++ b/src/imagine_mcp/providers/grok.py
@@ -197,44 +197,78 @@ def generate_video(
     headers = {"Authorization": f"Bearer {_api_key()}"}
 
     if job_id is None:
-        payload: dict[str, Any] = {
-            "model": model,
-            "prompt": prompt,
-            "duration_seconds": duration_seconds,
-            "aspect_ratio": aspect_ratio,
-        }
-        if reference_image_url:
-            # Download source image and pass as base64 data URL
-            resp_img = get_ssrf_safe_client().get(
-                reference_image_url, follow_redirects=True, timeout=60
-            )
-            img_b64 = base64.b64encode(resp_img.content).decode()
-            mime_type = resp_img.headers.get("content-type", "image/png")
-            data_url = f"data:{mime_type};base64,{img_b64}"
-            payload["source_image"] = data_url
-
-        resp = get_ssrf_safe_client().post(
-            f"{_BASE_URL}/videos/generations",
-            json=payload,
+        return _submit_video_generation(
+            prompt=prompt,
+            model=model,
             headers=headers,
-            timeout=60,
-            follow_redirects=True,
+            reference_image_url=reference_image_url,
+            aspect_ratio=aspect_ratio,
+            duration_seconds=duration_seconds,
+            tier=tier,
         )
-        if resp.status_code != 200:
-            raise ProviderAPIError(
-                f"Grok video submit failed: {resp.text}",
-                status_code=resp.status_code,
-            )
-        data = resp.json()
-        return {
-            "job_id": data["id"],
-            "status": "pending",
-            "eta_seconds": data.get("eta_seconds", 30),
-            "model": model,
-            "provider": "grok",
-            "tier": tier,
-        }
 
+    return _poll_video_generation(
+        job_id=job_id,
+        model=model,
+        headers=headers,
+        tier=tier,
+    )
+
+
+def _submit_video_generation(
+    prompt: str,
+    model: str,
+    headers: dict[str, str],
+    reference_image_url: str | None,
+    aspect_ratio: str,
+    duration_seconds: int,
+    tier: str,
+) -> dict[str, Any]:
+    payload: dict[str, Any] = {
+        "model": model,
+        "prompt": prompt,
+        "duration_seconds": duration_seconds,
+        "aspect_ratio": aspect_ratio,
+    }
+    if reference_image_url:
+        # Download source image and pass as base64 data URL
+        resp_img = get_ssrf_safe_client().get(
+            reference_image_url, follow_redirects=True, timeout=60
+        )
+        img_b64 = base64.b64encode(resp_img.content).decode()
+        mime_type = resp_img.headers.get("content-type", "image/png")
+        data_url = f"data:{mime_type};base64,{img_b64}"
+        payload["source_image"] = data_url
+
+    resp = get_ssrf_safe_client().post(
+        f"{_BASE_URL}/videos/generations",
+        json=payload,
+        headers=headers,
+        timeout=60,
+        follow_redirects=True,
+    )
+    if resp.status_code != 200:
+        raise ProviderAPIError(
+            f"Grok video submit failed: {resp.text}",
+            status_code=resp.status_code,
+        )
+    data = resp.json()
+    return {
+        "job_id": data["id"],
+        "status": "pending",
+        "eta_seconds": data.get("eta_seconds", 30),
+        "model": model,
+        "provider": "grok",
+        "tier": tier,
+    }
+
+
+def _poll_video_generation(
+    job_id: str,
+    model: str,
+    headers: dict[str, str],
+    tier: str,
+) -> dict[str, Any]:
     safe_job_id = urllib.parse.quote(job_id, safe="")
     resp = get_ssrf_safe_client().get(
         f"{_BASE_URL}/videos/generations/{safe_job_id}",

--- a/tests/test_providers_grok.py
+++ b/tests/test_providers_grok.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from pathlib import Path
 from unittest.mock import MagicMock
 
 import pytest
@@ -14,11 +15,15 @@ def mock_media_fetch(monkeypatch: pytest.MonkeyPatch) -> None:
     mock_resp = MagicMock()
     mock_resp.content = b"fake-image-bytes"
     mock_resp.headers = {"content-type": "image/png"}
+    mock_resp.status_code = 200
 
     mock_client = MagicMock()
     mock_client.get.return_value = mock_resp
+    mock_client.post.return_value = mock_resp
 
     monkeypatch.setattr("imagine_mcp.media.get_ssrf_safe_client", lambda: mock_client)
+    # Also monkeypatch where it's imported
+    monkeypatch.setattr(provider, "get_ssrf_safe_client", lambda: mock_client)
 
 
 def test_understand_video_raises() -> None:
@@ -45,3 +50,75 @@ def test_understand_image_mocked(
     assert result["text"] == "a parrot"
     assert result["model"] == "grok-4.20-0309-reasoning"
     assert result["provider"] == "grok"
+
+
+def test_generate_video_submit(
+    mock_media_fetch: None, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("XAI_API_KEY", "fake-key")
+
+    mock_resp = MagicMock()
+    mock_resp.status_code = 200
+    mock_resp.json.return_value = {"id": "job-123", "eta_seconds": 45}
+
+    mock_client = MagicMock()
+    mock_client.post.return_value = mock_resp
+
+    monkeypatch.setattr(provider, "get_ssrf_safe_client", lambda: mock_client)
+
+    result = provider.generate_video(prompt="a sunset", tier="rich")
+    assert result["job_id"] == "job-123"
+    assert result["status"] == "pending"
+    assert result["eta_seconds"] == 45
+    assert result["provider"] == "grok"
+
+
+def test_generate_video_poll_pending(
+    mock_media_fetch: None, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("XAI_API_KEY", "fake-key")
+
+    mock_resp = MagicMock()
+    mock_resp.status_code = 200
+    mock_resp.json.return_value = {"status": "pending", "eta_seconds": 10}
+
+    mock_client = MagicMock()
+    mock_client.get.return_value = mock_resp
+
+    monkeypatch.setattr(provider, "get_ssrf_safe_client", lambda: mock_client)
+
+    result = provider.generate_video(prompt="a sunset", tier="rich", job_id="job-123")
+    assert result["job_id"] == "job-123"
+    assert result["status"] == "pending"
+    assert result["eta_seconds"] == 10
+
+
+def test_generate_video_poll_done(
+    mock_media_fetch: None, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    monkeypatch.setenv("XAI_API_KEY", "fake-key")
+    monkeypatch.setattr("platformdirs.user_cache_dir", lambda _: str(tmp_path))
+
+    mock_status_resp = MagicMock()
+    mock_status_resp.status_code = 200
+    mock_status_resp.json.return_value = {
+        "status": "done",
+        "video_url": "https://example.com/video.mp4",
+    }
+
+    mock_video_resp = MagicMock()
+    mock_video_resp.status_code = 200
+    mock_video_resp.content = b"fake-video-bytes"
+
+    mock_client = MagicMock()
+    # First call is GET status, second call is GET video
+    mock_client.get.side_effect = [mock_status_resp, mock_video_resp]
+
+    monkeypatch.setattr(provider, "get_ssrf_safe_client", lambda: mock_client)
+
+    result = provider.generate_video(prompt="a sunset", tier="rich", job_id="job-123")
+    assert result["status"] == "done"
+    assert result["video_url"] == "https://example.com/video.mp4"
+    assert "video_path" in result
+    assert Path(result["video_path"]).exists()
+    assert Path(result["video_path"]).read_bytes() == b"fake-video-bytes"

--- a/uv.lock
+++ b/uv.lock
@@ -549,7 +549,7 @@ wheels = [
 
 [[package]]
 name = "imagine-mcp"
-version = "1.5.4b2"
+version = "1.5.4"
 source = { editable = "." }
 dependencies = [
     { name = "diskcache" },


### PR DESCRIPTION
This PR refactors the \`generate_video\` function in the Grok provider to improve readability and maintainability. The function was previously over 80 lines long and handled both job submission and status polling.

Changes:
- Split \`generate_video\` into \`_submit_video_generation\` and \`_poll_video_generation\` private helpers.
- Added 3 new test cases in \`tests/test_providers_grok.py\` covering the submission path, the "pending" polling path, and the "done" polling path.
- Verified that all existing and new tests pass.

---
*PR created automatically by Jules for task [1724153334178399530](https://jules.google.com/task/1724153334178399530) started by @n24q02m*