### PR TITLE
[FIX] Deeply Nested Function `download_to_path`

### DIFF
--- a/src/imagine_mcp/media.py
+++ b/src/imagine_mcp/media.py
@@ -258,6 +258,13 @@ def _extract_extension(url: str) -> str:
     return ext.lower()
 
 
+def _save_response(resp: httpx.Response, dest: Path) -> None:
+    """Write httpx response bytes to dest path in chunks."""
+    with dest.open("wb") as f:
+        for chunk in resp.iter_bytes(chunk_size=65536):
+            f.write(chunk)
+
+
 def download_to_path(url: str, dest: Path) -> Path:
     """Download URL content to dest path. Returns path."""
     dest.parent.mkdir(parents=True, exist_ok=True)
@@ -265,9 +272,7 @@ def download_to_path(url: str, dest: Path) -> Path:
         client = get_ssrf_safe_client()
         with client.stream("GET", url, follow_redirects=True, timeout=60) as resp:
             resp.raise_for_status()
-            with dest.open("wb") as f:
-                for chunk in resp.iter_bytes(chunk_size=65536):
-                    f.write(chunk)
+            _save_response(resp, dest)
     except InvalidURLError as e:
         raise httpx.HTTPError(f"Download failed due to invalid redirect: {e}") from e
     return dest

--- a/uv.lock
+++ b/uv.lock
@@ -552,7 +552,7 @@ wheels = [
 
 [[package]]
 name = "imagine-mcp"
-version = "1.6.1"
+version = "1.6.2b1"
 source = { editable = "." }
 dependencies = [
     { name = "diskcache" },


### PR DESCRIPTION
Refactored `download_to_path` in `src/imagine_mcp/media.py` by extracting the file-saving loop into a private helper function `_save_response`. This reduces the nesting depth and improves code readability while maintaining the same functionality and error handling. Verified with `ruff` and the full test suite.

---
*PR created automatically by Jules for task [5807218384591664973](https://jules.google.com/task/5807218384591664973) started by @n24q02m*