### PR TITLE
fix: add Comparison capability matrix to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ mcp-name: io.github.n24q02m/imagine-mcp
 - [Status](#status)
 - [Documentation](#documentation)
 - [Tools](#tools)
+- [Comparison](#comparison)
 - [Security](#security)
 - [Build from Source](#build-from-source)
 - [Trust Model](#trust-model)
@@ -114,6 +115,19 @@ Full docs at **[mcp.n24q02m.com/servers/imagine-mcp/setup/](https://mcp.n24q02m.
 | `config__open_relay` | -- | Framework-injected helper (mcp-core) equivalent to `config(action="open_relay")`; opens the browser credential form. |
 
 Model IDs per provider x action x tier are leaderboard-ranked; see [`docs/models.md`](docs/models.md) (auto-regenerated from `src/imagine_mcp/models.py`).
+
+## Comparison
+
+How imagine-mcp stacks up against direct competitors in each pillar:
+
+| Capability | imagine-mcp | EverArt MCP | fal.ai MCP | Replicate Flux MCP |
+|---|---|---|---|---|
+| Image/video understanding | Yes (describe / classify / reason over image + video URLs) | No | No | No |
+| Image generation | Yes (text-to-image + image-to-image via `reference_image_url`) | Yes (single `generate_image`) | Yes (text/image-to-image, edit, inpaint) | Yes (single `generate_image`) |
+| Video generation | Yes (text-to-video + image-to-video, async `job_id` poll) | No | Yes (text/image-to-video) | No |
+| Multi-provider backends | Yes (Gemini / OpenAI / Grok, auto-fallback) | No (EverArt only) | No (fal.ai only) | No (Replicate Flux only) |
+| Quality/cost tiers | Yes (`poor` cheap-fast vs `rich` high-quality per provider) | No | No | No |
+| Self-hostable / open source | Yes (MIT, stdio + HTTP self-host) | Yes (MIT, archived) | Yes (MIT) | Yes (MIT, archived) |
 
 ## Security
 


### PR DESCRIPTION
Adds a `## Comparison` section to the README, matching the Tier-1 house style (capability matrix vs named real competitors) already used in `wet-mcp` and `mnemo-mcp`. Placed after `## Tools`, before `## Security`, and added to the table of contents.

## Capability matrix

| Capability | imagine-mcp | EverArt MCP | fal.ai MCP | Replicate Flux MCP |
|---|---|---|---|---|
| Image/video understanding | Yes | No | No | No |
| Image generation | Yes | Yes | Yes | Yes |
| Video generation | Yes | No | Yes | No |
| Multi-provider backends | Yes (Gemini/OpenAI/Grok) | No | No | No |
| Quality/cost tiers | Yes (poor/rich) | No | No | No |
| Self-hostable / open source | Yes | Yes | Yes | Yes |

## Our capabilities (sourced from this repo)
Derived only from `understand` / `generate` tools + README: image+video understanding, image gen (text + `reference_image_url`), video gen (async `job_id`), 3 providers (gemini/openai/grok) with auto-fallback, `poor`/`rich` tiers, MIT + stdio/HTTP self-host.

## Competitor verification (all confirmed real, MIT, open source)

**EverArt MCP** — official `@modelcontextprotocol/server-everart` (now archived). Single `generate_image` tool, image generation only via EverArt platform (FLUX 1.1 / SD3.5 / Recraft). No video, no understanding, single backend.
- https://github.com/modelcontextprotocol/servers-archived/tree/main/src/everart

**fal.ai MCP** (`raveenb/fal-mcp-server`) — image + video + audio generation across fal.ai models. No understanding/analysis. Single backend (fal.ai, `FAL_KEY`). MIT, self-hostable.
- https://github.com/raveenb/fal-mcp-server

**Replicate Flux MCP** (`GongRzhe/Image-Generation-MCP-Server`, archived Mar 2026) — single `generate_image` tool, Replicate Flux only (`black-forest-labs/flux-schnell`), `REPLICATE_API_TOKEN`. No video, no understanding. MIT, self-hostable.
- https://github.com/GongRzhe/Image-Generation-MCP-Server

Competitor cells only marked from published docs; all three are single-platform generation-only servers, which is the honest point of differentiation (imagine-mcp adds understanding, video, multi-provider, and tiers).

🤖 Generated with [Claude Code](https://claude.com/claude-code)