### PR TITLE
fix: 🔒 [SECURITY] fix ssl validation when rewriting requests to ips

### DIFF
--- a/src/imagine_mcp/media.py
+++ b/src/imagine_mcp/media.py
@@ -113,6 +113,9 @@ class SSRFSafeBackend(httpcore.NetworkBackend):
         # Explicitly block Unix sockets for enhanced SSRF security.
         raise InvalidURLError("Unix sockets are not allowed.")
 
+    def sleep(self, seconds: float) -> None:
+        return self._backend.sleep(seconds)
+
 
 class SSRFSafeTransport(httpx.HTTPTransport):
     """Custom transport that uses SSRFSafeBackend for DNS pinning."""
@@ -121,7 +124,7 @@ class SSRFSafeTransport(httpx.HTTPTransport):
         super().__init__(**kwargs)
         # Inject the custom backend into the internal connection pool.
         # This is safe because HTTPTransport.__init__ creates the pool.
-        self._pool._network_backend = SSRFSafeBackend()
+        self._pool._network_backend = SSRFSafeBackend()  # type: ignore
 
     def handle_request(self, request: httpx.Request) -> httpx.Response:
         url = request.url
@@ -155,6 +158,7 @@ def _validate_hostname_and_get_ip(hostname: str, port: int | None, param: str) -
 
         for res in addr_info:
             # res[4] is the sockaddr tuple. The first element is the IP string.
+            # Explicitly stringify to satisfy type checkers.
             ip_str = str(res[4][0])
             ip_obj = ipaddress.ip_address(ip_str)
 

--- a/src/imagine_mcp/media.py
+++ b/src/imagine_mcp/media.py
@@ -6,10 +6,12 @@ import concurrent.futures
 import ipaddress
 import os
 import socket
+import typing
 from pathlib import Path
 from typing import Literal
 from urllib.parse import urlparse
 
+import httpcore
 import httpx
 
 from imagine_mcp.errors import InvalidURLError, MediaDetectError
@@ -73,64 +75,86 @@ def resolve_image_mime(content_type: str | None, data: bytes) -> str:
     return _IMAGE_FALLBACK_MIME
 
 
-class SSRFSafeTransport(httpx.HTTPTransport):
-    """Custom transport that implements DNS pinning to prevent TOCTOU SSRF.
+class SSRFSafeBackend(httpcore.NetworkBackend):
+    """Custom network backend that implements DNS pinning to prevent TOCTOU SSRF.
 
     It resolves the hostname, validates the IP against local/private ranges,
-    and then rewrites the request URL to use the IP address directly.
+    and then pins the TCP connection to that IP while preserving the original
+    hostname for TLS certificate validation.
     """
+
+    def __init__(self) -> None:
+        self._backend = httpcore.SyncBackend()
+
+    def connect_tcp(
+        self,
+        host: str,
+        port: int,
+        timeout: float | None = None,
+        local_address: str | None = None,
+        socket_options: typing.Iterable[httpcore.SOCKET_OPTION] | None = None,
+    ) -> httpcore.NetworkStream:
+        # Pin the request to a validated IP to prevent TOCTOU DNS rebinding.
+        ip = _validate_hostname_and_get_ip(host, port, "url")
+        return self._backend.connect_tcp(
+            host=ip,
+            port=port,
+            timeout=timeout,
+            local_address=local_address,
+            socket_options=socket_options,
+        )
+
+    def connect_unix_socket(
+        self,
+        path: str,
+        timeout: float | None = None,
+        socket_options: typing.Iterable[httpcore.SOCKET_OPTION] | None = None,
+    ) -> httpcore.NetworkStream:
+        # Explicitly block Unix sockets for enhanced SSRF security.
+        raise InvalidURLError("Unix sockets are not allowed.")
+
+
+class SSRFSafeTransport(httpx.HTTPTransport):
+    """Custom transport that uses SSRFSafeBackend for DNS pinning."""
+
+    def __init__(self, **kwargs: typing.Any) -> None:
+        super().__init__(**kwargs)
+        # Inject the custom backend into the internal connection pool.
+        # This is safe because HTTPTransport.__init__ creates the pool.
+        self._pool._network_backend = SSRFSafeBackend()
 
     def handle_request(self, request: httpx.Request) -> httpx.Response:
         url = request.url
         if url.scheme.lower() not in _SAFE_URL_SCHEMES:
             return super().handle_request(request)
 
-        host = url.host
-        ip = validate_url_and_get_ip(str(url), "redirect_url")
-
-        # Pin the request to the validated IP to prevent TOCTOU DNS rebinding.
-        request.url = request.url.copy_with(host=ip)
-
         # Ensure Host header is set for virtual hosting.
         if "Host" not in request.headers:
-            request.headers["Host"] = host
+            request.headers["Host"] = url.host
 
         # Set SNI extension for TLS.
-        request.extensions["sni_hostname"] = host
+        request.extensions["sni_hostname"] = url.host
 
         return super().handle_request(request)
 
 
-def validate_url_and_get_ip(url: str, param: str) -> str:
-    """Verify URL scheme and resolve hostname to a public IP.
+def _validate_hostname_and_get_ip(hostname: str, port: int | None, param: str) -> str:
+    """Resolve hostname to a public IP and validate it.
 
     Returns the first validated IP address string.
-    Raises InvalidURLError if the URL is unsafe.
+    Raises InvalidURLError if resolution fails or returns an unsafe IP.
     """
