### PR TITLE
fix: relay_status/relay_complete returned stale state

### DIFF
--- a/src/imagine_mcp/credential_state.py
+++ b/src/imagine_mcp/credential_state.py
@@ -97,6 +97,11 @@ def credentials_for_current_request() -> dict[str, str]:
         # over the bounded O(1) CLOUD_KEYS. This reduces latency significantly
         # when the environment has many variables.
         res = {k: v for k in CLOUD_KEYS if (v := os.environ.get(k))}
+
+        # If env is empty, fallback to PerPluginStore ONLY in HTTP mode (single-user).
+        # Stdio mode follows an env-only policy.
+        if not res:
+            res = load_credentials(None)
     else:
         res = read_for_sub(sub)
 

--- a/src/imagine_mcp/server.py
+++ b/src/imagine_mcp/server.py
@@ -34,11 +34,9 @@ def _get_version() -> str:
 
 
 def _creds_state() -> str:
-    # Read from os.environ -- settings singleton is frozen at import time
-    # and does not observe post-startup relay-saved credentials.
-    if any(
-        os.environ.get(k) for k in ("GEMINI_API_KEY", "OPENAI_API_KEY", "XAI_API_KEY")
-    ):
+    # Use live check so status is accurate even when env vars were not
+    # populated at startup.
+    if _providers_configured_live():
         return "CONFIGURED"
     return "NEEDS_SETUP"
 
@@ -58,27 +56,21 @@ def _providers_configured_live() -> list[str]:
     """Like _providers_configured but also checks PerPluginStore.
 
     env vars may not be populated at startup (no lifespan apply_config call),
-    so this reads the store directly for an accurate live view.
+    so this reads the store directly (via credential_state) for an accurate
+    live view that is sub-aware and respects the stdio env-only policy.
     """
-    from mcp_core.storage.per_plugin_store import PerPluginStore
+    from imagine_mcp.credential_state import credentials_for_current_request
 
-    from imagine_mcp.relay_setup import CREDENTIAL_KEYS, PLUGIN_NAME
-
-    saved = PerPluginStore(PLUGIN_NAME).load() or {}
+    creds = credentials_for_current_request()
     _key_to_provider = {
         "GEMINI_API_KEY": "gemini",
         "OPENAI_API_KEY": "openai",
         "XAI_API_KEY": "grok",
     }
-    seen: set[str] = set()
     out: list[str] = []
-    for key in CREDENTIAL_KEYS:
-        provider = _key_to_provider.get(key, key)
-        if provider in seen:
-            continue
-        if os.environ.get(key) or saved.get(key):
+    for key, provider in _key_to_provider.items():
+        if creds.get(key):
             out.append(provider)
-            seen.add(provider)
     return out
 
 
