### PR TITLE
[TEST] Test for get_ssrf_safe_client

### DIFF
--- a/tests/test_media.py
+++ b/tests/test_media.py
@@ -12,6 +12,7 @@ from imagine_mcp.media import (
     _extract_extension,
     detect_media_type,
     download_to_path,
+    get_ssrf_safe_client,
     resolve_image_mime,
     sniff_image_mime,
     validate_url_and_get_ip,
@@ -278,3 +279,17 @@ class TestSSRFProtection:
         transport = SSRFSafeTransport()
         transport.handle_request(httpx.Request("GET", "file:///etc/passwd"))
         assert called["validated"] is False
+
+
+def test_get_ssrf_safe_client() -> None:
+    client1 = get_ssrf_safe_client()
+    assert isinstance(client1, httpx.Client)
+
+    # Singleton behavior
+    client2 = get_ssrf_safe_client()
+    assert client1 is client2
+
+    # Verify transport
+    # Note: client._transport is private but used for verification here.
+    # In httpx, the transport is accessible via the _transport attribute on the client.
+    assert isinstance(client1._transport, SSRFSafeTransport)

--- a/uv.lock
+++ b/uv.lock
@@ -552,7 +552,7 @@ wheels = [
 
 [[package]]
 name = "imagine-mcp"
-version = "1.5.4"
+version = "1.6.0"
 source = { editable = "." }
 dependencies = [
     { name = "diskcache" },


### PR DESCRIPTION
This PR adds a unit test for the `get_ssrf_safe_client` function in `src/imagine_mcp/media.py`. The test verifies that the function returns an `httpx.Client` instance, follows the singleton pattern, and is correctly configured with `SSRFSafeTransport`.

---
*PR created automatically by Jules for task [17399667962969957954](https://jules.google.com/task/17399667962969957954) started by @n24q02m*