### PR TITLE
[SECURITY] Missing SSL certificate validation during TLS when rewriting requests to IPs

### DIFF
--- a/src/imagine_mcp/media.py
+++ b/src/imagine_mcp/media.py
@@ -7,12 +7,16 @@ import ipaddress
 import os
 import socket
 from pathlib import Path
-from typing import Literal
+from typing import TYPE_CHECKING, Any, Literal
 from urllib.parse import urlparse
 
+import httpcore
 import httpx
 
 from imagine_mcp.errors import InvalidURLError, MediaDetectError
+
+if TYPE_CHECKING:
+    pass
 
 MediaType = Literal["image", "video"]
 
@@ -73,64 +77,88 @@ def resolve_image_mime(content_type: str | None, data: bytes) -> str:
     return _IMAGE_FALLBACK_MIME
 
 
-class SSRFSafeTransport(httpx.HTTPTransport):
-    """Custom transport that implements DNS pinning to prevent TOCTOU SSRF.
+class SSRFSafeBackend(httpcore.NetworkBackend):
+    """Custom httpcore backend that implements DNS pinning and validation."""
 
-    It resolves the hostname, validates the IP against local/private ranges,
-    and then rewrites the request URL to use the IP address directly.
+    def __init__(self, backend: httpcore.NetworkBackend):
+        self._backend = backend
+
+    def connect_tcp(
+        self,
+        host: str,
+        port: int,
+        timeout: float | None = None,
+        local_address: str | None = None,
+        socket_options: Any = None,
+    ) -> httpcore.NetworkStream:
+        # Resolve and validate the IP address to prevent TOCTOU DNS rebinding.
+        # We use "url" as the param name for consistency with dispatcher's fail-fast check.
+        ip = _validate_hostname_and_get_ip(host, port, "url")
+        return self._backend.connect_tcp(
+            ip,
+            port,
+            timeout=timeout,
+            local_address=local_address,
+            socket_options=socket_options,
+        )
+
+    def connect_unix_socket(
+        self,
+        path: str,
+        timeout: float | None = None,
+        socket_options: Any = None,
+    ) -> httpcore.NetworkStream:
+        raise InvalidURLError("Unix sockets are not allowed.")
+
+
+class SSRFSafeTransport(httpx.HTTPTransport):
+    """Custom transport that prevents SSRF via DNS pinning in the backend.
+
+    It uses SSRFSafeBackend to ensure that hostname resolution is validated
+    against public IP ranges and pinned during the connection phase, while
+    preserving the original hostname in the request for TLS/SNI.
     """
+
+    def __init__(self, **kwargs: Any):
+        super().__init__(**kwargs)
+        # Inject our security-hardened backend into the connection pool.
+        # We use the internal _pool attribute which is standard for httpx.HTTPTransport.
+        if hasattr(self, "_pool") and hasattr(self._pool, "_network_backend"):
+            self._pool._network_backend = SSRFSafeBackend(self._pool._network_backend)
 
     def handle_request(self, request: httpx.Request) -> httpx.Response:
         url = request.url
         if url.scheme.lower() not in _SAFE_URL_SCHEMES:
-            return super().handle_request(request)
+            raise InvalidURLError(
+                f"Invalid URL scheme {url.scheme!r}. Only http/https are allowed."
+            )
 
-        host = url.host
-        ip = validate_url_and_get_ip(str(url), "redirect_url")
-
-        # Pin the request to the validated IP to prevent TOCTOU DNS rebinding.
-        request.url = request.url.copy_with(host=ip)
-
-        # Ensure Host header is set for virtual hosting.
-        if "Host" not in request.headers:
-            request.headers["Host"] = host
-
-        # Set SNI extension for TLS.
-        request.extensions["sni_hostname"] = host
-
+        # We rely on SSRFSafeBackend to perform the DNS pinning and validation
+        # during the connection phase. This ensures the TLS handshake uses
+        # the original request hostname for SNI and certificate verification.
         return super().handle_request(request)
 
 
-def validate_url_and_get_ip(url: str, param: str) -> str:
-    """Verify URL scheme and resolve hostname to a public IP.
+def _validate_hostname_and_get_ip(hostname: str, port: int | None, param: str) -> str:
+    """Core logic to resolve a hostname and validate it is a public IP.
 
     Returns the first validated IP address string.
-    Raises InvalidURLError if the URL is unsafe.
+    Raises InvalidURLError if the resolution fails or points to an unsafe IP.
     """
-    parsed = urlparse(url)
-    scheme = parsed.scheme.lower()
-    if scheme not in _SAFE_URL_SCHEMES:
-        raise InvalidURLError(
-            f"Invalid {param} scheme {scheme!r}. Only http/https are allowed."
-        )
-
-    hostname = parsed.hostname
     if not hostname:
         raise InvalidURLError(f"Invalid {param}: missing hostname.")
 
     try:
         # Wrap the blocking getaddrinfo in a thread with a short timeout
         # to prevent DoS attacks via malicious DNS servers.
