### PR TITLE
[FIX] Too many parameters: generate_video

### DIFF
--- a/src/imagine_mcp/dispatcher.py
+++ b/src/imagine_mcp/dispatcher.py
@@ -15,6 +15,7 @@ from imagine_mcp.errors import (
 )
 from imagine_mcp.media import detect_media_type, validate_url_and_get_ip
 from imagine_mcp.models import UNSUPPORTED, get_model_id
+from imagine_mcp.providers.base import VideoParams
 
 VALID_PROVIDERS = ["gemini", "openai", "grok"]
 VALID_TIERS = ["poor", "rich"]
@@ -192,6 +193,13 @@ def dispatch_generate(
     mod = _load_provider(provider)
     if media_type == "image":
         return mod.generate_image(prompt, tier, reference_image_url, aspect_ratio)
-    return mod.generate_video(
-        prompt, tier, reference_image_url, job_id, aspect_ratio, duration_seconds
+
+    params = VideoParams(
+        prompt=prompt,
+        tier=tier,
+        reference_image_url=reference_image_url,
+        job_id=job_id,
+        aspect_ratio=aspect_ratio,
+        duration_seconds=duration_seconds,
     )
+    return mod.generate_video(params)

--- a/src/imagine_mcp/providers/base.py
+++ b/src/imagine_mcp/providers/base.py
@@ -2,7 +2,18 @@
 
 from __future__ import annotations
 
+from dataclasses import dataclass
 from typing import Any, Protocol
+
+
+@dataclass(frozen=True, slots=True)
+class VideoParams:
+    prompt: str
+    tier: str
+    reference_image_url: str | None = None
+    job_id: str | None = None
+    aspect_ratio: str = "16:9"
+    duration_seconds: int = 8
 
 
 class ImagineProvider(Protocol):
@@ -22,12 +33,4 @@ class ImagineProvider(Protocol):
         aspect_ratio: str = "1:1",
     ) -> dict[str, Any]: ...
 
-    def generate_video(
-        self,
-        prompt: str,
-        tier: str,
-        reference_image_url: str | None = None,
-        job_id: str | None = None,
-        aspect_ratio: str = "16:9",
-        duration_seconds: int = 8,
-    ) -> dict[str, Any]: ...
+    def generate_video(self, params: VideoParams) -> dict[str, Any]: ...

--- a/src/imagine_mcp/providers/gemini.py
+++ b/src/imagine_mcp/providers/gemini.py
@@ -13,6 +13,7 @@ import platformdirs
 from imagine_mcp.config import settings
 from imagine_mcp.errors import CredentialMissingError, ProviderAPIError
 from imagine_mcp.models import get_model_id
+from imagine_mcp.providers.base import VideoParams
 
 _CLIENT: Any = None
 # Per-sub client cache for HTTP multi-user mode. Keyed by JWT sub so each
@@ -261,28 +262,19 @@ def generate_image(
     }
 
 
-def generate_video(
-    prompt: str,
-    tier: str,
-    reference_image_url: str | None = None,
-    job_id: str | None = None,
-    aspect_ratio: str = "16:9",
-    duration_seconds: int = 8,
-) -> dict[str, Any]:
+def generate_video(params: VideoParams) -> dict[str, Any]:
     from google.genai import types
 
-    model = get_model_id("gemini", "generate", "video", tier)
+    model = get_model_id("gemini", "generate", "video", params.tier)
     client = _client()
 
-    if job_id is None:
-        # Original code did not use reference_image_url here.
-        # Keeping it consistent for now but ensuring we don't pass it to the backend.
+    if params.job_id is None:
         op = client.models.generate_videos(
             model=model,
-            prompt=prompt,
+            prompt=params.prompt,
             config=types.GenerateVideosConfig(
-                aspect_ratio=aspect_ratio,
-                duration_seconds=duration_seconds,
+                aspect_ratio=params.aspect_ratio,
+                duration_seconds=params.duration_seconds,
                 person_generation="allow_all",
             ),
         )
@@ -292,12 +284,12 @@ def generate_video(
             "eta_seconds": 60,
             "model": model,
             "provider": "gemini",
-            "tier": tier,
+            "tier": params.tier,
         }
 
-    op = client.operations.get(job_id)
+    op = client.operations.get(params.job_id)
     if not op.done:
-        return {"job_id": job_id, "status": "pending", "eta_seconds": 30}
+        return {"job_id": params.job_id, "status": "pending", "eta_seconds": 30}
 
     if op.error:
         raise ProviderAPIError(f"Gemini job error: {op.error}", status_code=500)
@@ -311,9 +303,9 @@ def generate_video(
 
     return {
         "video_path": str(out_path),
-        "job_id": job_id,
+        "job_id": params.job_id,
         "status": "done",
         "model": model,
         "provider": "gemini",
-        "tier": tier,
+        "tier": params.tier,
     }

--- a/src/imagine_mcp/providers/grok.py
+++ b/src/imagine_mcp/providers/grok.py
@@ -27,6 +27,7 @@ from imagine_mcp.errors import (
 )
 from imagine_mcp.media import get_ssrf_safe_client
 from imagine_mcp.models import get_model_id
+from imagine_mcp.providers.base import VideoParams
 
 _CLIENT: Any = None
 _BASE_URL = "https://api.x.ai/v1"
@@ -185,28 +186,21 @@ def generate_image(
     }
 
 
-def generate_video(
-    prompt: str,
-    tier: str,
-    reference_image_url: str | None = None,
-    job_id: str | None = None,
-    aspect_ratio: str = "16:9",
-    duration_seconds: int = 8,
-) -> dict[str, Any]:
-    model = get_model_id("grok", "generate", "video", tier)
+def generate_video(params: VideoParams) -> dict[str, Any]:
+    model = get_model_id("grok", "generate", "video", params.tier)
     headers = {"Authorization": f"Bearer {_api_key()}"}
 
-    if job_id is None:
+    if params.job_id is None:
         payload: dict[str, Any] = {
             "model": model,
-            "prompt": prompt,
-            "duration_seconds": duration_seconds,
-            "aspect_ratio": aspect_ratio,
+            "prompt": params.prompt,
+            "duration_seconds": params.duration_seconds,
+            "aspect_ratio": params.aspect_ratio,
         }
-        if reference_image_url:
+        if params.reference_image_url:
             # Download source image and pass as base64 data URL
             resp_img = get_ssrf_safe_client().get(
-                reference_image_url, follow_redirects=True, timeout=60
+                params.reference_image_url, follow_redirects=True, timeout=60
             )
             img_b64 = base64.b64encode(resp_img.content).decode()
             mime_type = resp_img.headers.get("content-type", "image/png")
@@ -232,10 +226,10 @@ def generate_video(
             "eta_seconds": data.get("eta_seconds", 30),
             "model": model,
             "provider": "grok",
-            "tier": tier,
+            "tier": params.tier,
         }
 
-    safe_job_id = urllib.parse.quote(job_id, safe="")
+    safe_job_id = urllib.parse.quote(params.job_id, safe="")
     resp = get_ssrf_safe_client().get(
         f"{_BASE_URL}/videos/generations/{safe_job_id}",
         headers=headers,
@@ -251,7 +245,7 @@ def generate_video(
 
     if data["status"] == "pending":
         return {
-            "job_id": job_id,
+            "job_id": params.job_id,
             "status": "pending",
             "eta_seconds": data.get("eta_seconds", 15),
         }
@@ -277,9 +271,9 @@ def generate_video(
     return {
         "video_path": str(out_path),
         "video_url": video_url,
-        "job_id": job_id,
+        "job_id": params.job_id,
         "status": "done",
         "model": model,
         "provider": "grok",
-        "tier": tier,
+        "tier": params.tier,
     }

--- a/src/imagine_mcp/providers/openai.py
+++ b/src/imagine_mcp/providers/openai.py
@@ -17,6 +17,7 @@ from imagine_mcp.errors import (
     ProviderUnsupportedError,
 )
 from imagine_mcp.models import get_model_id
+from imagine_mcp.providers.base import VideoParams
 
 _CLIENT: Any = None
 # Per-sub client cache for HTTP multi-user mode. See providers/gemini.py
@@ -162,14 +163,7 @@ def generate_image(
     }
 
 
-def generate_video(
-    prompt: str,
-    tier: str,
-    reference_image_url: str | None = None,
-    job_id: str | None = None,
-    aspect_ratio: str = "16:9",
-    duration_seconds: int = 8,
-) -> dict[str, Any]:
+def generate_video(params: VideoParams) -> dict[str, Any]:
     raise ProviderUnsupportedError(
         "openai.generate.video: Sora 2 API shutdown 2026-09-24. "
         "Use provider='gemini' (Veo) or 'grok' (Grok Imagine)."

--- a/tests/test_providers_openai.py
+++ b/tests/test_providers_openai.py
@@ -6,6 +6,7 @@ import pytest
 
 from imagine_mcp.errors import ProviderUnsupportedError
 from imagine_mcp.providers import openai as provider
+from imagine_mcp.providers.base import VideoParams
 
 
 @pytest.fixture
@@ -28,7 +29,7 @@ def test_understand_video_raises() -> None:
 
 def test_generate_video_raises() -> None:
     with pytest.raises(ProviderUnsupportedError):
-        provider.generate_video("a dog", "poor")
+        provider.generate_video(VideoParams(prompt="a dog", tier="poor"))
 
 
 def test_understand_image_mocked(

--- a/uv.lock
+++ b/uv.lock
@@ -549,7 +549,7 @@ wheels = [
 
 [[package]]
 name = "imagine-mcp"
-version = "1.5.4b2"
+version = "1.5.4"
 source = { editable = "." }
 dependencies = [
     { name = "diskcache" },


### PR DESCRIPTION
Refactored the `generate_video` method in the `ImagineProvider` protocol and its implementations (Gemini, OpenAI, Grok) to accept a single `VideoParams` dataclass instead of multiple individual parameters. This improves code maintainability and complies with the design goal of reducing parameter counts in complex functions.

Key changes:
- Defined `VideoParams` dataclass in `src/imagine_mcp/providers/base.py`.
- Updated `ImagineProvider` protocol to use `VideoParams`.
- Updated Gemini, OpenAI, and Grok provider implementations.
- Updated `src/imagine_mcp/dispatcher.py` to instantiate `VideoParams`.
- Updated `tests/test_providers_openai.py` to reflect the new signature.

---
*PR created automatically by Jules for task [1390033471017201057](https://jules.google.com/task/1390033471017201057) started by @n24q02m*