### PR TITLE
[FIX] Long function: generate_video

### DIFF
--- a/src/imagine_mcp/providers/grok.py
+++ b/src/imagine_mcp/providers/grok.py
@@ -185,56 +185,60 @@ def generate_image(
     }
 
 
-def generate_video(
+def _submit_video_generation(
+    model: str,
     prompt: str,
     tier: str,
-    reference_image_url: str | None = None,
-    job_id: str | None = None,
-    aspect_ratio: str = "16:9",
-    duration_seconds: int = 8,
+    reference_image_url: str | None,
+    aspect_ratio: str,
+    duration_seconds: int,
+    headers: dict[str, str],
 ) -> dict[str, Any]:
-    model = get_model_id("grok", "generate", "video", tier)
-    headers = {"Authorization": f"Bearer {_api_key()}"}
-
-    if job_id is None:
-        payload: dict[str, Any] = {
-            "model": model,
-            "prompt": prompt,
-            "duration_seconds": duration_seconds,
-            "aspect_ratio": aspect_ratio,
-        }
-        if reference_image_url:
-            # Download source image and pass as base64 data URL
-            resp_img = get_ssrf_safe_client().get(
-                reference_image_url, follow_redirects=True, timeout=60
-            )
-            img_b64 = base64.b64encode(resp_img.content).decode()
-            mime_type = resp_img.headers.get("content-type", "image/png")
-            data_url = f"data:{mime_type};base64,{img_b64}"
-            payload["source_image"] = data_url
-
-        resp = get_ssrf_safe_client().post(
-            f"{_BASE_URL}/videos/generations",
-            json=payload,
-            headers=headers,
-            timeout=60,
-            follow_redirects=True,
+    payload: dict[str, Any] = {
+        "model": model,
+        "prompt": prompt,
+        "duration_seconds": duration_seconds,
+        "aspect_ratio": aspect_ratio,
+    }
+    if reference_image_url:
+        # Download source image and pass as base64 data URL
+        resp_img = get_ssrf_safe_client().get(
+            reference_image_url, follow_redirects=True, timeout=60
         )
-        if resp.status_code != 200:
-            raise ProviderAPIError(
-                f"Grok video submit failed: {resp.text}",
-                status_code=resp.status_code,
-            )
-        data = resp.json()
-        return {
-            "job_id": data["id"],
-            "status": "pending",
-            "eta_seconds": data.get("eta_seconds", 30),
-            "model": model,
-            "provider": "grok",
-            "tier": tier,
-        }
+        img_b64 = base64.b64encode(resp_img.content).decode()
+        mime_type = resp_img.headers.get("content-type", "image/png")
+        data_url = f"data:{mime_type};base64,{img_b64}"
+        payload["source_image"] = data_url
 
+    resp = get_ssrf_safe_client().post(
+        f"{_BASE_URL}/videos/generations",
+        json=payload,
+        headers=headers,
+        timeout=60,
+        follow_redirects=True,
+    )
+    if resp.status_code != 200:
+        raise ProviderAPIError(
+            f"Grok video submit failed: {resp.text}",
+            status_code=resp.status_code,
+        )
+    data = resp.json()
+    return {
+        "job_id": data["id"],
+        "status": "pending",
+        "eta_seconds": data.get("eta_seconds", 30),
+        "model": model,
+        "provider": "grok",
+        "tier": tier,
+    }
+
+
+def _poll_video_generation(
+    job_id: str,
+    model: str,
+    tier: str,
+    headers: dict[str, str],
+) -> dict[str, Any]:
     safe_job_id = urllib.parse.quote(job_id, safe="")
     resp = get_ssrf_safe_client().get(
         f"{_BASE_URL}/videos/generations/{safe_job_id}",
@@ -283,3 +287,28 @@ def generate_video(
         "provider": "grok",
         "tier": tier,
     }
+
+
+def generate_video(
+    prompt: str,
+    tier: str,
+    reference_image_url: str | None = None,
+    job_id: str | None = None,
+    aspect_ratio: str = "16:9",
+    duration_seconds: int = 8,
+) -> dict[str, Any]:
+    model = get_model_id("grok", "generate", "video", tier)
+    headers = {"Authorization": f"Bearer {_api_key()}"}
+
+    if job_id is None:
+        return _submit_video_generation(
+            model,
+            prompt,
+            tier,
+            reference_image_url,
+            aspect_ratio,
+            duration_seconds,
+            headers,
+        )
+
+    return _poll_video_generation(job_id, model, tier, headers)

--- a/tests/test_providers_grok_video.py
+++ b/tests/test_providers_grok_video.py
@@ -1,0 +1,78 @@
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from imagine_mcp.providers import grok as provider
+
+
+@pytest.fixture
+def mock_deps(monkeypatch: pytest.MonkeyPatch) -> MagicMock:
+    monkeypatch.setattr(provider, "_api_key", lambda: "fake-key")
+
+    mock_client = MagicMock()
+    # Mocking get_ssrf_safe_client to return our mock_client
+    monkeypatch.setattr(
+        "imagine_mcp.providers.grok.get_ssrf_safe_client", lambda: mock_client
+    )
+    return mock_client
+
+
+def test_generate_video_submit(mock_deps: MagicMock) -> None:
+    # Mock submission response
+    mock_resp = MagicMock()
+    mock_resp.status_code = 200
+    mock_resp.json.return_value = {"id": "job123", "eta_seconds": 45}
+    mock_deps.post.return_value = mock_resp
+
+    result = provider.generate_video(
+        prompt="a flying cat",
+        tier="rich",
+    )
+
+    assert result["job_id"] == "job123"
+    assert result["status"] == "pending"
+    assert result["eta_seconds"] == 45
+    assert result["provider"] == "grok"
+
+
+def test_generate_video_poll_pending(mock_deps: MagicMock) -> None:
+    # Mock polling response (pending)
+    mock_resp = MagicMock()
+    mock_resp.status_code = 200
+    mock_resp.json.return_value = {"status": "pending", "eta_seconds": 10}
+    mock_deps.get.return_value = mock_resp
+
+    result = provider.generate_video(
+        prompt="a flying cat", tier="rich", job_id="job123"
+    )
+
+    assert result["job_id"] == "job123"
+    assert result["status"] == "pending"
+    assert result["eta_seconds"] == 10
+
+
+def test_generate_video_poll_done(mock_deps: MagicMock) -> None:
+    # Mock polling response (done)
+    mock_poll_resp = MagicMock()
+    mock_poll_resp.status_code = 200
+    mock_poll_resp.json.return_value = {
+        "status": "done",
+        "video_url": "https://example.com/video.mp4",
+    }
+
+    mock_video_resp = MagicMock()
+    mock_video_resp.content = b"fake-video-bytes"
+
+    # Configure mock_deps.get to return different responses based on call
+    mock_deps.get.side_effect = [mock_poll_resp, mock_video_resp]
+
+    result = provider.generate_video(
+        prompt="a flying cat", tier="rich", job_id="job123"
+    )
+
+    assert result["job_id"] == "job123"
+    assert result["status"] == "done"
+    assert "video_path" in result
+    assert result["video_url"] == "https://example.com/video.mp4"

--- a/uv.lock
+++ b/uv.lock
@@ -552,7 +552,7 @@ wheels = [
 
 [[package]]
 name = "imagine-mcp"
-version = "1.5.4"
+version = "1.6.0"
 source = { editable = "." }
 dependencies = [
     { name = "diskcache" },


### PR DESCRIPTION
Refactored the `generate_video` function in `src/imagine_mcp/providers/grok.py` which was identified as too long.

Changes:
- Split `generate_video` into three functions:
    - `_submit_video_generation`: Handles the initial video generation request.
    - `_poll_video_generation`: Handles status polling and video download.
    - `generate_video`: Orchestrates the call to either of the above based on `job_id`.
- Added `tests/test_providers_grok_video.py` to ensure functional parity and prevent regressions.
- Verified all tests pass, including the full suite.

---
*PR created automatically by Jules for task [8529299035625995106](https://jules.google.com/task/8529299035625995106) started by @n24q02m*