@@ -225,7 +217,7 @@ def build_app() -> FastMCP:
                 return {
                     "version": _get_version(),
                     "credentials_state": _creds_state(),
-                    "providers_configured": _providers_configured(),
+                    "providers_configured": _providers_configured_live(),
                     "default_provider": settings.default_provider,
                     "default_tier": settings.default_tier,
                     "cache_ttl_seconds": settings.cache_ttl_seconds,

--- a/tests/test_g6_ux_status_accuracy.py
+++ b/tests/test_g6_ux_status_accuracy.py
@@ -14,6 +14,7 @@ before claiming "using_env" and returns needs_setup if none are set.
 
 from __future__ import annotations
 
+import sys
 from typing import Any
 from unittest.mock import patch
 
@@ -44,6 +45,16 @@ def _relay_skip() -> dict[str, Any]:
     return {"status": "using_env", "providers": env_providers}
 
 
+def _status() -> dict[str, Any]:
+    """Simulate config(action='status') using module-level helper."""
+    from imagine_mcp.server import _creds_state, _providers_configured_live
+
+    return {
+        "credentials_state": _creds_state(),
+        "providers_configured": _providers_configured_live(),
+    }
+
+
 class TestRelayStatusLiveDerivedState:
     """relay_status derives state from live PerPluginStore, not env-only."""
 
@@ -54,6 +65,11 @@ class TestRelayStatusLiveDerivedState:
         monkeypatch.delenv("GEMINI_API_KEY", raising=False)
         monkeypatch.delenv("OPENAI_API_KEY", raising=False)
         monkeypatch.delenv("XAI_API_KEY", raising=False)
+        monkeypatch.setattr(sys, "argv", ["imagine-mcp", "--http"])
+
+        from imagine_mcp.credential_state import _request_creds
+
+        _request_creds.set(None)
 
         with patch(
             "mcp_core.storage.per_plugin_store.PerPluginStore.load",
@@ -71,6 +87,11 @@ class TestRelayStatusLiveDerivedState:
         monkeypatch.delenv("GEMINI_API_KEY", raising=False)
         monkeypatch.delenv("OPENAI_API_KEY", raising=False)
         monkeypatch.delenv("XAI_API_KEY", raising=False)
+        monkeypatch.setattr(sys, "argv", ["imagine-mcp", "--http"])
+
+        from imagine_mcp.credential_state import _request_creds
+
+        _request_creds.set(None)
 
         with patch(
             "mcp_core.storage.per_plugin_store.PerPluginStore.load",
@@ -88,6 +109,11 @@ class TestRelayStatusLiveDerivedState:
         monkeypatch.delenv("GEMINI_API_KEY", raising=False)
         monkeypatch.delenv("OPENAI_API_KEY", raising=False)
         monkeypatch.delenv("XAI_API_KEY", raising=False)
+        monkeypatch.setattr(sys, "argv", ["imagine-mcp", "--http"])
+
+        from imagine_mcp.credential_state import _request_creds
+
+        _request_creds.set(None)
 
         with patch(
             "mcp_core.storage.per_plugin_store.PerPluginStore.load",
@@ -101,6 +127,11 @@ class TestRelayStatusLiveDerivedState:
     def test_no_duplicate_providers(self, monkeypatch: pytest.MonkeyPatch) -> None:
         """If same key appears in both env and store, provider appears only once."""
         monkeypatch.setenv("GEMINI_API_KEY", "key-from-env")
+        monkeypatch.setattr(sys, "argv", ["imagine-mcp", "--http"])
+
+        from imagine_mcp.credential_state import _request_creds
+
+        _request_creds.set(None)
 
         with patch(
             "mcp_core.storage.per_plugin_store.PerPluginStore.load",
@@ -139,3 +170,51 @@ class TestRelaySkipHonesty:
 
         assert result["status"] == "using_env"
         assert "openai" in result["providers"]
+
+
+class TestStatusAccuracy:
+    """config(action='status') is accurate even without env vars (HTTP mode)."""
+
+    def test_status_accurate_with_store_keys(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """status returns CONFIGURED when store has keys but env is empty."""
+        monkeypatch.delenv("GEMINI_API_KEY", raising=False)
+        monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+        monkeypatch.delenv("XAI_API_KEY", raising=False)
+        monkeypatch.setattr(sys, "argv", ["imagine-mcp", "--http"])
+
+        from imagine_mcp.credential_state import _request_creds
+
+        _request_creds.set(None)
+
+        with patch(
+            "mcp_core.storage.per_plugin_store.PerPluginStore.load",
+            return_value={"OPENAI_API_KEY": "sk-123"},
+        ):
+            result = _status()
+
+        assert result["credentials_state"] == "CONFIGURED"
+        assert "openai" in result["providers_configured"]
+
+    def test_status_needs_setup_when_empty(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """status returns NEEDS_SETUP when both env and store are empty."""
+        monkeypatch.delenv("GEMINI_API_KEY", raising=False)
+        monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+        monkeypatch.delenv("XAI_API_KEY", raising=False)
+        monkeypatch.setattr(sys, "argv", ["imagine-mcp", "--http"])
+
+        from imagine_mcp.credential_state import _request_creds
+
+        _request_creds.set(None)
+
+        with patch(
+            "mcp_core.storage.per_plugin_store.PerPluginStore.load",
+            return_value={},
+        ):
+            result = _status()
+
+        assert result["credentials_state"] == "NEEDS_SETUP"
+        assert result["providers_configured"] == []

--- a/uv.lock
+++ b/uv.lock
@@ -549,7 +549,7 @@ wheels = [
 
 [[package]]
 name = "imagine-mcp"
-version = "1.5.4b2"
+version = "1.5.4"
 source = { editable = "." }
 dependencies = [
     { name = "diskcache" },


### PR DESCRIPTION
This PR fixes the stale state issues in `relay_status`, `relay_complete`, and the `status` tool.

Specifically:
1. `credentials_for_current_request` in `credential_state.py` now correctly falls back to `PerPluginStore` when in HTTP mode and environment variables are empty. This is crucial because `imagine-mcp` does not have a lifespan `apply_config` call, meaning env vars might not be populated at startup even if credentials exist in the store.
2. `_providers_configured_live` in `server.py` now uses the unified `credentials_for_current_request()` logic, making it sub-aware (for multi-user mode) and ensuring it respects the stdio "env-only" policy.
3. The `status` tool and `_creds_state` helper now use the live check instead of an env-only check, providing an accurate view of the server's configuration status.
4. `relay_skip` maintains its env-only check to accurately report when it is "using env vars" vs needing browser-based setup.

Updated `tests/test_g6_ux_status_accuracy.py` to simulate HTTP mode for fallback tests and added new test cases for the `status` tool accuracy. All tests pass.

---
*PR created automatically by Jules for task [665915565259373210](https://jules.google.com/task/665915565259373210) started by @n24q02m*