### PR TITLE
fix: correct stale env var, CLI flag, docs-site links and tool inventory in docs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -37,11 +37,11 @@ uv run pre-commit install --hook-type commit-msg
 ### Run locally
 
 ```bash
-mise run dev                  # http local relay mode (default)
-uv run imagine-mcp --stdio    # stdio proxy mode
+mise run dev                  # http local relay mode (--http)
+uv run imagine-mcp            # stdio mode (default, no flag)
 
 # Optional: set env vars so the server skips the relay form
-export GOOGLE_AI_STUDIO_API_KEY=...
+export GEMINI_API_KEY=...
 export OPENAI_API_KEY=...
 export XAI_API_KEY=...
 ```

--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ mcp-name: io.github.n24q02m/imagine-mcp
 
 ## Documentation
 
-Full docs at **[mcp.n24q02m.com/servers/imagine-mcp/](https://mcp.n24q02m.com/servers/imagine-mcp/)**:
+Full docs at **[mcp.n24q02m.com/servers/imagine-mcp/setup/](https://mcp.n24q02m.com/servers/imagine-mcp/setup/)**:
 
 - [Setup](https://mcp.n24q02m.com/servers/imagine-mcp/setup/) -- install methods for Claude Code, Codex, Gemini CLI, Cursor, Windsurf, mcp.json
 - [Modes overview](https://mcp.n24q02m.com/get-started/modes-overview/) -- stdio / local-relay / remote-relay / remote-oauth
@@ -111,6 +111,7 @@ Full docs at **[mcp.n24q02m.com/servers/imagine-mcp/](https://mcp.n24q02m.com/se
 | `generate` | -- | Generate an image or video from a text prompt. `media_type: image\|video`, optional `reference_image_url`, optional `job_id` (video poll), `aspect_ratio`, `duration_seconds`. |
 | `config` | `open_relay`, `relay_status`, `relay_skip`, `relay_reset`, `relay_complete`, `warmup`, `status`, `set`, `cache_clear` | Credential + runtime config: open relay form, check credential state, set runtime knobs (log level, default provider, TTL), clear response cache. |
 | `help` | -- | Full Markdown documentation for `understand`, `generate`, or `config` topics. |
+| `config__open_relay` | -- | Framework-injected helper (mcp-core) equivalent to `config(action="open_relay")`; opens the browser credential form. |
 
 Model IDs per provider x action x tier are leaderboard-ranked; see [`docs/models.md`](docs/models.md) (auto-regenerated from `src/imagine_mcp/models.py`).
 
@@ -132,7 +133,7 @@ mise run dev        # run http local relay daemon
 
 ## Trust Model
 
-This plugin implements **TC-Local** (machine-bound, single trust principal). See [mcp-core/docs/TRUST-MODEL.md](https://github.com/n24q02m/mcp-core/blob/main/docs/TRUST-MODEL.md) for full classification.
+This plugin implements **TC-Local** (machine-bound, single trust principal). See [mcp-core trust model](https://mcp.n24q02m.com/servers/mcp-core/trust-model/) for full classification.
 
 | Mode | Storage | Encryption | Who can read your data? |
 |---|---|---|---|

--- a/server.json
+++ b/server.json
@@ -22,7 +22,7 @@
       },
       "environmentVariables": [
         {
-          "name": "GOOGLE_AI_STUDIO_API_KEY",
+          "name": "GEMINI_API_KEY",
           "description": "Google AI Studio API key (aistudio.google.com/apikey)",
           "isRequired": false,
           "isSecret": true
@@ -50,7 +50,7 @@
       },
       "environmentVariables": [
         {
-          "name": "GOOGLE_AI_STUDIO_API_KEY",
+          "name": "GEMINI_API_KEY",
           "description": "Google AI Studio API key",
           "isRequired": false,
           "isSecret": true

--- a/src/imagine_mcp/__main__.py
+++ b/src/imagine_mcp/__main__.py
@@ -33,7 +33,7 @@ Options:
   2. Switch to HTTP mode (browser-based setup):
      See https://mcp.n24q02m.com/servers/imagine-mcp/setup/ "Self-Hosting HTTP Mode"
 
-Documentation: https://mcp.n24q02m.com/servers/imagine-mcp/
+Documentation: https://mcp.n24q02m.com/servers/imagine-mcp/setup/
 """
 
 

--- a/uv.lock
+++ b/uv.lock
@@ -552,7 +552,7 @@ wheels = [
 
 [[package]]
 name = "imagine-mcp"
-version = "1.6.0"
+version = "1.6.1"
 source = { editable = "." }
 dependencies = [
     { name = "diskcache" },


### PR DESCRIPTION
## Docs/config drift audit — imagine-mcp

All findings verified against actual source before editing.

### Findings + status

1. **Stale env var `GOOGLE_AI_STUDIO_API_KEY` (drift, FIXED)** — code reads `GEMINI_API_KEY` everywhere (`__main__.py`, `server.py`, `dispatcher.py`, `providers/*`, `relay_schema.py`); no source reads the old name. Replaced the stale doc references in `server.json` (x2 `name` fields) and `CONTRIBUTING.md`. Historical rename notes in CLAUDE.md/CHANGELOG/code comments left intact (correctly describe the 2026-04-26 rename history).

2. **Nonexistent `--stdio` flag (drift, FIXED)** — `__main__.py:41-64` only parses `--http` (or `MCP_TRANSPORT=http`/`TRANSPORT_MODE=http`); stdio is the default with no flag. `CONTRIBUTING.md` claimed `uv run imagine-mcp --stdio  # stdio proxy mode`; corrected to `uv run imagine-mcp` (default, no flag) and labelled `mise run dev` as `--http`.

3. **Tool count (already-correct + completeness FIX)** — actual registered tools = `understand`, `generate`, `config`, `help` + framework-injected `config__open_relay` (verified `tests/test_server_tools.py`). The documented "4 total, N+2 layout" counts the 4 product tools per the standard convention and is correct (NOT changed). Added a `config__open_relay` row to the README Tools table so the inventory is complete.

4. **Dead links (drift, FIXED)** — verified with `curl -sI`:
   - `mcp-core/docs/TRUST-MODEL.md` -> **404**. mcp-core's own README points to `https://mcp.n24q02m.com/servers/mcp-core/trust-model/` (**200**); README updated to that target.
   - Bare docs-site server-root `/servers/imagine-mcp/` -> **404** (root pages 404 for all servers; only leaf pages like `/setup/` exist, **200**). Fixed in README "Full docs" line and in the `__main__.py` stdio-missing-cred error message.

5. **CONTRIBUTING commit-type list (already-correct)** — already states `fix:`/`feat:` only and lists `refactor/chore/docs/ci/build/style/perf/test/!` as disallowed. Aligns with repo convention; no change.

### Notes
- `uv.lock` self-version `1.6.0 -> 1.6.1` was applied by the lock-sync pre-commit hook (lockfile catching up to the released `pyproject.toml` version); kept to keep the hook/CI green.
- ruff check + ruff format clean; tool-registration tests pass (5 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)