-    parsed = urlparse(url)
-    scheme = parsed.scheme.lower()
-    if scheme not in _SAFE_URL_SCHEMES:
-        raise InvalidURLError(
-            f"Invalid {param} scheme {scheme!r}. Only http/https are allowed."
-        )
-
-    hostname = parsed.hostname
-    if not hostname:
-        raise InvalidURLError(f"Invalid {param}: missing hostname.")
-
     try:
         # Wrap the blocking getaddrinfo in a thread with a short timeout
         # to prevent DoS attacks via malicious DNS servers.
-        # Note: parsed.port may be None, which is fine for getaddrinfo.
         future = _DNS_RESOLVER_POOL.submit(
-            socket.getaddrinfo, hostname, parsed.port, socket.AF_UNSPEC
+            socket.getaddrinfo, hostname, port, socket.AF_UNSPEC
         )
         # Short timeout to fail fast on tarpit DNS
         addr_info = future.result(timeout=2.0)
 
         for res in addr_info:
             # res[4] is the sockaddr tuple. The first element is the IP string.
-            # Explicitly stringify to satisfy type checkers.
             ip_str = str(res[4][0])
             ip_obj = ipaddress.ip_address(ip_str)
 
@@ -157,6 +181,26 @@ def validate_url_and_get_ip(url: str, param: str) -> str:
         raise InvalidURLError(
             f"Invalid {param}: Could not resolve hostname {hostname!r}."
         ) from e
+
+
+def validate_url_and_get_ip(url: str, param: str) -> str:
+    """Verify URL scheme and resolve hostname to a public IP.
+
+    Returns the first validated IP address string.
+    Raises InvalidURLError if the URL is unsafe.
+    """
+    parsed = urlparse(url)
+    scheme = parsed.scheme.lower()
+    if scheme not in _SAFE_URL_SCHEMES:
+        raise InvalidURLError(
+            f"Invalid {param} scheme {scheme!r}. Only http/https are allowed."
+        )
+
+    hostname = parsed.hostname
+    if not hostname:
+        raise InvalidURLError(f"Invalid {param}: missing hostname.")
+
+    return _validate_hostname_and_get_ip(hostname, parsed.port, param)
 
 
 _CLIENT: httpx.Client | None = None

