### PR TITLE
[TEST] Missing Error Path Test for InvalidURLError in get_ssrf_safe_client

### DIFF
--- a/tests/test_media.py
+++ b/tests/test_media.py
@@ -123,6 +123,28 @@ def test_detect_ambiguous_raises(monkeypatch: pytest.MonkeyPatch) -> None:
         detect_media_type("https://example.com/unknown-bin")
 
 
+def test_detect_media_type_http_error(monkeypatch: pytest.MonkeyPatch) -> None:
+    class MockClient:
+        def head(self, url, **kw):
+            raise httpx.HTTPError("network error")
+
+    monkeypatch.setattr("imagine_mcp.media.get_ssrf_safe_client", lambda: MockClient())
+    with pytest.raises(MediaDetectError, match="HEAD request failed for"):
+        detect_media_type("https://example.com/xyz")
+
+
+def test_detect_media_type_invalid_url_error(monkeypatch: pytest.MonkeyPatch) -> None:
+    class MockClient:
+        def head(self, url, **kw):
+            raise InvalidURLError("unsafe")
+
+    monkeypatch.setattr("imagine_mcp.media.get_ssrf_safe_client", lambda: MockClient())
+    with pytest.raises(
+        MediaDetectError, match="HEAD request failed due to invalid redirect"
+    ):
+        detect_media_type("https://example.com/xyz")
+
+
 def test_extract_extension() -> None:
     assert _extract_extension("https://example.com/foo.PNG") == ".png"
     assert _extract_extension("https://example.com/foo.mp4?q=1") == ".mp4"

--- a/uv.lock
+++ b/uv.lock
@@ -552,7 +552,7 @@ wheels = [
 
 [[package]]
 name = "imagine-mcp"
-version = "1.6.1"
+version = "1.6.2b1"
 source = { editable = "." }
 dependencies = [
     { name = "diskcache" },


### PR DESCRIPTION
Added unit tests to `tests/test_media.py` to cover `httpx.HTTPError` and `InvalidURLError` error paths in the `detect_media_type` function within `src/imagine_mcp/media.py`. These tests verify that these exceptions are correctly caught and re-raised as `MediaDetectError`.

---
*PR created automatically by Jules for task [10272544666201579455](https://jules.google.com/task/10272544666201579455) started by @n24q02m*