-        # Note: parsed.port may be None, which is fine for getaddrinfo.
         future = _DNS_RESOLVER_POOL.submit(
-            socket.getaddrinfo, hostname, parsed.port, socket.AF_UNSPEC
+            socket.getaddrinfo, hostname, port, socket.AF_UNSPEC
         )
         # Short timeout to fail fast on tarpit DNS
         addr_info = future.result(timeout=2.0)
 
         for res in addr_info:
             # res[4] is the sockaddr tuple. The first element is the IP string.
-            # Explicitly stringify to satisfy type checkers.
             ip_str = str(res[4][0])
             ip_obj = ipaddress.ip_address(ip_str)
 
@@ -157,6 +185,21 @@ def validate_url_and_get_ip(url: str, param: str) -> str:
         raise InvalidURLError(
             f"Invalid {param}: Could not resolve hostname {hostname!r}."
         ) from e
+
+
+def validate_url_and_get_ip(url: str, param: str) -> str:
+    """Verify URL scheme and resolve hostname to a public IP.
+
+    This provides a fail-fast check before initiating a full request.
+    """
+    parsed = urlparse(url)
+    scheme = parsed.scheme.lower()
+    if scheme not in _SAFE_URL_SCHEMES:
+        raise InvalidURLError(
+            f"Invalid {param} scheme {scheme!r}. Only http/https are allowed."
+        )
+
+    return _validate_hostname_and_get_ip(parsed.hostname or "", parsed.port, param)
 
 
 _CLIENT: httpx.Client | None = None

--- a/src/imagine_mcp/media.py
+++ b/src/imagine_mcp/media.py
@@ -7,16 +7,13 @@ import ipaddress
 import os
 import socket
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Literal
+from typing import Any, Literal, cast
 from urllib.parse import urlparse
 
 import httpcore
 import httpx
 
 from imagine_mcp.errors import InvalidURLError, MediaDetectError
-
-if TYPE_CHECKING:
-    pass
 
 MediaType = Literal["image", "video"]
 
@@ -123,8 +120,12 @@ class SSRFSafeTransport(httpx.HTTPTransport):
         super().__init__(**kwargs)
         # Inject our security-hardened backend into the connection pool.
         # We use the internal _pool attribute which is standard for httpx.HTTPTransport.
-        if hasattr(self, "_pool") and hasattr(self._pool, "_network_backend"):
-            self._pool._network_backend = SSRFSafeBackend(self._pool._network_backend)
+        pool = getattr(self, "_pool", None)
+        if pool is not None:
+            backend = getattr(pool, "_network_backend", None)
+            if isinstance(backend, httpcore.NetworkBackend):
+                # Use setattr to satisfy type checkers for internal attribute access.
+                setattr(pool, "_network_backend", SSRFSafeBackend(backend))
 
     def handle_request(self, request: httpx.Request) -> httpx.Response:
         url = request.url
@@ -155,7 +156,7 @@ def _validate_hostname_and_get_ip(hostname: str, port: int | None, param: str) -
             socket.getaddrinfo, hostname, port, socket.AF_UNSPEC
         )
         # Short timeout to fail fast on tarpit DNS
-        addr_info = future.result(timeout=2.0)
+        addr_info = cast(list[Any], future.result(timeout=2.0))
 
         for res in addr_info:
             # res[4] is the sockaddr tuple. The first element is the IP string.

--- a/src/imagine_mcp/media.py
+++ b/src/imagine_mcp/media.py
@@ -124,8 +124,9 @@ class SSRFSafeTransport(httpx.HTTPTransport):
         if pool is not None:
             backend = getattr(pool, "_network_backend", None)
             if isinstance(backend, httpcore.NetworkBackend):
-                # Use setattr to satisfy type checkers for internal attribute access.
-                setattr(pool, "_network_backend", SSRFSafeBackend(backend))
+                # Use Any cast to bypass type checking for internal attribute assignment
+                # while avoiding setattr which triggers ruff B010.
+                cast(Any, pool)._network_backend = SSRFSafeBackend(backend)
 
     def handle_request(self, request: httpx.Request) -> httpx.Response:
         url = request.url

--- a/tests/test_security_pinning.py
+++ b/tests/test_security_pinning.py
@@ -1,7 +1,9 @@
 from __future__ import annotations
 
 import socket
+from unittest.mock import MagicMock
 
+import httpcore
 import httpx
 import pytest
 
@@ -30,32 +32,49 @@ def test_validate_url_and_get_ip_private(monkeypatch):
 
 
 def test_ssrf_safe_transport_pinning(monkeypatch):
-    # This test verifies that handle_request rewrites the URL and sets headers.
+    # This test verifies that SSRFSafeBackend pins the TCP connection to the IP
+    # while preserving the hostname for TLS.
+
+    # 1. Mock DNS resolution
     def mock_getaddrinfo(host, port, family=0, type=0, proto=0, flags=0):
-        return [(socket.AF_INET, socket.SOCK_STREAM, 6, "", ("93.184.215.14", 80))]
+        return [(socket.AF_INET, socket.SOCK_STREAM, 6, "", ("93.184.215.14", 443))]
 
     monkeypatch.setattr(socket, "getaddrinfo", mock_getaddrinfo)
 
