### PR TITLE
[FIX] Long function: generate_video

### DIFF
--- a/src/imagine_mcp/providers/grok.py
+++ b/src/imagine_mcp/providers/grok.py
@@ -185,56 +185,60 @@ def generate_image(
     }
 
 
-def generate_video(
+def _submit_video_generation(
+    model: str,
+    headers: dict[str, str],
     prompt: str,
+    aspect_ratio: str,
+    duration_seconds: int,
+    reference_image_url: str | None,
     tier: str,
-    reference_image_url: str | None = None,
-    job_id: str | None = None,
-    aspect_ratio: str = "16:9",
-    duration_seconds: int = 8,
 ) -> dict[str, Any]:
-    model = get_model_id("grok", "generate", "video", tier)
-    headers = {"Authorization": f"Bearer {_api_key()}"}
-
-    if job_id is None:
-        payload: dict[str, Any] = {
-            "model": model,
-            "prompt": prompt,
-            "duration_seconds": duration_seconds,
-            "aspect_ratio": aspect_ratio,
-        }
-        if reference_image_url:
-            # Download source image and pass as base64 data URL
-            resp_img = get_ssrf_safe_client().get(
-                reference_image_url, follow_redirects=True, timeout=60
-            )
-            img_b64 = base64.b64encode(resp_img.content).decode()
-            mime_type = resp_img.headers.get("content-type", "image/png")
-            data_url = f"data:{mime_type};base64,{img_b64}"
-            payload["source_image"] = data_url
-
-        resp = get_ssrf_safe_client().post(
-            f"{_BASE_URL}/videos/generations",
-            json=payload,
-            headers=headers,
-            timeout=60,
-            follow_redirects=True,
+    payload: dict[str, Any] = {
+        "model": model,
+        "prompt": prompt,
+        "duration_seconds": duration_seconds,
+        "aspect_ratio": aspect_ratio,
+    }
+    if reference_image_url:
+        # Download source image and pass as base64 data URL
+        resp_img = get_ssrf_safe_client().get(
+            reference_image_url, follow_redirects=True, timeout=60
         )
-        if resp.status_code != 200:
-            raise ProviderAPIError(
-                f"Grok video submit failed: {resp.text}",
-                status_code=resp.status_code,
-            )
-        data = resp.json()
-        return {
-            "job_id": data["id"],
-            "status": "pending",
-            "eta_seconds": data.get("eta_seconds", 30),
-            "model": model,
-            "provider": "grok",
-            "tier": tier,
-        }
+        img_b64 = base64.b64encode(resp_img.content).decode()
+        mime_type = resp_img.headers.get("content-type", "image/png")
+        data_url = f"data:{mime_type};base64,{img_b64}"
+        payload["source_image"] = data_url
 
+    resp = get_ssrf_safe_client().post(
+        f"{_BASE_URL}/videos/generations",
+        json=payload,
+        headers=headers,
+        timeout=60,
+        follow_redirects=True,
+    )
+    if resp.status_code != 200:
+        raise ProviderAPIError(
+            f"Grok video submit failed: {resp.text}",
+            status_code=resp.status_code,
+        )
+    data = resp.json()
+    return {
+        "job_id": data["id"],
+        "status": "pending",
+        "eta_seconds": data.get("eta_seconds", 30),
+        "model": model,
+        "provider": "grok",
+        "tier": tier,
+    }
+
+
+def _poll_video_generation(
+    job_id: str,
+    headers: dict[str, str],
+    model: str,
+    tier: str,
+) -> dict[str, Any]:
     safe_job_id = urllib.parse.quote(job_id, safe="")
     resp = get_ssrf_safe_client().get(
         f"{_BASE_URL}/videos/generations/{safe_job_id}",
@@ -283,3 +287,33 @@ def generate_video(
         "provider": "grok",
         "tier": tier,
     }
+
+
+def generate_video(
+    prompt: str,
+    tier: str,
+    reference_image_url: str | None = None,
+    job_id: str | None = None,
+    aspect_ratio: str = "16:9",
+    duration_seconds: int = 8,
+) -> dict[str, Any]:
+    model = get_model_id("grok", "generate", "video", tier)
+    headers = {"Authorization": f"Bearer {_api_key()}"}
+
+    if job_id is None:
+        return _submit_video_generation(
+            model=model,
+            headers=headers,
+            prompt=prompt,
+            aspect_ratio=aspect_ratio,
+            duration_seconds=duration_seconds,
+            reference_image_url=reference_image_url,
+            tier=tier,
+        )
+
+    return _poll_video_generation(
+        job_id=job_id,
+        headers=headers,
+        model=model,
+        tier=tier,
+    )

--- a/tests/test_providers_grok.py
+++ b/tests/test_providers_grok.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from pathlib import Path
 from unittest.mock import MagicMock
 
 import pytest
@@ -18,7 +19,7 @@ def mock_media_fetch(monkeypatch: pytest.MonkeyPatch) -> None:
     mock_client = MagicMock()
     mock_client.get.return_value = mock_resp
 
-    monkeypatch.setattr("imagine_mcp.media.get_ssrf_safe_client", lambda: mock_client)
+    monkeypatch.setattr(provider, "get_ssrf_safe_client", lambda: mock_client)
 
 
 def test_understand_video_raises() -> None:
@@ -45,3 +46,53 @@ def test_understand_image_mocked(
     assert result["text"] == "a parrot"
     assert result["model"] == "grok-4.20-0309-reasoning"
     assert result["provider"] == "grok"
+
+
+def test_generate_video_submit(
+    mock_media_fetch: None, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("XAI_API_KEY", "fake-key")
+
+    mock_resp = MagicMock()
+    mock_resp.status_code = 200
+    mock_resp.json.return_value = {"id": "job-123", "eta_seconds": 45}
+
+    mock_client = MagicMock()
+    mock_client.post.return_value = mock_resp
+
+    monkeypatch.setattr(provider, "get_ssrf_safe_client", lambda: mock_client)
+
+    result = provider.generate_video(prompt="a sunset", tier="poor")
+    assert result["job_id"] == "job-123"
+    assert result["status"] == "pending"
+    assert result["model"] == "grok-imagine-video"
+
+
+def test_generate_video_poll_done(
+    mock_media_fetch: None, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    monkeypatch.setenv("XAI_API_KEY", "fake-key")
+    monkeypatch.setattr("platformdirs.user_cache_dir", lambda _: str(tmp_path))
+
+    mock_poll_resp = MagicMock()
+    mock_poll_resp.status_code = 200
+    mock_poll_resp.json.return_value = {
+        "status": "done",
+        "video_url": "https://example.com/video.mp4",
+    }
+
+    mock_video_resp = MagicMock()
+    mock_video_resp.status_code = 200
+    mock_video_resp.content = b"fake-video-bytes"
+
+    mock_client = MagicMock()
+    mock_client.get.side_effect = [mock_poll_resp, mock_video_resp]
+
+    monkeypatch.setattr(provider, "get_ssrf_safe_client", lambda: mock_client)
+
+    result = provider.generate_video(prompt="a sunset", tier="poor", job_id="job-123")
+    assert result["job_id"] == "job-123"
+    assert result["status"] == "done"
+    assert result["video_url"] == "https://example.com/video.mp4"
+    assert "video_path" in result
+    assert Path(result["video_path"]).exists()

--- a/uv.lock
+++ b/uv.lock
@@ -549,7 +549,7 @@ wheels = [
 
 [[package]]
 name = "imagine-mcp"
-version = "1.5.4b2"
+version = "1.5.4"
 source = { editable = "." }
 dependencies = [
     { name = "diskcache" },


### PR DESCRIPTION
Refactored the `generate_video` function in `src/imagine_mcp/providers/grok.py` to address the "Long function" issue. The logic was split into two private helper functions, `_submit_video_generation` and `_poll_video_generation`, to improve readability and maintainability. Comprehensive unit tests were added to `tests/test_providers_grok.py` to ensure both the submission and polling/downloading logic are covered and work as expected. All tests passed.

---
*PR created automatically by Jules for task [14894631151364501623](https://jules.google.com/task/14894631151364501623) started by @n24q02m*