### PR TITLE
fix: relay_status/relay_complete returned stale state

### DIFF
--- a/src/imagine_mcp/server.py
+++ b/src/imagine_mcp/server.py
@@ -35,13 +35,9 @@ def _get_version() -> str:
 
 
 def _creds_state() -> str:
-    # Read from os.environ -- settings singleton is frozen at import time
-    # and does not observe post-startup relay-saved credentials.
-    if any(
-        os.environ.get(k) for k in ("GEMINI_API_KEY", "OPENAI_API_KEY", "XAI_API_KEY")
-    ):
-        return "CONFIGURED"
-    return "NEEDS_SETUP"
+    # Derive state from live PerPluginStore + env so status
+    # is accurate even when env vars were not populated at startup.
+    return "CONFIGURED" if _providers_configured_live() else "NEEDS_SETUP"
 
 
 def _providers_configured() -> list[str]:
@@ -195,7 +191,7 @@ def build_app() -> FastMCP:
                     }
                 return {
                     "status": "saved",
-                    "providers_configured": _providers_configured(),
+                    "providers_configured": _providers_configured_live(),
                 }
             case "relay_status":
                 # Derive providers from live PerPluginStore + env so status
@@ -234,7 +230,7 @@ def build_app() -> FastMCP:
                 return {
                     "version": _get_version(),
                     "credentials_state": _creds_state(),
-                    "providers_configured": _providers_configured(),
+                    "providers_configured": _providers_configured_live(),
                     "default_provider": settings.default_provider,
                     "default_tier": settings.default_tier,
                     "cache_ttl_seconds": settings.cache_ttl_seconds,

--- a/uv.lock
+++ b/uv.lock
@@ -552,7 +552,7 @@ wheels = [
 
 [[package]]
 name = "imagine-mcp"
-version = "1.5.4"
+version = "1.6.0"
 source = { editable = "." }
 dependencies = [
     { name = "diskcache" },


### PR DESCRIPTION
Updated _creds_state, open_relay, and status actions in the config tool to use _providers_configured_live(), ensuring accurate status reporting after credentials have been saved via the relay. This fix ensures that the server correctly reflects the configuration state even when environment variables were not populated at startup.

---
*PR created automatically by Jules for task [7151617724886333490](https://jules.google.com/task/7151617724886333490) started by @n24q02m*