### PR TITLE
fix: add test for get_ssrf_safe_client

### DIFF
--- a/tests/test_media.py
+++ b/tests/test_media.py
@@ -2,12 +2,15 @@ from __future__ import annotations
 
 from unittest.mock import MagicMock
 
+import httpx
 import pytest
 
 from imagine_mcp.errors import MediaDetectError
 from imagine_mcp.media import (
+    SSRFSafeTransport,
     _extract_extension,
     detect_media_type,
+    get_ssrf_safe_client,
     resolve_image_mime,
     sniff_image_mime,
 )
@@ -122,3 +125,16 @@ def test_extract_extension() -> None:
     assert _extract_extension("https://example.com/foo.PNG") == ".png"
     assert _extract_extension("https://example.com/foo.mp4?q=1") == ".mp4"
     assert _extract_extension("https://example.com/foo") == ""
+
+
+def test_get_ssrf_safe_client(monkeypatch: pytest.MonkeyPatch) -> None:
+    # Ensure we start from a clean state
+    monkeypatch.setattr("imagine_mcp.media._CLIENT", None)
+
+    client1 = get_ssrf_safe_client()
+    assert isinstance(client1, httpx.Client)
+    assert isinstance(client1._transport, SSRFSafeTransport)
+
+    # Verify singleton behavior
+    client2 = get_ssrf_safe_client()
+    assert client1 is client2

--- a/uv.lock
+++ b/uv.lock
@@ -549,7 +549,7 @@ wheels = [
 
 [[package]]
 name = "imagine-mcp"
-version = "1.5.4b2"
+version = "1.5.4"
 source = { editable = "." }
 dependencies = [
     { name = "diskcache" },


### PR DESCRIPTION
Added a unit test for the `get_ssrf_safe_client` function in `src/imagine_mcp/media.py`. The test verifies that the function returns an `httpx.Client` instance, that it uses the `SSRFSafeTransport`, and that it correctly implements the singleton pattern by returning the same instance on subsequent calls. This increases test coverage for the media utility module.

---
*PR created automatically by Jules for task [6713918982642738846](https://jules.google.com/task/6713918982642738846) started by @n24q02m*