### PR TITLE
[CLEANUP] Unsupported grok understand_video

### DIFF
--- a/src/imagine_mcp/providers/grok.py
+++ b/src/imagine_mcp/providers/grok.py
@@ -28,6 +28,11 @@ from imagine_mcp.errors import (
 from imagine_mcp.media import get_ssrf_safe_client
 from imagine_mcp.models import get_model_id
 
+try:
+    from openai import OpenAI
+except ImportError:
+    OpenAI = Any
+
 _CLIENT: Any = None
 _BASE_URL = "https://api.x.ai/v1"
 # Per-sub client cache for HTTP multi-user mode (see providers/gemini.py).
@@ -59,7 +64,6 @@ def _openai_compat_client() -> Any:
         cached = _SUB_CLIENTS.get(sub)
         if cached is not None:
             return cached
-        from openai import OpenAI
 
         client = OpenAI(
             api_key=_api_key(),
@@ -70,8 +74,6 @@ def _openai_compat_client() -> Any:
         return client
 
     if _CLIENT is None:
-        from openai import OpenAI
-
         _CLIENT = OpenAI(
             api_key=_api_key(),
             base_url=_BASE_URL,
@@ -122,8 +124,8 @@ def understand_video(
     url: str, prompt: str, tier: str, max_tokens: int = 2048
 ) -> dict[str, Any]:
     raise ProviderUnsupportedError(
-        "grok.understand.video: Grok production (4.20-0309-v2) is image-only. "
-        "Beta supports video but is not stable. Use provider='gemini'."
+        "Grok production (4.20-0309-v2) is image-only. "
+        "Use provider='gemini' for video understanding."
     )
 
 

--- a/src/imagine_mcp/providers/grok.py
+++ b/src/imagine_mcp/providers/grok.py
@@ -14,6 +14,7 @@ from pathlib import Path
 from typing import Any
 
 import platformdirs
+from openai import OpenAI
 
 from imagine_mcp.config import settings
 from imagine_mcp.credential_state import (
@@ -27,11 +28,6 @@ from imagine_mcp.errors import (
 )
 from imagine_mcp.media import get_ssrf_safe_client
 from imagine_mcp.models import get_model_id
-
-try:
-    from openai import OpenAI
-except ImportError:
-    OpenAI = Any
 
 _CLIENT: Any = None
 _BASE_URL = "https://api.x.ai/v1"

--- a/uv.lock
+++ b/uv.lock
@@ -549,7 +549,7 @@ wheels = [
 
 [[package]]
 name = "imagine-mcp"
-version = "1.5.4b2"
+version = "1.5.4"
 source = { editable = "." }
 dependencies = [
     { name = "diskcache" },


### PR DESCRIPTION
This PR cleans up the `understand_video` function in the Grok provider and consolidates its imports.

**Changes:**
1.  **Import Consolidation:** Moved the `from openai import OpenAI` import from local function scopes to the top level of `src/imagine_mcp/providers/grok.py`. This follows the pattern used in other providers and is better for performance/parallelization.
2.  **Error Message Update:** Updated the error message in `understand_video` to "Grok production (4.20-0309-v2) is image-only. Use provider='gemini' for video understanding." This is more concise and avoids mentioning unstable beta features.

**Verification:**
-   Ran `uv run pytest tests/test_providers_grok.py` (Passed)
-   Ran `uv run pytest tests/test_dispatcher.py` (Passed)
-   Ran `uv run ruff format .` and `uv run ruff check . --fix` (Passed)

---
*PR created automatically by Jules for task [10781955955331329510](https://jules.google.com/task/10781955955331329510) started by @n24q02m*