### PR TITLE
[FIX] Duplicate Code between `_client` functions

### DIFF
--- a/src/imagine_mcp/providers/base.py
+++ b/src/imagine_mcp/providers/base.py
@@ -1,8 +1,11 @@
-"""Provider protocol -- each provider module exposes 4 action functions."""
+"""Provider base types and shared utilities."""
 
 from __future__ import annotations
 
-from typing import Any, Protocol
+import os
+from typing import Any, Callable, Protocol
+
+from imagine_mcp.errors import CredentialMissingError
 
 
 class ImagineProvider(Protocol):
@@ -31,3 +34,68 @@ class ImagineProvider(Protocol):
         aspect_ratio: str = "16:9",
         duration_seconds: int = 8,
     ) -> dict[str, Any]: ...
+
+
+class ClientManager:
+    """Manages API client lifecycle and credential resolution for a provider.
+
+    Handles per-user client caching for multi-user mode and falls back to
+    global settings/environment variables for single-user/stdio mode.
+    """
+
+    def __init__(
+        self,
+        provider_name: str,
+        env_var: str,
+        settings_attr: str,
+        client_factory: Callable[[str], Any],
+    ):
+        self.provider_name = provider_name
+        self.env_var = env_var
+        self.settings_attr = settings_attr
+        self.client_factory = client_factory
+        self._client: Any = None
+        self._sub_clients: dict[str, Any] = {}
+
+    def get_api_key(self) -> str:
+        """Resolve the API key for the current request scope."""
+        from imagine_mcp.config import settings
+        from imagine_mcp.credential_state import (
+            credentials_for_current_request,
+            get_current_sub,
+        )
+
+        sub = get_current_sub()
+        if sub is not None:
+            key = credentials_for_current_request().get(self.env_var)
+        else:
+            key = getattr(settings, self.settings_attr) or os.environ.get(self.env_var)
+
+        if not key:
+            raise CredentialMissingError(
+                f"{self.provider_name} API key missing. Run config(action='open_relay') for "
+                f"browser-based setup, or set {self.env_var}."
+            )
+        return key
+
+    def get_client(self) -> Any:
+        """Return a cached client instance for the current request scope."""
+        from imagine_mcp.credential_state import get_current_sub
+
+        sub = get_current_sub()
+        if sub is not None:
+            cached = self._sub_clients.get(sub)
+            if cached is not None:
+                return cached
+            client = self.client_factory(self.get_api_key())
+            self._sub_clients[sub] = client
+            return client
+
+        if self._client is None:
+            self._client = self.client_factory(self.get_api_key())
+        return self._client
+
+    def reset(self) -> None:
+        """Clear all cached client instances (primarily for testing)."""
+        self._client = None
+        self._sub_clients.clear()

--- a/src/imagine_mcp/providers/gemini.py
+++ b/src/imagine_mcp/providers/gemini.py
@@ -3,81 +3,38 @@
 from __future__ import annotations
 
 import base64
-import os
 import uuid
 from pathlib import Path
 from typing import Any
 
 import platformdirs
 
-from imagine_mcp.config import settings
-from imagine_mcp.errors import CredentialMissingError, ProviderAPIError
+from imagine_mcp.errors import ProviderAPIError
 from imagine_mcp.models import get_model_id
-
-_CLIENT: Any = None
-# Per-sub client cache for HTTP multi-user mode. Keyed by JWT sub so each
-# user gets a client wired to their own ``GEMINI_API_KEY``. Single-user /
-# stdio mode still uses the module-level ``_CLIENT`` above.
-_SUB_CLIENTS: dict[str, Any] = {}
+from imagine_mcp.providers.base import ClientManager
 
 
-def _resolve_api_key() -> str | None:
-    """Return the GEMINI_API_KEY for the current request scope.
+def _create_client(api_key: str) -> Any:
+    from google import genai
 
-    Multi-user HTTP path uses the per-sub config from PerPluginStore. The
-    settings singleton is read first (frozen at import) for backwards
-    compatibility, then ``credentials_for_current_request()`` which falls
-    back to ``os.environ`` when no sub is active.
-    """
-    from imagine_mcp.credential_state import (
-        credentials_for_current_request,
-        get_current_sub,
-    )
+    return genai.Client(api_key=api_key)
 
-    if get_current_sub() is not None:
-        return credentials_for_current_request().get("GEMINI_API_KEY")
-    return settings.gemini_api_key or os.environ.get("GEMINI_API_KEY")
+
+_manager = ClientManager(
+    provider_name="Gemini",
+    env_var="GEMINI_API_KEY",
+    settings_attr="gemini_api_key",
+    client_factory=_create_client,
+)
 
 
 def _client() -> Any:
