### PR TITLE
[FIX] Long function: config

### DIFF
--- a/src/imagine_mcp/server.py
+++ b/src/imagine_mcp/server.py
@@ -13,6 +13,7 @@ from fastmcp import FastMCP
 from loguru import logger
 from mcp_core.relay.tool_helpers import register_open_relay_tool
 
+from imagine_mcp import relay_setup
 from imagine_mcp.config import settings
 from imagine_mcp.dispatcher import dispatch_generate, dispatch_understand
 from imagine_mcp.relay_schema import RELAY_SCHEMA
@@ -94,6 +95,87 @@ def _set_runtime(key: str | None, value: str | None) -> dict[str, Any]:
     }
 
 
+def _config_open_relay() -> dict[str, Any]:
+    result = asyncio.run(relay_setup.ensure_config(force=True))
+    if result is None:
+        return {
+            "status": "degraded",
+            "message": (
+                "No credentials loaded. Set MCP_RELAY_URL and retry, "
+                "or run the server in `http local relay mode` (default)."
+            ),
+        }
+    return {
+        "status": "saved",
+        "providers_configured": _providers_configured(),
+    }
+
+
+def _config_relay_status() -> dict[str, Any]:
+    # Derive providers from live PerPluginStore + env so status
+    # is accurate even when env vars were not populated at startup.
+    _live_providers = _providers_configured_live()
+    return {
+        "status": "configured" if _live_providers else "pending",
+        "providers_configured": _live_providers,
+    }
+
+
+def _config_relay_complete() -> dict[str, Any]:
+    _live_providers = _providers_configured_live()
+    return {
+        "status": "saved" if _live_providers else "no_credentials",
+        "providers_configured": _live_providers,
+    }
+
+
+def _config_relay_skip() -> dict[str, Any]:
+    # Only claim "using env vars" when env vars are actually set.
+    _env_providers = _providers_configured()
+    if not _env_providers:
+        return {
+            "status": "needs_setup",
+            "message": "No env vars set. Run config(action='open_relay') to configure via browser.",
+        }
+    return {
+        "status": "using_env",
+        "providers": _env_providers,
+    }
+
+
+def _config_relay_reset() -> dict[str, Any]:
+    return relay_setup.reset_credentials()
+
+
+def _config_warmup() -> dict[str, Any]:
+    return {
+        "status": "ok",
+        "message": "No heavy resources to warm up in v1.",
+    }
+
+
+def _config_status() -> dict[str, Any]:
+    return {
+        "version": _get_version(),
+        "credentials_state": _creds_state(),
+        "providers_configured": _providers_configured(),
+        "default_provider": settings.default_provider,
+        "default_tier": settings.default_tier,
+        "cache_ttl_seconds": settings.cache_ttl_seconds,
+    }
+
+
+def _config_cache_clear() -> dict[str, Any]:
+    from imagine_mcp.cache import ResponseCache
+
+    cache = ResponseCache(
+        path=Path(platformdirs.user_cache_dir("imagine-mcp")) / "cache",
+        default_ttl=settings.cache_ttl_seconds,
+    )
+    cache.clear()
+    return {"status": "ok", "message": "Cache cleared."}
+
+
 def build_app() -> FastMCP:
     """Create FastMCP app with 4 tools registered."""
     app: FastMCP = FastMCP(
@@ -169,78 +251,25 @@ def build_app() -> FastMCP:
         value: str | None = None,
     ) -> dict[str, Any]:
         """Server config and credential management."""
-        from imagine_mcp import relay_setup
-
         match action:
             case "open_relay":
-                import asyncio
-
-                result = asyncio.run(relay_setup.ensure_config(force=True))
-                if result is None:
-                    return {
-                        "status": "degraded",
-                        "message": (
-                            "No credentials loaded. Set MCP_RELAY_URL and retry, "
-                            "or run the server in `http local relay mode` (default)."
-                        ),
-                    }
-                return {
-                    "status": "saved",
-                    "providers_configured": _providers_configured(),
-                }
+                return _config_open_relay()
             case "relay_status":
-                # Derive providers from live PerPluginStore + env so status
-                # is accurate even when env vars were not populated at startup.
-                _live_providers = _providers_configured_live()
-                return {
-                    "status": "configured" if _live_providers else "pending",
-                    "providers_configured": _live_providers,
-                }
+                return _config_relay_status()
             case "relay_complete":
-                _live_providers = _providers_configured_live()
-                return {
-                    "status": "saved" if _live_providers else "no_credentials",
-                    "providers_configured": _live_providers,
-                }
+                return _config_relay_complete()
             case "relay_skip":
-                # Only claim "using env vars" when env vars are actually set.
-                _env_providers = _providers_configured()
-                if not _env_providers:
-                    return {
-                        "status": "needs_setup",
-                        "message": "No env vars set. Run config(action='open_relay') to configure via browser.",
-                    }
-                return {
-                    "status": "using_env",
-                    "providers": _env_providers,
-                }
+                return _config_relay_skip()
             case "relay_reset":
-                return relay_setup.reset_credentials()
+                return _config_relay_reset()
             case "warmup":
-                return {
-                    "status": "ok",
-                    "message": "No heavy resources to warm up in v1.",
-                }
+                return _config_warmup()
             case "status":
-                return {
-                    "version": _get_version(),
-                    "credentials_state": _creds_state(),
-                    "providers_configured": _providers_configured(),
-                    "default_provider": settings.default_provider,
-                    "default_tier": settings.default_tier,
-                    "cache_ttl_seconds": settings.cache_ttl_seconds,
-                }
+                return _config_status()
             case "set":
                 return _set_runtime(key, value)
             case "cache_clear":
-                from imagine_mcp.cache import ResponseCache
-
-                cache = ResponseCache(
-                    path=Path(platformdirs.user_cache_dir("imagine-mcp")) / "cache",
-                    default_ttl=settings.cache_ttl_seconds,
-                )
-                cache.clear()
-                return {"status": "ok", "message": "Cache cleared."}
+                return _config_cache_clear()
             case _:
                 return {
                     "status": "error",

--- a/uv.lock
+++ b/uv.lock
@@ -549,7 +549,7 @@ wheels = [
 
 [[package]]
 name = "imagine-mcp"
-version = "1.5.4b2"
+version = "1.5.4"
 source = { editable = "." }
 dependencies = [
     { name = "diskcache" },


### PR DESCRIPTION
This PR refactors the long 'config' function in 'src/imagine_mcp/server.py' by extracting its action-specific logic into private module-level helper functions. This improves code readability and maintainability without changing existing functionality.

Key changes:
- Moved 'relay_setup' import to top-level.
- Created helper functions: '_config_open_relay', '_config_relay_status', '_config_relay_complete', '_config_relay_skip', '_config_relay_reset', '_config_warmup', '_config_status', and '_config_cache_clear'.
- Refactored 'config' tool to delegate to these helpers.
- Verified logic with segment-by-segment file reading and full test suite.

---
*PR created automatically by Jules for task [15865489697462990457](https://jules.google.com/task/15865489697462990457) started by @n24q02m*