### PR TITLE
[FIX] relay_status/relay_complete returned stale state

### DIFF
--- a/src/imagine_mcp/server.py
+++ b/src/imagine_mcp/server.py
@@ -34,13 +34,8 @@ def _get_version() -> str:
 
 
 def _creds_state() -> str:
-    # Read from os.environ -- settings singleton is frozen at import time
-    # and does not observe post-startup relay-saved credentials.
-    if any(
-        os.environ.get(k) for k in ("GEMINI_API_KEY", "OPENAI_API_KEY", "XAI_API_KEY")
-    ):
-        return "CONFIGURED"
-    return "NEEDS_SETUP"
+    """Return CONFIGURED if at least one provider has an API key (live check)."""
+    return "CONFIGURED" if _providers_configured_live() else "NEEDS_SETUP"
 
 
 def _providers_configured() -> list[str]:
@@ -186,7 +181,7 @@ def build_app() -> FastMCP:
                     }
                 return {
                     "status": "saved",
-                    "providers_configured": _providers_configured(),
+                    "providers_configured": _providers_configured_live(),
                 }
             case "relay_status":
                 # Derive providers from live PerPluginStore + env so status
@@ -225,7 +220,7 @@ def build_app() -> FastMCP:
                 return {
                     "version": _get_version(),
                     "credentials_state": _creds_state(),
-                    "providers_configured": _providers_configured(),
+                    "providers_configured": _providers_configured_live(),
                     "default_provider": settings.default_provider,
                     "default_tier": settings.default_tier,
                     "cache_ttl_seconds": settings.cache_ttl_seconds,

--- a/uv.lock
+++ b/uv.lock
@@ -549,7 +549,7 @@ wheels = [
 
 [[package]]
 name = "imagine-mcp"
-version = "1.5.4b2"
+version = "1.5.4"
 source = { editable = "." }
 dependencies = [
     { name = "diskcache" },


### PR DESCRIPTION
This PR fixes a UX bug where the config tool actions (status and open_relay) and the internal _creds_state helper returned stale credential information. They now use _providers_configured_live() to check both environment variables and the PerPluginStore, ensuring accuracy even when environment variables haven't been populated at startup.

---
*PR created automatically by Jules for task [15892724023488236633](https://jules.google.com/task/15892724023488236633) started by @n24q02m*