### PR TITLE
fix: [TEST] missing error path test for MediaDetectError in validate_url_and_get_ip

### DIFF
--- a/tests/test_media.py
+++ b/tests/test_media.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import concurrent.futures
+import socket
 from pathlib import Path
 from unittest.mock import MagicMock
 
@@ -192,6 +194,30 @@ def test_download_to_path_http_error(
 
     with pytest.raises(httpx.HTTPStatusError, match="404 Not Found"):
         download_to_path("https://example.com/404.png", dest)
+
+
+def test_validate_url_dns_timeout(monkeypatch: pytest.MonkeyPatch) -> None:
+    mock_future = MagicMock()
+    mock_future.result.side_effect = concurrent.futures.TimeoutError()
+
+    mock_pool = MagicMock()
+    mock_pool.submit.return_value = mock_future
+
+    monkeypatch.setattr("imagine_mcp.media._DNS_RESOLVER_POOL", mock_pool)
+
+    with pytest.raises(InvalidURLError, match="DNS resolution timed out"):
+        validate_url_and_get_ip("https://example.com/img.png", "image_url")
+
+
+def test_validate_url_gaierror(monkeypatch: pytest.MonkeyPatch) -> None:
+    # We mock socket.getaddrinfo because it is what is called by the thread pool
+    monkeypatch.setattr(
+        "socket.getaddrinfo",
+        MagicMock(side_effect=socket.gaierror(-2, "Name or service not known")),
+    )
+
+    with pytest.raises(InvalidURLError, match="Could not resolve hostname"):
+        validate_url_and_get_ip("https://nonexistent.example.com/img.png", "image_url")
 
 
 class TestSSRFProtection:

--- a/uv.lock
+++ b/uv.lock
@@ -552,7 +552,7 @@ wheels = [
 
 [[package]]
 name = "imagine-mcp"
-version = "1.6.1"
+version = "1.6.2b1"
 source = { editable = "." }
 dependencies = [
     { name = "diskcache" },


### PR DESCRIPTION
This PR adds missing unit tests for the error paths in `validate_url_and_get_ip` within `src/imagine_mcp/media.py`. Specifically, it covers the cases where DNS resolution times out (`concurrent.futures.TimeoutError`) or fails to resolve the hostname (`socket.gaierror`).

These additions ensure that the error handling logic for DNS resolution is correctly verified and prevents regressions in SSRF protection.

Fixes: Missing Error Path Test for MediaDetectError in validate_url_and_get_ip

---
*PR created automatically by Jules for task [18012135048942696448](https://jules.google.com/task/18012135048942696448) started by @n24q02m*