-    global _CLIENT
-    from imagine_mcp.credential_state import get_current_sub
-
-    sub = get_current_sub()
-    if sub is not None:
-        cached = _SUB_CLIENTS.get(sub)
-        if cached is not None:
-            return cached
-        api_key = _resolve_api_key()
-        if not api_key:
-            raise CredentialMissingError(
-                "Gemini API key missing. Run config(action='open_relay') for "
-                "browser-based setup, or set GEMINI_API_KEY."
-            )
-        from google import genai
-
-        client = genai.Client(api_key=api_key)
-        _SUB_CLIENTS[sub] = client
-        return client
-
-    if _CLIENT is None:
-        api_key = _resolve_api_key()
-        if not api_key:
-            raise CredentialMissingError(
-                "Gemini API key missing. Run config(action='open_relay') for "
-                "browser-based setup, or set GEMINI_API_KEY."
-            )
-        from google import genai
-
-        _CLIENT = genai.Client(api_key=api_key)
-    return _CLIENT
+    return _manager.get_client()
 
 
 def _reset_client() -> None:
     """Test hook: force _client() to re-read settings."""
-    global _CLIENT
-    _CLIENT = None
-    _SUB_CLIENTS.clear()
+    _manager.reset()
 
 
 def understand_image(
@@ -180,8 +137,7 @@ def understand_multimodal(
             mt = media_types[i] if media_types else detect_media_type(u)
             if mt == "image":
                 img_resp = get_ssrf_safe_client().get(
-                    u, follow_redirects=True, timeout=60
-                )
+                    u, follow_redirects=True, timeout=60)
                 img_data = img_resp.content
                 mime_type = resolve_image_mime(
                     img_resp.headers.get("content-type"), img_data

--- a/src/imagine_mcp/providers/grok.py
+++ b/src/imagine_mcp/providers/grok.py
@@ -7,7 +7,6 @@ Dedicated endpoints for images and videos via httpx.
 from __future__ import annotations
 
 import base64
-import os
 import urllib.parse
 import uuid
 from pathlib import Path
@@ -15,75 +14,45 @@ from typing import Any
 
 import platformdirs
 
-from imagine_mcp.config import settings
-from imagine_mcp.credential_state import (
-    credentials_for_current_request,
-    get_current_sub,
-)
 from imagine_mcp.errors import (
-    CredentialMissingError,
     ProviderAPIError,
     ProviderUnsupportedError,
 )
 from imagine_mcp.media import get_ssrf_safe_client
 from imagine_mcp.models import get_model_id
+from imagine_mcp.providers.base import ClientManager
 
-_CLIENT: Any = None
 _BASE_URL = "https://api.x.ai/v1"
-# Per-sub client cache for HTTP multi-user mode (see providers/gemini.py).
-_SUB_CLIENTS: dict[str, Any] = {}
+
+
+def _create_client(api_key: str) -> Any:
+    from openai import OpenAI
+
+    return OpenAI(
+        api_key=api_key,
+        base_url=_BASE_URL,
+        http_client=get_ssrf_safe_client(),
+    )
+
+
+_manager = ClientManager(
+    provider_name="xAI (Grok)",
+    env_var="XAI_API_KEY",
+    settings_attr="xai_api_key",
+    client_factory=_create_client,
+)
 
 
 def _api_key() -> str:
-    """Return XAI_API_KEY for the current request scope.
-
-    Multi-user HTTP requests pull from the per-sub config; single-user /
-    stdio falls back to settings + os.environ.
-    """
-    if get_current_sub() is not None:
-        key = credentials_for_current_request().get("XAI_API_KEY")
-    else:
-        key = settings.xai_api_key or os.environ.get("XAI_API_KEY")
-    if not key:
-        raise CredentialMissingError(
-            "xAI (Grok) API key missing. Run config(action='open_relay') for "
-            "browser-based setup, or set XAI_API_KEY."
-        )
-    return key
+    return _manager.get_api_key()
 
 
 def _openai_compat_client() -> Any:
-    global _CLIENT
-    sub = get_current_sub()
-    if sub is not None:
-        cached = _SUB_CLIENTS.get(sub)
-        if cached is not None:
-            return cached
-        from openai import OpenAI
-
-        client = OpenAI(
-            api_key=_api_key(),
-            base_url=_BASE_URL,
-            http_client=get_ssrf_safe_client(),
-        )
-        _SUB_CLIENTS[sub] = client
-        return client
-
-    if _CLIENT is None:
-        from openai import OpenAI
-
-        _CLIENT = OpenAI(
-            api_key=_api_key(),
-            base_url=_BASE_URL,
-            http_client=get_ssrf_safe_client(),
-        )
-    return _CLIENT
+    return _manager.get_client()
 
 
 def _reset_client() -> None:
-    global _CLIENT
-    _CLIENT = None
-    _SUB_CLIENTS.clear()
+    _manager.reset()
 
 
 def understand_image(

--- a/src/imagine_mcp/providers/openai.py
+++ b/src/imagine_mcp/providers/openai.py
@@ -3,77 +3,41 @@
 from __future__ import annotations
 
 import base64
-import os
 import uuid
 from pathlib import Path
 from typing import Any
 
 import platformdirs
 
-from imagine_mcp.config import settings
 from imagine_mcp.errors import (
-    CredentialMissingError,
     ProviderAPIError,
     ProviderUnsupportedError,
 )
 from imagine_mcp.models import get_model_id
-
-_CLIENT: Any = None
-# Per-sub client cache for HTTP multi-user mode. See providers/gemini.py
-# for rationale; module-level ``_CLIENT`` still serves stdio + single-user.
-_SUB_CLIENTS: dict[str, Any] = {}
+from imagine_mcp.providers.base import ClientManager
 
 
-def _resolve_api_key() -> str | None:
-    """Return OPENAI_API_KEY for the current request scope (per-sub or env)."""
-    from imagine_mcp.credential_state import (
-        credentials_for_current_request,
-        get_current_sub,
-    )
+def _create_client(api_key: str) -> Any:
+    from openai import OpenAI
 
-    if get_current_sub() is not None:
-        return credentials_for_current_request().get("OPENAI_API_KEY")
-    return settings.openai_api_key or os.environ.get("OPENAI_API_KEY")
+    return OpenAI(api_key=api_key)
+
+
+_manager = ClientManager(
+    provider_name="OpenAI",
+    env_var="OPENAI_API_KEY",
+    settings_attr="openai_api_key",
+    client_factory=_create_client,
+)
 
 
 def _client() -> Any:
-    global _CLIENT
-    from imagine_mcp.credential_state import get_current_sub
-
-    sub = get_current_sub()
-    if sub is not None:
-        cached = _SUB_CLIENTS.get(sub)
-        if cached is not None:
-            return cached
-        api_key = _resolve_api_key()
-        if not api_key:
-            raise CredentialMissingError(
-                "OpenAI API key missing. Run config(action='open_relay') for "
-                "browser-based setup, or set OPENAI_API_KEY."
-            )
-        from openai import OpenAI
-
-        client = OpenAI(api_key=api_key)
-        _SUB_CLIENTS[sub] = client
-        return client
-
-    if _CLIENT is None:
-        api_key = _resolve_api_key()
-        if not api_key:
-            raise CredentialMissingError(
-                "OpenAI API key missing. Run config(action='open_relay') for "
-                "browser-based setup, or set OPENAI_API_KEY."
-            )
-        from openai import OpenAI
-
-        _CLIENT = OpenAI(api_key=api_key)
-    return _CLIENT
+    return _manager.get_client()
 
 
 def _reset_client() -> None:
-    global _CLIENT
-    _CLIENT = None
-    _SUB_CLIENTS.clear()
+    """Test hook: force client to re-read settings."""
+    _manager.reset()
 
 
 def understand_image(

--- a/uv.lock
+++ b/uv.lock
@@ -552,7 +552,7 @@ wheels = [
 
 [[package]]
 name = "imagine-mcp"
-version = "1.6.1"
+version = "1.6.2b1"
 source = { editable = "." }
 dependencies = [
     { name = "diskcache" },


### PR DESCRIPTION
This PR refactors the redundant client initialization and credential management logic across the three provider modules (`openai.py`, `gemini.py`, and `grok.py`).

### Changes
- **New `ClientManager` Class**: Added to `src/imagine_mcp/providers/base.py`. This utility encapsulates:
  - API key resolution from multiple sources (per-user credentials, global settings, or environment variables).
  - Per-user client instance caching for multi-user (HTTP) mode.
  - Global client instance management for single-user (stdio) mode.
  - A `reset()` mechanism for testing.
- **Provider Refactoring**:
  - `openai.py`, `gemini.py`, and `grok.py` now utilize module-level `ClientManager` instances.
  - Redundant `_resolve_api_key`, `_client`, and `_reset_client` implementations were removed and replaced with calls to the manager.
  - Existing function wrappers (`_client`, `_reset_client`) were maintained to ensure compatibility with tests and existing internal calls.

### Impact
- **Consistency**: Credential resolution logic is now centralized, ensuring all providers behave identically regarding API key priority.
- **Maintainability**: Reduced boilerplate code across providers makes it easier to add new providers or update credential logic.
- **Performance**: No impact on runtime performance as the caching behavior remains identical to the previous implementation.

### Verification
- Full test suite execution: `uv run pytest` (205/205 passed).
- Specific provider tests:
  - `tests/test_providers_openai.py`
  - `tests/test_providers_gemini.py`
  - `tests/test_providers_grok.py`

---
*PR created automatically by Jules for task [7342472162347732021](https://jules.google.com/task/7342472162347732021) started by @n24q02m*