### PR TITLE
fix: cleanup unsupported openai generate_video

### DIFF
--- a/src/imagine_mcp/providers/openai.py
+++ b/src/imagine_mcp/providers/openai.py
@@ -114,34 +114,31 @@ def understand_video(
     url: str, prompt: str, tier: str, max_tokens: int = 2048
 ) -> dict[str, Any]:
     raise ProviderUnsupportedError(
-        "openai.understand.video: GPT-5.4 is image-only. "
-        "Extract frames externally or use provider='gemini'."
+        "openai.understand.video: GPT-5.4 vision is image-only. Workarounds: "
+        "(1) use provider='gemini' (native multimodal), or "
+        "(2) extract frames externally and pass as image URLs."
     )
 
 
-def generate_image(
+def edit(
+    url: str,
     prompt: str,
     tier: str,
-    reference_image_url: str | None = None,
     aspect_ratio: str = "1:1",
 ) -> dict[str, Any]:
+    """Edit an image using OpenAI DALL-E 2."""
+    from imagine_mcp.media import get_ssrf_safe_client
+
     model = get_model_id("openai", "generate", "image", tier)
     size_map = {"1:1": "1024x1024", "16:9": "1792x1024", "9:16": "1024x1792"}
     size = size_map.get(aspect_ratio, "1024x1024")
 
-    if reference_image_url:
-        from imagine_mcp.media import get_ssrf_safe_client
+    # Download reference image securely to prevent backend SSRF
+    img_bytes = (
+        get_ssrf_safe_client().get(url, follow_redirects=True, timeout=60).content
+    )
 
-        img_bytes = (
-            get_ssrf_safe_client()
-            .get(reference_image_url, follow_redirects=True, timeout=60)
-            .content
-        )
-        resp = _client().images.edit(
-            model=model, image=img_bytes, prompt=prompt, size=size
-        )
-    else:
-        resp = _client().images.generate(model=model, prompt=prompt, size=size, n=1)
+    resp = _client().images.edit(model=model, image=img_bytes, prompt=prompt, size=size)
 
     img_b64 = resp.data[0].b64_json
     if not img_b64:
@@ -162,6 +159,54 @@ def generate_image(
     }
 
 
+def generate_image(
+    prompt: str,
+    tier: str,
+    reference_image_url: str | None = None,
+    aspect_ratio: str = "1:1",
+) -> dict[str, Any]:
+    if reference_image_url:
+        return edit(reference_image_url, prompt, tier, aspect_ratio)
+
+    model = get_model_id("openai", "generate", "image", tier)
+    size_map = {"1:1": "1024x1024", "16:9": "1792x1024", "9:16": "1024x1792"}
+    size = size_map.get(aspect_ratio, "1024x1024")
+
+    resp = _client().images.generate(model=model, prompt=prompt, size=size, n=1)
+
+    img_b64 = resp.data[0].b64_json
+    if not img_b64:
+        raise ProviderAPIError("OpenAI returned no image", status_code=500)
+    img_bytes = base64.b64decode(img_b64)
+
+    out_dir = Path(platformdirs.user_cache_dir("imagine-mcp")) / "generations"
+    out_dir.mkdir(parents=True, exist_ok=True)
+    out_path = out_dir / f"{uuid.uuid4().hex}.png"
+    out_path.write_bytes(img_bytes)
+
+    return {
+        "image_path": str(out_path),
+        "image_base64": img_b64,
+        "model": model,
+        "provider": "openai",
+        "tier": tier,
+    }
+
+
+def video_status(
+    job_id: str,
+    prompt: str,
+    tier: str,
+    reference_image_url: str | None = None,
+    aspect_ratio: str = "16:9",
+    duration_seconds: int = 8,
+) -> dict[str, Any]:
+    """Proxy for generate_video status polling."""
+    return generate_video(
+        prompt, tier, reference_image_url, job_id, aspect_ratio, duration_seconds
+    )
+
+
 def generate_video(
     prompt: str,
     tier: str,
@@ -172,5 +217,5 @@ def generate_video(
 ) -> dict[str, Any]:
     raise ProviderUnsupportedError(
         "openai.generate.video: Sora 2 API shutdown 2026-09-24. "
-        "Use provider='gemini' (Veo) or 'grok' (Grok Imagine)."
+        "Use provider='gemini' (Veo 3.1) or 'grok' (Grok Imagine)."
     )

--- a/tests/test_providers_openai.py
+++ b/tests/test_providers_openai.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import base64
 from unittest.mock import MagicMock
 
 import pytest
@@ -22,13 +23,20 @@ def mock_media_fetch(monkeypatch: pytest.MonkeyPatch) -> None:
 
 
 def test_understand_video_raises() -> None:
-    with pytest.raises(ProviderUnsupportedError):
+    with pytest.raises(
+        ProviderUnsupportedError, match=r"GPT-5\.4 vision is image-only"
+    ):
         provider.understand_video("https://example.com/x.mp4", "describe", "poor")
 
 
 def test_generate_video_raises() -> None:
-    with pytest.raises(ProviderUnsupportedError):
+    with pytest.raises(ProviderUnsupportedError, match=r"Sora 2 API shutdown"):
         provider.generate_video("a dog", "poor")
+
+
+def test_video_status_raises() -> None:
+    with pytest.raises(ProviderUnsupportedError, match=r"Sora 2 API shutdown"):
+        provider.video_status("job-123", "a dog", "poor")
 
 
 def test_understand_image_mocked(
@@ -44,3 +52,36 @@ def test_understand_image_mocked(
     assert result["text"] == "a dog"
     assert result["model"] == "gpt-5.4-mini"
     assert result["provider"] == "openai"
+
+
+def test_edit_mocked(mock_media_fetch: None, monkeypatch: pytest.MonkeyPatch) -> None:
+    fake = MagicMock()
+    fake_img = MagicMock()
+    fake_img.b64_json = base64.b64encode(b"fake-edited-image").decode()
+    fake.images.edit.return_value = MagicMock(data=[fake_img])
+    monkeypatch.setattr(provider, "_client", lambda: fake)
+
+    result = provider.edit(
+        url="https://example.com/dog.png", prompt="make it a cat", tier="poor"
+    )
+    assert "image_path" in result
+    assert result["model"] == "gpt-image-1-mini"
+    assert result["provider"] == "openai"
+
+
+def test_generate_image_delegates_to_edit(
+    mock_media_fetch: None, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # Use a spy or mock to verify edit is called
+    mock_edit = MagicMock(return_value={"status": "edited"})
+    monkeypatch.setattr(provider, "edit", mock_edit)
+
+    result = provider.generate_image(
+        prompt="make it a cat",
+        tier="poor",
+        reference_image_url="https://example.com/dog.png",
+    )
+    assert result == {"status": "edited"}
+    mock_edit.assert_called_once_with(
+        "https://example.com/dog.png", "make it a cat", "poor", "1:1"
+    )

--- a/uv.lock
+++ b/uv.lock
@@ -549,7 +549,7 @@ wheels = [
 
 [[package]]
 name = "imagine-mcp"
-version = "1.5.4b2"
+version = "1.5.4"
 source = { editable = "." }
 dependencies = [
     { name = "diskcache" },


### PR DESCRIPTION
Align OpenAI provider with unified interface by extracting edit() and
video_status() proxies. Update error messages for unsupported video
actions to match dispatcher hints.

Highlights:
- Extracted image editing logic into `edit()` function in `openai.py`.
- Added `video_status()` proxy in `openai.py` for consistent polling interface.
- Updated `understand_video` and `generate_video` in `openai.py` to use standardized error messages from `dispatcher.py`.
- Updated tests in `test_providers_openai.py` to cover new functions and verify error messages.

---
*PR created automatically by Jules for task [11872384111828442769](https://jules.google.com/task/11872384111828442769) started by @n24q02m*