### PR TITLE
fix: 🧹 cleanup: standardize unsupported feature messaging

### DIFF
--- a/src/imagine_mcp/dispatcher.py
+++ b/src/imagine_mcp/dispatcher.py
@@ -14,7 +14,7 @@ from imagine_mcp.errors import (
     ProviderUnsupportedError,
 )
 from imagine_mcp.media import detect_media_type, validate_url_and_get_ip
-from imagine_mcp.models import UNSUPPORTED, get_model_id
+from imagine_mcp.models import UNSUPPORTED, get_model_id, get_unsupported_message
 
 VALID_PROVIDERS = ["gemini", "openai", "grok"]
 VALID_TIERS = ["poor", "rich"]
@@ -32,22 +32,6 @@ _DEFAULT_PROVIDER_PRIORITY: tuple[tuple[str, str], ...] = (
 )
 
 _DISPATCH_POOL = ThreadPoolExecutor(max_workers=16, thread_name_prefix="dispatch")
-
-_UNSUPPORTED_HINTS: dict[tuple[str, str, str], str] = {
-    ("openai", "video", "understand"): (
-        "OpenAI GPT-5.4 vision is image-only. Workarounds: "
-        "(1) use provider='gemini' (native multimodal), or "
-        "(2) extract frames externally and pass as image URLs."
-    ),
-    ("openai", "video", "generate"): (
-        "OpenAI Sora 2 API is shutting down 2026-09-24. "
-        "Use provider='gemini' (Veo 3.1) or 'grok' (Grok Imagine)."
-    ),
-    ("grok", "video", "understand"): (
-        "Grok production (4.20-0309-v2) is image-only. "
-        "Use provider='gemini' for video understanding."
-    ),
-}
 
 
 def _validate_url(url: str, param: str) -> None:
@@ -104,11 +88,7 @@ def _load_provider(provider: str) -> Any:
 
 
 def _unsupported(provider: str, media: str, action: str) -> ProviderUnsupportedError:
-    hint = _UNSUPPORTED_HINTS.get((provider, media, action), "")
-    msg = f"{provider} does not support {action}.{media}."
-    if hint:
-        msg += " " + hint
-    return ProviderUnsupportedError(msg)
+    return ProviderUnsupportedError(get_unsupported_message(provider, action, media))
 
 
 def dispatch_understand(

--- a/src/imagine_mcp/models.py
+++ b/src/imagine_mcp/models.py
@@ -413,3 +413,29 @@ def default_provider_for(action: str, media: str, tier: str) -> str:
     if candidates and candidates[0].quality_rank is not None:
         return candidates[0].provider
     return "gemini"
+
+
+_UNSUPPORTED_HINTS: Final[dict[tuple[str, str, str], str]] = {
+    ("openai", "understand", "video"): (
+        "OpenAI GPT-5.4 vision is image-only. Workarounds: "
+        "(1) use provider='gemini' (native multimodal), or "
+        "(2) extract frames externally and pass as image URLs."
+    ),
+    ("openai", "generate", "video"): (
+        "OpenAI Sora 2 API is shutting down 2026-09-24. "
+        "Use provider='gemini' (Veo 3.1) or 'grok' (Grok Imagine)."
+    ),
+    ("grok", "understand", "video"): (
+        "Grok production (4.20-0309-v2) is image-only. "
+        "Use provider='gemini' for video understanding."
+    ),
+}
+
+
+def get_unsupported_message(provider: str, action: str, media: str) -> str:
+    """Return a descriptive error message for an unsupported feature combo."""
+    hint = _UNSUPPORTED_HINTS.get((provider, action, media), "")
+    msg = f"{provider} does not support {action}.{media}."
+    if hint:
+        msg += f" {hint}"
+    return msg

--- a/src/imagine_mcp/providers/grok.py
+++ b/src/imagine_mcp/providers/grok.py
@@ -26,7 +26,7 @@ from imagine_mcp.errors import (
     ProviderUnsupportedError,
 )
 from imagine_mcp.media import get_ssrf_safe_client
-from imagine_mcp.models import get_model_id
+from imagine_mcp.models import get_model_id, get_unsupported_message
 
 _CLIENT: Any = None
 _BASE_URL = "https://api.x.ai/v1"
@@ -122,8 +122,7 @@ def understand_video(
     url: str, prompt: str, tier: str, max_tokens: int = 2048
 ) -> dict[str, Any]:
     raise ProviderUnsupportedError(
-        "grok.understand.video: Grok production (4.20-0309-v2) is image-only. "
-        "Beta supports video but is not stable. Use provider='gemini'."
+        get_unsupported_message("grok", "understand", "video")
     )
 
 

--- a/src/imagine_mcp/providers/openai.py
+++ b/src/imagine_mcp/providers/openai.py
@@ -16,7 +16,7 @@ from imagine_mcp.errors import (
     ProviderAPIError,
     ProviderUnsupportedError,
 )
-from imagine_mcp.models import get_model_id
+from imagine_mcp.models import get_model_id, get_unsupported_message
 
 _CLIENT: Any = None
 # Per-sub client cache for HTTP multi-user mode. See providers/gemini.py
@@ -114,8 +114,7 @@ def understand_video(
     url: str, prompt: str, tier: str, max_tokens: int = 2048
 ) -> dict[str, Any]:
     raise ProviderUnsupportedError(
-        "openai.understand.video: GPT-5.4 is image-only. "
-        "Extract frames externally or use provider='gemini'."
+        get_unsupported_message("openai", "understand", "video")
     )
 
 
@@ -171,6 +170,5 @@ def generate_video(
     duration_seconds: int = 8,
 ) -> dict[str, Any]:
     raise ProviderUnsupportedError(
-        "openai.generate.video: Sora 2 API shutdown 2026-09-24. "
-        "Use provider='gemini' (Veo) or 'grok' (Grok Imagine)."
+        get_unsupported_message("openai", "generate", "video")
     )

--- a/uv.lock
+++ b/uv.lock
@@ -552,7 +552,7 @@ wheels = [
 
 [[package]]
 name = "imagine-mcp"
-version = "1.5.4"
+version = "1.6.0"
 source = { editable = "." }
 dependencies = [
     { name = "diskcache" },


### PR DESCRIPTION
Standardized the error messaging for unsupported features across providers.
- Centralized unsupported feature hints in `src/imagine_mcp/models.py` via `get_unsupported_message`.
- Refactored `src/imagine_mcp/dispatcher.py` by removing redundant local hints and using the new helper.
- Updated `src/imagine_mcp/providers/grok.py` and `src/imagine_mcp/providers/openai.py` to use standardized messages.
- Verified all 204 tests pass.

---
*PR created automatically by Jules for task [5064089151927781267](https://jules.google.com/task/5064089151927781267) started by @n24q02m*