### PR TITLE
[FIX] relay_skip reported Using env vars for credentials

### DIFF
--- a/src/imagine_mcp/credential_state.py
+++ b/src/imagine_mcp/credential_state.py
@@ -97,6 +97,14 @@ def credentials_for_current_request() -> dict[str, str]:
         # over the bounded O(1) CLOUD_KEYS. This reduces latency significantly
         # when the environment has many variables.
         res = {k: v for k in CLOUD_KEYS if (v := os.environ.get(k))}
+
+        # Single-user HTTP mode: fallback to store if env vars missing.
+        # Stdio mode (not _is_http()) stays env-only via load_credentials guard.
+        if _is_http():
+            saved = load_credentials(None)
+            for k, v in saved.items():
+                if k in CLOUD_KEYS and k not in res:
+                    res[k] = v
     else:
         res = read_for_sub(sub)
 

--- a/src/imagine_mcp/server.py
+++ b/src/imagine_mcp/server.py
@@ -34,13 +34,8 @@ def _get_version() -> str:
 
 
 def _creds_state() -> str:
-    # Read from os.environ -- settings singleton is frozen at import time
-    # and does not observe post-startup relay-saved credentials.
-    if any(
-        os.environ.get(k) for k in ("GEMINI_API_KEY", "OPENAI_API_KEY", "XAI_API_KEY")
-    ):
-        return "CONFIGURED"
-    return "NEEDS_SETUP"
+    """Return CONFIGURED if any providers are configured live, else NEEDS_SETUP."""
+    return "CONFIGURED" if _providers_configured_live() else "NEEDS_SETUP"
 
 
 def _providers_configured() -> list[str]:
@@ -55,16 +50,14 @@ def _providers_configured() -> list[str]:
 
 
 def _providers_configured_live() -> list[str]:
-    """Like _providers_configured but also checks PerPluginStore.
+    """Like _providers_configured but sub-aware and checks PerPluginStore.
 
     env vars may not be populated at startup (no lifespan apply_config call),
-    so this reads the store directly for an accurate live view.
+    so this uses credentials_for_current_request() for an accurate live view.
     """
-    from mcp_core.storage.per_plugin_store import PerPluginStore
+    from imagine_mcp.credential_state import credentials_for_current_request
 
-    from imagine_mcp.relay_setup import CREDENTIAL_KEYS, PLUGIN_NAME
-
-    saved = PerPluginStore(PLUGIN_NAME).load() or {}
+    creds = credentials_for_current_request()
     _key_to_provider = {
         "GEMINI_API_KEY": "gemini",
         "OPENAI_API_KEY": "openai",
@@ -72,11 +65,9 @@ def _providers_configured_live() -> list[str]:
     }
     seen: set[str] = set()
     out: list[str] = []
-    for key in CREDENTIAL_KEYS:
-        provider = _key_to_provider.get(key, key)
-        if provider in seen:
-            continue
-        if os.environ.get(key) or saved.get(key):
+    for key in ["GEMINI_API_KEY", "OPENAI_API_KEY", "XAI_API_KEY"]:
+        provider = _key_to_provider[key]
+        if provider not in seen and creds.get(key):
             out.append(provider)
             seen.add(provider)
     return out
@@ -186,7 +177,7 @@ def build_app() -> FastMCP:
                     }
                 return {
                     "status": "saved",
-                    "providers_configured": _providers_configured(),
+                    "providers_configured": _providers_configured_live(),
                 }
             case "relay_status":
                 # Derive providers from live PerPluginStore + env so status
@@ -204,6 +195,14 @@ def build_app() -> FastMCP:
                 }
             case "relay_skip":
                 # Only claim "using env vars" when env vars are actually set.
+                from imagine_mcp.credential_state import get_current_sub
+
+                if get_current_sub():
+                    return {
+                        "status": "needs_setup",
+                        "message": "Multi-user mode ignores environment variables. Run config(action='open_relay') to configure.",
+                    }
+
                 _env_providers = _providers_configured()
                 if not _env_providers:
                     return {
@@ -225,7 +224,7 @@ def build_app() -> FastMCP:
                 return {
                     "version": _get_version(),
                     "credentials_state": _creds_state(),
-                    "providers_configured": _providers_configured(),
+                    "providers_configured": _providers_configured_live(),
                     "default_provider": settings.default_provider,
                     "default_tier": settings.default_tier,
                     "cache_ttl_seconds": settings.cache_ttl_seconds,

--- a/tests/test_g6_ux_status_accuracy.py
+++ b/tests/test_g6_ux_status_accuracy.py
@@ -33,7 +33,14 @@ def _relay_status() -> dict[str, Any]:
 
 def _relay_skip() -> dict[str, Any]:
     """Simulate config(action='relay_skip') using module-level helper."""
+    from imagine_mcp.credential_state import get_current_sub
     from imagine_mcp.server import _providers_configured
+
+    if get_current_sub():
+        return {
+            "status": "needs_setup",
+            "message": "Multi-user mode ignores environment variables. Run config(action='open_relay') to configure.",
+        }
 
     env_providers = _providers_configured()
     if not env_providers:
@@ -46,6 +53,10 @@ def _relay_skip() -> dict[str, Any]:
 
 class TestRelayStatusLiveDerivedState:
     """relay_status derives state from live PerPluginStore, not env-only."""
+
+    @pytest.fixture(autouse=True)
+    def ensure_http_mode(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("TRANSPORT_MODE", "http")
 
     def test_returns_configured_when_store_has_keys(
         self, monkeypatch: pytest.MonkeyPatch
@@ -139,3 +150,17 @@ class TestRelaySkipHonesty:
 
         assert result["status"] == "using_env"
         assert "openai" in result["providers"]
+
+    def test_returns_needs_setup_when_sub_set(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """relay_skip returns needs_setup when sub context is set."""
+        from imagine_mcp.credential_state import set_current_sub
+
+        set_current_sub("test-sub")
+        try:
+            result = _relay_skip()
+            assert result["status"] == "needs_setup"
+            assert "Multi-user mode ignores environment variables" in result["message"]
+        finally:
+            set_current_sub(None)

--- a/uv.lock
+++ b/uv.lock
@@ -549,7 +549,7 @@ wheels = [
 
 [[package]]
 name = "imagine-mcp"
-version = "1.5.4b2"
+version = "1.5.4"
 source = { editable = "." }
 dependencies = [
     { name = "diskcache" },


### PR DESCRIPTION
This PR fixes an issue where `relay_skip` incorrectly reported "Using env vars for credentials" even when none were set, and ensures that `relay_status`/`relay_complete` provide an accurate live view of credentials across restarts by integrating `PerPluginStore` fallback into the core credential resolution logic.

Key changes:
1.  **Credential Resolution**: `credentials_for_current_request` now falls back to the global `PerPluginStore` in single-user HTTP mode if environment variables are missing.
2.  **Live Status**: `_providers_configured_live` and `_creds_state` now use the sub-aware `credentials_for_current_request` for accuracy.
3.  **Sub-Aware Relay Skip**: `relay_skip` now checks if a `sub` is present and returns `needs_setup` if so, as multi-user mode ignores environment variables.
4.  **Test Updates**: Updated `tests/test_g6_ux_status_accuracy.py` to verify these fixes.

---
*PR created automatically by Jules for task [8079152168782411557](https://jules.google.com/task/8079152168782411557) started by @n24q02m*