### PR TITLE
[CLEANUP] Unsupported openai understand_video

### DIFF
--- a/src/imagine_mcp/providers/openai.py
+++ b/src/imagine_mcp/providers/openai.py
@@ -14,7 +14,6 @@ from imagine_mcp.config import settings
 from imagine_mcp.errors import (
     CredentialMissingError,
     ProviderAPIError,
-    ProviderUnsupportedError,
 )
 from imagine_mcp.models import get_model_id
 
@@ -70,12 +69,6 @@ def _client() -> Any:
     return _CLIENT
 
 
-def _reset_client() -> None:
-    global _CLIENT
-    _CLIENT = None
-    _SUB_CLIENTS.clear()
-
-
 def understand_image(
     url: str, prompt: str, tier: str, max_tokens: int = 2048
 ) -> dict[str, Any]:
@@ -108,15 +101,6 @@ def understand_image(
         "provider": "openai",
         "tier": tier,
     }
-
-
-def understand_video(
-    url: str, prompt: str, tier: str, max_tokens: int = 2048
-) -> dict[str, Any]:
-    raise ProviderUnsupportedError(
-        "openai.understand.video: GPT-5.4 is image-only. "
-        "Extract frames externally or use provider='gemini'."
-    )
 
 
 def generate_image(
@@ -160,17 +144,3 @@ def generate_image(
         "provider": "openai",
         "tier": tier,
     }
-
-
-def generate_video(
-    prompt: str,
-    tier: str,
-    reference_image_url: str | None = None,
-    job_id: str | None = None,
-    aspect_ratio: str = "16:9",
-    duration_seconds: int = 8,
-) -> dict[str, Any]:
-    raise ProviderUnsupportedError(
-        "openai.generate.video: Sora 2 API shutdown 2026-09-24. "
-        "Use provider='gemini' (Veo) or 'grok' (Grok Imagine)."
-    )

--- a/tests/test_providers_openai.py
+++ b/tests/test_providers_openai.py
@@ -4,7 +4,6 @@ from unittest.mock import MagicMock
 
 import pytest
 
-from imagine_mcp.errors import ProviderUnsupportedError
 from imagine_mcp.providers import openai as provider
 
 
@@ -19,16 +18,6 @@ def mock_media_fetch(monkeypatch: pytest.MonkeyPatch) -> None:
     mock_client.get.return_value = mock_resp
 
     monkeypatch.setattr("imagine_mcp.media.get_ssrf_safe_client", lambda: mock_client)
-
-
-def test_understand_video_raises() -> None:
-    with pytest.raises(ProviderUnsupportedError):
-        provider.understand_video("https://example.com/x.mp4", "describe", "poor")
-
-
-def test_generate_video_raises() -> None:
-    with pytest.raises(ProviderUnsupportedError):
-        provider.generate_video("a dog", "poor")
 
 
 def test_understand_image_mocked(

--- a/uv.lock
+++ b/uv.lock
@@ -549,7 +549,7 @@ wheels = [
 
 [[package]]
 name = "imagine-mcp"
-version = "1.5.4b2"
+version = "1.5.4"
 source = { editable = "." }
 dependencies = [
     { name = "diskcache" },


### PR DESCRIPTION
### 💡 What
Removed the redundant `understand_video` and `generate_video` stub functions from `src/imagine_mcp/providers/openai.py`. Also removed the dead `_reset_client` function.

### 🎯 Why
These stubs only raised `ProviderUnsupportedError`. The central `dispatcher.py` already checks `models.py` for model support and raises a more descriptive `ProviderUnsupportedError` (including helpful hints) before these provider-specific stubs are reached. Removing them simplifies the provider code and eliminates redundancy. `_reset_client` was identified as dead code in this provider.

### 📊 Impact
Cleaner codebase with less redundancy. No change in behavior for users as the dispatcher continues to correctly reject these unsupported actions.

### 🔬 Measurement
Verified that `tests/test_dispatcher.py` still correctly catches unsupported OpenAI video actions. Updated `tests/test_providers_openai.py` to remove tests for the deleted functions. All tests passed.

---
*PR created automatically by Jules for task [3251239786767374371](https://jules.google.com/task/3251239786767374371) started by @n24q02m*