--- a/tests/test_media.py
+++ b/tests/test_media.py
@@ -233,12 +233,12 @@ class TestSSRFProtection:
     def test_transport_pins_ip_and_sets_sni(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        """handle_request must rewrite host->validated IP and set sni_hostname to
-        the original host so TLS verification targets the hostname, not the IP."""
+        """handle_request must set sni_hostname to the original host so TLS
+        verification targets the hostname, while the backend pins to the IP."""
         captured: dict = {}
 
-        def fake_validate(url: str, param: str) -> str:
-            return "93.184.216.34"  # pretend example.com resolved here (public)
+        def fake_validate_hostname(hostname: str, port: int | None, param: str) -> str:
+            return "93.184.216.34"
 
         def fake_super(
             self: SSRFSafeTransport, request: httpx.Request
@@ -248,16 +248,32 @@ class TestSSRFProtection:
             captured["host_header"] = request.headers.get("Host")
             return httpx.Response(200)
 
-        monkeypatch.setattr("imagine_mcp.media.validate_url_and_get_ip", fake_validate)
+        monkeypatch.setattr(
+            "imagine_mcp.media._validate_hostname_and_get_ip", fake_validate_hostname
+        )
         monkeypatch.setattr(httpx.HTTPTransport, "handle_request", fake_super)
 
         transport = SSRFSafeTransport()
         req = httpx.Request("GET", "https://example.com/img.png")
         transport.handle_request(req)
 
-        assert captured["host"] == "93.184.216.34"  # pinned to validated IP
+        # URL is NOT rewritten in the request object anymore
+        assert captured["host"] == "example.com"
         assert captured["sni"] == "example.com"  # TLS verifies against hostname
         assert captured["host_header"] == "example.com"  # virtual-host routing intact
+
+        # Verify pinning happens in the backend
+        captured_conn_host = []
+
+        def mock_connect_tcp(self, host, port, **kwargs):
+            captured_conn_host.append(host)
+            return MagicMock()
+
+        import httpcore
+
+        monkeypatch.setattr(httpcore.SyncBackend, "connect_tcp", mock_connect_tcp)
+        transport._pool._network_backend.connect_tcp("example.com", 443)
+        assert captured_conn_host[0] == "93.184.216.34"
 
     def test_transport_passes_through_non_http_scheme(
         self, monkeypatch: pytest.MonkeyPatch

--- a/tests/test_security_pinning.py
+++ b/tests/test_security_pinning.py
@@ -1,12 +1,18 @@
 from __future__ import annotations
 
 import socket
+import typing
 
+import httpcore
 import httpx
 import pytest
 
 from imagine_mcp.errors import InvalidURLError
-from imagine_mcp.media import SSRFSafeTransport, validate_url_and_get_ip
+from imagine_mcp.media import (
+    SSRFSafeBackend,
+    SSRFSafeTransport,
+    validate_url_and_get_ip,
+)
 
 
 def test_validate_url_and_get_ip_success(monkeypatch):
@@ -30,42 +36,61 @@ def test_validate_url_and_get_ip_private(monkeypatch):
 
 
 def test_ssrf_safe_transport_pinning(monkeypatch):
-    # This test verifies that handle_request rewrites the URL and sets headers.
+    # This test verifies that handle_request does NOT rewrite the URL,
+    # but the backend DOES use the pinned IP.
+    captured_host = []
+
     def mock_getaddrinfo(host, port, family=0, type=0, proto=0, flags=0):
         return [(socket.AF_INET, socket.SOCK_STREAM, 6, "", ("93.184.215.14", 80))]
 
     monkeypatch.setattr(socket, "getaddrinfo", mock_getaddrinfo)
 
-    # Mocking the actual network call so we don't need real internet
-    class MockTransport(httpx.HTTPTransport):
-        def handle_request(self, request):
-            return httpx.Response(200, content=b"ok", request=request)
+    # Mock the internal httpcore.SyncBackend.connect_tcp to capture the host used for connection.
 
-    transport = SSRFSafeTransport()
-    # We need to reach super().handle_request, so we patch HTTPTransport.handle_request
+    def mock_connect_tcp(self, host, port, **kwargs):
+        captured_host.append(host)
+        # Return a mock stream to avoid real network call
+        return typing.cast(httpcore.NetworkStream, typing.Any)
+
+    monkeypatch.setattr(httpcore.SyncBackend, "connect_tcp", mock_connect_tcp)
+
+    # Mock handle_request to avoid issues with the cast mock stream
     monkeypatch.setattr(
         httpx.HTTPTransport,
         "handle_request",
         lambda self, req: httpx.Response(200, content=b"ok", request=req),
     )
 
+    transport = SSRFSafeTransport()
     request = httpx.Request("GET", "https://example.com/foo")
+
+    # Manually trigger the backend to verify pinning
+    backend = transport._pool._network_backend
+    backend.connect_tcp("example.com", 443)
+
+    assert captured_host[0] == "93.184.215.14"
+
+    # Now verify handle_request behavior
     transport.handle_request(request)
 
-    # Verification
-    assert str(request.url) == "https://93.184.215.14/foo"
+    # Verification: URL is NOT rewritten anymore
+    assert str(request.url) == "https://example.com/foo"
     assert request.headers["Host"] == "example.com"
     assert request.extensions["sni_hostname"] == "example.com"
 
 
-def test_ssrf_safe_transport_blocks_private(monkeypatch):
+def test_ssrf_safe_backend_blocks_private(monkeypatch):
     def mock_getaddrinfo(host, port, family=0, type=0, proto=0, flags=0):
         return [(socket.AF_INET, socket.SOCK_STREAM, 6, "", ("192.168.1.1", 80))]
 
     monkeypatch.setattr(socket, "getaddrinfo", mock_getaddrinfo)
 
-    transport = SSRFSafeTransport()
-    request = httpx.Request("GET", "http://internal.service/foo")
-
+    backend = SSRFSafeBackend()
     with pytest.raises(InvalidURLError, match="internal/private IP"):
-        transport.handle_request(request)
+        backend.connect_tcp("internal.service", 80)
+
+
+def test_ssrf_safe_backend_blocks_unix_sockets():
+    backend = SSRFSafeBackend()
+    with pytest.raises(InvalidURLError, match="Unix sockets are not allowed"):
+        backend.connect_unix_socket("/var/run/docker.sock")

--- a/uv.lock
+++ b/uv.lock
@@ -552,7 +552,7 @@ wheels = [
 
 [[package]]
 name = "imagine-mcp"
-version = "1.5.4"
+version = "1.6.0"
 source = { editable = "." }
 dependencies = [
     { name = "diskcache" },


### PR DESCRIPTION
Fixed a security vulnerability where DNS pinning (rewriting URLs to resolved IPs) caused SSL verification failures because httpx would validate the certificate against the IP rather than the hostname.

The fix moves DNS pinning logic from the transport layer (URL rewriting) to the network backend layer using a custom \`httpcore.NetworkBackend\`. This allows the IP resolution and validation to happen at the socket connection layer while preserving the original hostname in the request for correct SNI and TLS certificate verification.

Key changes:
- Created \`SSRFSafeBackend\` to handle IP pinning at the TCP connection level.
- Refactored DNS validation into a private helper for better reuse.
- Updated \`SSRFSafeTransport\` to inject the custom backend and stopped rewriting request URLs.
- Added explicit protection against Unix socket SSRF.
- Verified with unit tests that pinning works while preserving the original hostname in the request.

---
*PR created automatically by Jules for task [4633529897080506074](https://jules.google.com/task/4633529897080506074) started by @n24q02m*