### PR TITLE
[FIX] Too many parameters: generate_video

### DIFF
--- a/src/imagine_mcp/dispatcher.py
+++ b/src/imagine_mcp/dispatcher.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import importlib
 from concurrent.futures import ThreadPoolExecutor
+from dataclasses import dataclass
 from typing import Any
 
 from imagine_mcp.errors import (
@@ -15,10 +16,24 @@ from imagine_mcp.errors import (
 )
 from imagine_mcp.media import detect_media_type, validate_url_and_get_ip
 from imagine_mcp.models import UNSUPPORTED, get_model_id
+from imagine_mcp.providers.base import ImageParams, VideoParams
 
 VALID_PROVIDERS = ["gemini", "openai", "grok"]
 VALID_TIERS = ["poor", "rich"]
 VALID_MEDIA_TYPES = ["image", "video"]
+
+
+@dataclass(frozen=True, slots=True)
+class GenerateParams:
+    media_type: str
+    prompt: str
+    provider: str | None = None
+    tier: str = "poor"
+    reference_image_url: str | None = None
+    job_id: str | None = None
+    aspect_ratio: str = "16:9"
+    duration_seconds: int = 8
+
 
 # Auto-fallback priority when caller does not pin a provider. Order is
 # (XAI, OpenAI, Gemini): Gemini stays last because Google AI Studio
@@ -160,38 +175,44 @@ def dispatch_understand(
     return mod.understand_video(url, prompt, tier, max_tokens)
 
 
-def dispatch_generate(
-    media_type: str,
-    prompt: str,
-    provider: str | None,
-    tier: str,
-    reference_image_url: str | None = None,
-    job_id: str | None = None,
-    aspect_ratio: str = "16:9",
-    duration_seconds: int = 8,
-) -> dict[str, Any]:
+def dispatch_generate(params: GenerateParams) -> dict[str, Any]:
     """Dispatch generate call to provider.
 
     When ``provider`` is ``None``, auto-resolve via :func:`_default_provider`
     (first provider whose API key is present in the environment).
     """
+    provider = params.provider
     if provider is None:
         provider = _default_provider()
-    _validate(provider, tier)
-    if media_type not in VALID_MEDIA_TYPES:
-        raise InvalidMediaTypeError(
-            f"Unknown media_type {media_type!r}. Valid: {VALID_MEDIA_TYPES}"
-        )
-    if reference_image_url is not None:
-        _validate_url(reference_image_url, "reference_image_url")
 
-    model = get_model_id(provider, "generate", media_type, tier)
+    _validate(provider, params.tier)
+    if params.media_type not in VALID_MEDIA_TYPES:
+        raise InvalidMediaTypeError(
+            f"Unknown media_type {params.media_type!r}. Valid: {VALID_MEDIA_TYPES}"
+        )
+    if params.reference_image_url is not None:
+        _validate_url(params.reference_image_url, "reference_image_url")
+
+    model = get_model_id(provider, "generate", params.media_type, params.tier)
     if model is UNSUPPORTED:
-        raise _unsupported(provider, media_type, "generate")
+        raise _unsupported(provider, params.media_type, "generate")
 
     mod = _load_provider(provider)
-    if media_type == "image":
-        return mod.generate_image(prompt, tier, reference_image_url, aspect_ratio)
-    return mod.generate_video(
-        prompt, tier, reference_image_url, job_id, aspect_ratio, duration_seconds
+    if params.media_type == "image":
+        p = ImageParams(
+            prompt=params.prompt,
+            tier=params.tier,
+            reference_image_url=params.reference_image_url,
+            aspect_ratio=params.aspect_ratio,
+        )
+        return mod.generate_image(p)
+
+    p_vid = VideoParams(
+        prompt=params.prompt,
+        tier=params.tier,
+        reference_image_url=params.reference_image_url,
+        job_id=params.job_id,
+        aspect_ratio=params.aspect_ratio,
+        duration_seconds=params.duration_seconds,
     )
+    return mod.generate_video(p_vid)

--- a/src/imagine_mcp/providers/base.py
+++ b/src/imagine_mcp/providers/base.py
@@ -2,7 +2,26 @@
 
 from __future__ import annotations
 
+from dataclasses import dataclass
 from typing import Any, Protocol
+
+
+@dataclass(frozen=True, slots=True)
+class ImageParams:
+    prompt: str
+    tier: str
+    reference_image_url: str | None = None
+    aspect_ratio: str = "1:1"
+
+
+@dataclass(frozen=True, slots=True)
+class VideoParams:
+    prompt: str
+    tier: str
+    reference_image_url: str | None = None
+    job_id: str | None = None
+    aspect_ratio: str = "16:9"
+    duration_seconds: int = 8
 
 
 class ImagineProvider(Protocol):
@@ -14,20 +33,6 @@ class ImagineProvider(Protocol):
         self, url: str, prompt: str, tier: str, max_tokens: int = 2048
     ) -> dict[str, Any]: ...
 
-    def generate_image(
-        self,
-        prompt: str,
-        tier: str,
-        reference_image_url: str | None = None,
-        aspect_ratio: str = "1:1",
-    ) -> dict[str, Any]: ...
+    def generate_image(self, params: ImageParams) -> dict[str, Any]: ...
 
-    def generate_video(
-        self,
-        prompt: str,
-        tier: str,
-        reference_image_url: str | None = None,
-        job_id: str | None = None,
-        aspect_ratio: str = "16:9",
-        duration_seconds: int = 8,
-    ) -> dict[str, Any]: ...
+    def generate_video(self, params: VideoParams) -> dict[str, Any]: ...

--- a/src/imagine_mcp/providers/gemini.py
+++ b/src/imagine_mcp/providers/gemini.py
@@ -13,6 +13,7 @@ import platformdirs
 from imagine_mcp.config import settings
 from imagine_mcp.errors import CredentialMissingError, ProviderAPIError
 from imagine_mcp.models import get_model_id
+from imagine_mcp.providers.base import ImageParams, VideoParams
 
 _CLIENT: Any = None
 # Per-sub client cache for HTTP multi-user mode. Keyed by JWT sub so each
@@ -212,23 +213,18 @@ def understand_multimodal(
     }
 
 
-def generate_image(
-    prompt: str,
-    tier: str,
-    reference_image_url: str | None = None,
-    aspect_ratio: str = "1:1",
-) -> dict[str, Any]:
+def generate_image(params: ImageParams) -> dict[str, Any]:
     from google.genai import types
 
     from imagine_mcp.media import get_ssrf_safe_client, resolve_image_mime
 
     client = _client()
-    model = get_model_id("gemini", "generate", "image", tier)
-    contents: list[Any] = [prompt]
+    model = get_model_id("gemini", "generate", "image", params.tier)
+    contents: list[Any] = [params.prompt]
 
-    if reference_image_url:
+    if params.reference_image_url:
         img_resp = get_ssrf_safe_client().get(
-            reference_image_url, follow_redirects=True, timeout=60
+            params.reference_image_url, follow_redirects=True, timeout=60
         )
         img_data = img_resp.content
         mime_type = resolve_image_mime(img_resp.headers.get("content-type"), img_data)
@@ -257,32 +253,25 @@ def generate_image(
         "image_base64": base64.b64encode(image_data).decode(),
         "model": model,
         "provider": "gemini",
-        "tier": tier,
+        "tier": params.tier,
     }
 
 
-def generate_video(
-    prompt: str,
-    tier: str,
-    reference_image_url: str | None = None,
-    job_id: str | None = None,
-    aspect_ratio: str = "16:9",
-    duration_seconds: int = 8,
-) -> dict[str, Any]:
+def generate_video(params: VideoParams) -> dict[str, Any]:
     from google.genai import types
 
-    model = get_model_id("gemini", "generate", "video", tier)
+    model = get_model_id("gemini", "generate", "video", params.tier)
     client = _client()
 
-    if job_id is None:
+    if params.job_id is None:
         # Original code did not use reference_image_url here.
         # Keeping it consistent for now but ensuring we don't pass it to the backend.
         op = client.models.generate_videos(
             model=model,
-            prompt=prompt,
+            prompt=params.prompt,
             config=types.GenerateVideosConfig(
-                aspect_ratio=aspect_ratio,
-                duration_seconds=duration_seconds,
+                aspect_ratio=params.aspect_ratio,
+                duration_seconds=params.duration_seconds,
                 person_generation="allow_all",
             ),
         )
@@ -292,12 +281,12 @@ def generate_video(
             "eta_seconds": 60,
             "model": model,
             "provider": "gemini",
-            "tier": tier,
+            "tier": params.tier,
         }
 
-    op = client.operations.get(job_id)
+    op = client.operations.get(params.job_id)
     if not op.done:
-        return {"job_id": job_id, "status": "pending", "eta_seconds": 30}
+        return {"job_id": params.job_id, "status": "pending", "eta_seconds": 30}
 
     if op.error:
         raise ProviderAPIError(f"Gemini job error: {op.error}", status_code=500)
@@ -311,9 +300,9 @@ def generate_video(
 
     return {
         "video_path": str(out_path),
-        "job_id": job_id,
+        "job_id": params.job_id,
         "status": "done",
         "model": model,
         "provider": "gemini",
-        "tier": tier,
+        "tier": params.tier,
     }

--- a/src/imagine_mcp/providers/grok.py
+++ b/src/imagine_mcp/providers/grok.py
@@ -27,6 +27,7 @@ from imagine_mcp.errors import (
 )
 from imagine_mcp.media import get_ssrf_safe_client
 from imagine_mcp.models import get_model_id
+from imagine_mcp.providers.base import ImageParams, VideoParams
 
 _CLIENT: Any = None
 _BASE_URL = "https://api.x.ai/v1"
@@ -127,20 +128,15 @@ def understand_video(
     )
 
 
-def generate_image(
-    prompt: str,
-    tier: str,
-    reference_image_url: str | None = None,
-    aspect_ratio: str = "1:1",
-) -> dict[str, Any]:
-    model = get_model_id("grok", "generate", "image", tier)
+def generate_image(params: ImageParams) -> dict[str, Any]:
+    model = get_model_id("grok", "generate", "image", params.tier)
     headers = {"Authorization": f"Bearer {_api_key()}"}
-    payload: dict[str, Any] = {"model": model, "prompt": prompt, "n": 1}
+    payload: dict[str, Any] = {"model": model, "prompt": params.prompt, "n": 1}
 
-    if reference_image_url:
+    if params.reference_image_url:
         # Download reference image and pass as base64 data URL
         resp_img = get_ssrf_safe_client().get(
-            reference_image_url, follow_redirects=True, timeout=60
+            params.reference_image_url, follow_redirects=True, timeout=60
         )
         img_b64 = base64.b64encode(resp_img.content).decode()
         mime_type = resp_img.headers.get("content-type", "image/png")
@@ -181,32 +177,25 @@ def generate_image(
         "image_base64": img_b64,
         "model": model,
         "provider": "grok",
-        "tier": tier,
+        "tier": params.tier,
     }
 
 
-def generate_video(
-    prompt: str,
-    tier: str,
-    reference_image_url: str | None = None,
-    job_id: str | None = None,
-    aspect_ratio: str = "16:9",
-    duration_seconds: int = 8,
-) -> dict[str, Any]:
-    model = get_model_id("grok", "generate", "video", tier)
+def generate_video(params: VideoParams) -> dict[str, Any]:
+    model = get_model_id("grok", "generate", "video", params.tier)
     headers = {"Authorization": f"Bearer {_api_key()}"}
 
-    if job_id is None:
+    if params.job_id is None:
         payload: dict[str, Any] = {
             "model": model,
-            "prompt": prompt,
-            "duration_seconds": duration_seconds,
-            "aspect_ratio": aspect_ratio,
+            "prompt": params.prompt,
+            "duration_seconds": params.duration_seconds,
+            "aspect_ratio": params.aspect_ratio,
         }
-        if reference_image_url:
+        if params.reference_image_url:
             # Download source image and pass as base64 data URL
             resp_img = get_ssrf_safe_client().get(
-                reference_image_url, follow_redirects=True, timeout=60
+                params.reference_image_url, follow_redirects=True, timeout=60
             )
             img_b64 = base64.b64encode(resp_img.content).decode()
             mime_type = resp_img.headers.get("content-type", "image/png")
@@ -232,10 +221,10 @@ def generate_video(
             "eta_seconds": data.get("eta_seconds", 30),
             "model": model,
             "provider": "grok",
-            "tier": tier,
+            "tier": params.tier,
         }
 
-    safe_job_id = urllib.parse.quote(job_id, safe="")
+    safe_job_id = urllib.parse.quote(params.job_id, safe="")
     resp = get_ssrf_safe_client().get(
         f"{_BASE_URL}/videos/generations/{safe_job_id}",
         headers=headers,
@@ -251,7 +240,7 @@ def generate_video(
 
     if data["status"] == "pending":
         return {
-            "job_id": job_id,
+            "job_id": params.job_id,
             "status": "pending",
             "eta_seconds": data.get("eta_seconds", 15),
         }
@@ -277,9 +266,9 @@ def generate_video(
     return {
         "video_path": str(out_path),
         "video_url": video_url,
-        "job_id": job_id,
+        "job_id": params.job_id,
         "status": "done",
         "model": model,
         "provider": "grok",
-        "tier": tier,
+        "tier": params.tier,
     }

--- a/src/imagine_mcp/providers/openai.py
+++ b/src/imagine_mcp/providers/openai.py
@@ -17,6 +17,7 @@ from imagine_mcp.errors import (
     ProviderUnsupportedError,
 )
 from imagine_mcp.models import get_model_id
+from imagine_mcp.providers.base import ImageParams, VideoParams
 
 _CLIENT: Any = None
 # Per-sub client cache for HTTP multi-user mode. See providers/gemini.py
@@ -119,29 +120,26 @@ def understand_video(
     )
 
 
-def generate_image(
-    prompt: str,
-    tier: str,
-    reference_image_url: str | None = None,
-    aspect_ratio: str = "1:1",
-) -> dict[str, Any]:
-    model = get_model_id("openai", "generate", "image", tier)
+def generate_image(params: ImageParams) -> dict[str, Any]:
+    model = get_model_id("openai", "generate", "image", params.tier)
     size_map = {"1:1": "1024x1024", "16:9": "1792x1024", "9:16": "1024x1792"}
-    size = size_map.get(aspect_ratio, "1024x1024")
+    size = size_map.get(params.aspect_ratio, "1024x1024")
 
-    if reference_image_url:
+    if params.reference_image_url:
         from imagine_mcp.media import get_ssrf_safe_client
 
         img_bytes = (
             get_ssrf_safe_client()
-            .get(reference_image_url, follow_redirects=True, timeout=60)
+            .get(params.reference_image_url, follow_redirects=True, timeout=60)
             .content
         )
         resp = _client().images.edit(
-            model=model, image=img_bytes, prompt=prompt, size=size
+            model=model, image=img_bytes, prompt=params.prompt, size=size
         )
     else:
-        resp = _client().images.generate(model=model, prompt=prompt, size=size, n=1)
+        resp = _client().images.generate(
+            model=model, prompt=params.prompt, size=size, n=1
+        )
 
     img_b64 = resp.data[0].b64_json
     if not img_b64:
@@ -158,18 +156,11 @@ def generate_image(
         "image_base64": img_b64,
         "model": model,
         "provider": "openai",
-        "tier": tier,
+        "tier": params.tier,
     }
 
 
-def generate_video(
-    prompt: str,
-    tier: str,
-    reference_image_url: str | None = None,
-    job_id: str | None = None,
-    aspect_ratio: str = "16:9",
-    duration_seconds: int = 8,
-) -> dict[str, Any]:
+def generate_video(params: VideoParams) -> dict[str, Any]:
     raise ProviderUnsupportedError(
         "openai.generate.video: Sora 2 API shutdown 2026-09-24. "
         "Use provider='gemini' (Veo) or 'grok' (Grok Imagine)."

--- a/src/imagine_mcp/server.py
+++ b/src/imagine_mcp/server.py
@@ -15,7 +15,11 @@ from loguru import logger
 from mcp_core.relay.tool_helpers import register_open_relay_tool
 
 from imagine_mcp.config import settings
-from imagine_mcp.dispatcher import dispatch_generate, dispatch_understand
+from imagine_mcp.dispatcher import (
+    GenerateParams,
+    dispatch_generate,
+    dispatch_understand,
+)
 from imagine_mcp.relay_schema import RELAY_SCHEMA
 
 VALID_HELP_TOPICS = {"understand", "generate", "config"}
@@ -154,16 +158,17 @@ def build_app() -> FastMCP:
         duration_seconds: int = 8,
     ) -> dict[str, Any]:
         """Generate image or video."""
-        return dispatch_generate(
-            media_type,
-            prompt,
-            provider,
-            tier,
-            reference_image_url,
-            job_id,
-            aspect_ratio,
-            duration_seconds,
+        params = GenerateParams(
+            media_type=media_type,
+            prompt=prompt,
+            provider=provider,
+            tier=tier,
+            reference_image_url=reference_image_url,
+            job_id=job_id,
+            aspect_ratio=aspect_ratio,
+            duration_seconds=duration_seconds,
         )
+        return dispatch_generate(params)
 
     @app.tool(
         description=(

--- a/tests/test_dispatcher.py
+++ b/tests/test_dispatcher.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import pytest
 
 from imagine_mcp.dispatcher import (
+    GenerateParams,
     _default_provider,
     dispatch_generate,
     dispatch_understand,
@@ -89,20 +90,16 @@ def test_understand_unsupported_video_grok(monkeypatch: pytest.MonkeyPatch) -> N
 def test_generate_invalid_media_type() -> None:
     with pytest.raises(InvalidMediaTypeError):
         dispatch_generate(
-            media_type="audio",
-            prompt="hi",
-            provider="gemini",
-            tier="poor",
+            GenerateParams(media_type="audio", prompt="hi", provider="gemini")
         )
 
 
 def test_generate_unsupported_video_openai() -> None:
     with pytest.raises(ProviderUnsupportedError) as exc_info:
         dispatch_generate(
-            media_type="video",
-            prompt="a dog running",
-            provider="openai",
-            tier="poor",
+            GenerateParams(
+                media_type="video", prompt="a dog running", provider="openai"
+            )
         )
     assert (
         "sora" in str(exc_info.value).lower()
@@ -153,11 +150,12 @@ def test_understand_rejects_non_http_url_in_second_position() -> None:
 def test_generate_rejects_non_http_reference_image_url() -> None:
     with pytest.raises(InvalidURLError, match="reference_image_url"):
         dispatch_generate(
-            media_type="image",
-            prompt="cat",
-            provider="gemini",
-            tier="poor",
-            reference_image_url="file:///etc/passwd",
+            GenerateParams(
+                media_type="image",
+                prompt="cat",
+                provider="gemini",
+                reference_image_url="file:///etc/passwd",
+            )
         )
 
 
@@ -242,12 +240,9 @@ def test_dispatch_generate_resolves_default_provider(
 
     captured: dict[str, str] = {}
 
-    def mock_fn(
-        prompt: str,
-        tier: str,
-        reference_image_url: str | None,
-        aspect_ratio: str,
-    ) -> dict:
+    from imagine_mcp.providers.base import ImageParams
+
+    def mock_fn(params: ImageParams) -> dict:
         captured["called"] = "openai"
         return {"image": "...", "model": "gpt-image", "provider": "openai"}
 
@@ -256,10 +251,7 @@ def test_dispatch_generate_resolves_default_provider(
     monkeypatch.setattr(openai_mod, "generate_image", mock_fn, raising=False)
 
     result = dispatch_generate(
-        media_type="image",
-        prompt="a cat",
-        provider=None,
-        tier="poor",
+        GenerateParams(media_type="image", prompt="a cat", provider=None)
     )
     assert captured["called"] == "openai"
     assert result["provider"] == "openai"

--- a/tests/test_providers_gemini_generate.py
+++ b/tests/test_providers_gemini_generate.py
@@ -6,6 +6,7 @@ import pytest
 
 from imagine_mcp.errors import ProviderAPIError
 from imagine_mcp.providers import gemini
+from imagine_mcp.providers.base import ImageParams
 
 
 def test_generate_image_missing_data(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -25,7 +26,7 @@ def test_generate_image_missing_data(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(gemini, "_client", lambda: fake_client)
 
     with pytest.raises(ProviderAPIError, match="Gemini returned no image") as exc_info:
-        gemini.generate_image(prompt="a sunset", tier="poor")
+        gemini.generate_image(ImageParams(prompt="a sunset", tier="poor"))
 
     assert exc_info.value.status_code == 500
 
@@ -46,6 +47,6 @@ def test_generate_image_empty_inline_data(monkeypatch: pytest.MonkeyPatch) -> No
     monkeypatch.setattr(gemini, "_client", lambda: fake_client)
 
     with pytest.raises(ProviderAPIError, match="Gemini returned no image") as exc_info:
-        gemini.generate_image(prompt="a sunset", tier="poor")
+        gemini.generate_image(ImageParams(prompt="a sunset", tier="poor"))
 
     assert exc_info.value.status_code == 500

--- a/tests/test_providers_openai.py
+++ b/tests/test_providers_openai.py
@@ -6,6 +6,7 @@ import pytest
 
 from imagine_mcp.errors import ProviderUnsupportedError
 from imagine_mcp.providers import openai as provider
+from imagine_mcp.providers.base import VideoParams
 
 
 @pytest.fixture
@@ -28,7 +29,7 @@ def test_understand_video_raises() -> None:
 
 def test_generate_video_raises() -> None:
     with pytest.raises(ProviderUnsupportedError):
-        provider.generate_video("a dog", "poor")
+        provider.generate_video(VideoParams(prompt="a dog", tier="poor"))
 
 
 def test_understand_image_mocked(

--- a/uv.lock
+++ b/uv.lock
@@ -552,7 +552,7 @@ wheels = [
 
 [[package]]
 name = "imagine-mcp"
-version = "1.5.4"
+version = "1.6.0"
 source = { editable = "." }
 dependencies = [
     { name = "diskcache" },


### PR DESCRIPTION
Refactored image and video generation to use dataclasses for parameter encapsulation. This addresses the issue of functions having too many parameters, making them easier to test and maintain.

Changes:
- Defined `ImageParams` and `VideoParams` dataclasses in `src/imagine_mcp/providers/base.py`.
- Defined `GenerateParams` dataclass in `src/imagine_mcp/dispatcher.py`.
- Updated `ImagineProvider` protocol and all provider implementations (`gemini`, `grok`, `openai`).
- Updated the `generate` tool in `src/imagine_mcp/server.py` to use the new dataclasses.
- Updated the test suite to reflect the changes.

---
*PR created automatically by Jules for task [8501451112595578524](https://jules.google.com/task/8501451112595578524) started by @n24q02m*