-    # Mocking the actual network call so we don't need real internet
-    class MockTransport(httpx.HTTPTransport):
-        def handle_request(self, request):
-            return httpx.Response(200, content=b"ok", request=request)
+    # 2. Mock the underlying network backend to record calls
+    mock_backend = MagicMock(spec=httpcore.NetworkBackend)
+    mock_stream = MagicMock(spec=httpcore.NetworkStream)
+    mock_backend.connect_tcp.return_value = mock_stream
+    # start_tls must return the stream (or a new one)
+    mock_stream.start_tls.return_value = mock_stream
+    # Mock read for the HTTP response
+    mock_stream.read.return_value = b"HTTP/1.1 200 OK\r\nContent-Length: 2\r\n\r\nok"
 
+    # 3. Create transport and inject mock backend
     transport = SSRFSafeTransport()
-    # We need to reach super().handle_request, so we patch HTTPTransport.handle_request
-    monkeypatch.setattr(
-        httpx.HTTPTransport,
-        "handle_request",
-        lambda self, req: httpx.Response(200, content=b"ok", request=req),
-    )
+    # Replace the actual backend with our mock
+    transport._pool._network_backend._backend = mock_backend
 
-    request = httpx.Request("GET", "https://example.com/foo")
-    transport.handle_request(request)
+    # 4. Perform request
+    with httpx.Client(transport=transport) as client:
+        resp = client.get("https://example.com/foo")
 
-    # Verification
-    assert str(request.url) == "https://93.184.215.14/foo"
-    assert request.headers["Host"] == "example.com"
-    assert request.extensions["sni_hostname"] == "example.com"
+    # 5. Verification
+    assert resp.status_code == 200
+    assert resp.text == "ok"
+
+    # Check TCP connection was to the IP
+    args, kwargs = mock_backend.connect_tcp.call_args
+    assert args[0] == "93.184.215.14"
+    assert args[1] == 443
+
+    # Check TLS handshake used the HOSTNAME
+    # httpcore calls start_tls(ssl_context, server_hostname=...)
+    args, kwargs = mock_stream.start_tls.call_args
+    assert kwargs["server_hostname"] == "example.com"
+
+    # Verify request URL was NOT rewritten (it's handled at connection level now)
+    assert str(resp.request.url) == "https://example.com/foo"
 
 
 def test_ssrf_safe_transport_blocks_private(monkeypatch):
@@ -65,7 +84,7 @@ def test_ssrf_safe_transport_blocks_private(monkeypatch):
     monkeypatch.setattr(socket, "getaddrinfo", mock_getaddrinfo)
 
     transport = SSRFSafeTransport()
-    request = httpx.Request("GET", "http://internal.service/foo")
 
-    with pytest.raises(InvalidURLError, match="internal/private IP"):
-        transport.handle_request(request)
+    # SSRFSafeBackend will raise InvalidURLError during connect_tcp
+    with httpx.Client(transport=transport) as client, pytest.raises(InvalidURLError, match="internal/private IP"):
+        client.get("http://internal.service/foo")

--- a/tests/test_security_pinning.py
+++ b/tests/test_security_pinning.py
@@ -86,5 +86,8 @@ def test_ssrf_safe_transport_blocks_private(monkeypatch):
     transport = SSRFSafeTransport()
 
     # SSRFSafeBackend will raise InvalidURLError during connect_tcp
-    with httpx.Client(transport=transport) as client, pytest.raises(InvalidURLError, match="internal/private IP"):
+    with (
+        httpx.Client(transport=transport) as client,
+        pytest.raises(InvalidURLError, match="internal/private IP"),
+    ):
         client.get("http://internal.service/foo")

--- a/uv.lock
+++ b/uv.lock
@@ -549,7 +549,7 @@ wheels = [
 
 [[package]]
 name = "imagine-mcp"
-version = "1.5.4b2"
+version = "1.5.4"
 source = { editable = "." }
 dependencies = [
     { name = "diskcache" },


### PR DESCRIPTION
Fixed a security vulnerability in `SSRFSafeTransport` where TLS certificate validation would fail (or be bypassed) because the request host was rewritten to an IP address. The fix implements a custom `httpcore.NetworkBackend` (`SSRFSafeBackend`) that performs DNS pinning and validation during the socket connection phase while preserving the original hostname in the request URL. This allows `httpcore` to correctly perform SNI and verify the server's certificate against the intended hostname.

Key changes:
- Created `SSRFSafeBackend` to intercept `connect_tcp` and perform DNS resolution/validation.
- Updated `SSRFSafeTransport` to wrap its internal pool backend with `SSRFSafeBackend`.
- Removed manual URL host rewriting in `handle_request`, which was the root cause of the TLS validation issue.
- Updated security tests to verify that TCP connects to the IP while TLS still uses the hostname.

---
*PR created automatically by Jules for task [15684353864031780777](https://jules.google.com/task/15684353864031780777) started by @n24q02m*