### PR TITLE
perf: ⚡ bolt: optimize merge_ranks to O(N) using dictionary lookups

### DIFF
--- a/scripts/fetch_leaderboards.py
+++ b/scripts/fetch_leaderboards.py
@@ -213,14 +213,20 @@ def parse_leaderboard(url: str, html: str) -> list[LBRow]:
 
 def merge_ranks(rows_aa: list[LBRow], rows_lmarena: list[LBRow]) -> dict[str, int]:
     """Return {canonical_model_id: quality_rank} using min(rank_aa, rank_lmarena)."""
+    # ⚡ Bolt: O(N) optimization. We convert the arrays into O(1) dictionary lookups upfront
+    # instead of doing nested O(M) searches inside the loop over all_ids.
+    ranks_aa = {r.model_id: r.rank for r in rows_aa}
+    ranks_lm = {r.model_id: r.rank for r in rows_lmarena}
+
     result: dict[str, int] = {}
-    all_ids = {r.model_id for r in rows_aa} | {r.model_id for r in rows_lmarena}
+    all_ids = ranks_aa.keys() | ranks_lm.keys()
+
     for model_id in all_ids:
         ranks: list[int] = []
-        for rows in (rows_aa, rows_lmarena):
-            match = next((r for r in rows if r.model_id == model_id), None)
-            if match:
-                ranks.append(match.rank)
+        if model_id in ranks_aa:
+            ranks.append(ranks_aa[model_id])
+        if model_id in ranks_lm:
+            ranks.append(ranks_lm[model_id])
         result[model_id] = min(ranks) if ranks else 999
     return result
 

--- a/uv.lock
+++ b/uv.lock
@@ -549,7 +549,7 @@ wheels = [
 
 [[package]]
 name = "imagine-mcp"
-version = "1.5.4b2"
+version = "1.5.4"
 source = { editable = "." }
 dependencies = [
     { name = "diskcache" },


### PR DESCRIPTION
💡 What: Refactored `merge_ranks` in `scripts/fetch_leaderboards.py` to use dictionary comprehensions for O(1) lookups instead of nested list traversals.

🎯 Why: The previous implementation iterated over a combined list of model IDs and, for each ID, used `next(...)` to search through both leaderboard arrays. This resulted in O(N*M) time complexity. Creating dictionaries upfront reduces this to a single O(N) pass.

📊 Impact: Significantly improves the performance of merging leaderboard arrays, especially as the number of ranked models grows. Time complexity drops from O(N*M) to O(N).

🔬 Measurement: Tests run via `uv run pytest` (specifically `tests/test_fetch_leaderboards.py`) verify the ranks merge correctly using `min()` and missing ranks correctly default to `999`. Code checked with `uv run ruff check .`

---
*PR created automatically by Jules for task [3698656505624156848](https://jules.google.com/task/3698656505624156848) started by @n24q02m*