### PR TITLE
[FIX] Repeated Client Instantiation

### DIFF
--- a/src/imagine_mcp/media.py
+++ b/src/imagine_mcp/media.py
@@ -6,6 +6,7 @@ import concurrent.futures
 import ipaddress
 import os
 import socket
+import threading
 import typing
 from pathlib import Path
 from typing import Literal
@@ -208,13 +209,29 @@ def validate_url_and_get_ip(url: str, param: str) -> str:
 
 
 _CLIENT: httpx.Client | None = None
+_CLIENT_LOCK = threading.Lock()
 
 
 def get_ssrf_safe_client() -> httpx.Client:
+    """Return a shared, thread-safe, SSRF-safe httpx.Client singleton.
+
+    The client uses SSRFSafeTransport to prevent server-side request forgery
+    by pinning DNS resolutions to validated public IPs.
+    """
     global _CLIENT
     if _CLIENT is None:
-        _CLIENT = httpx.Client(transport=SSRFSafeTransport())
+        with _CLIENT_LOCK:
+            if _CLIENT is None:
+                _CLIENT = httpx.Client(transport=SSRFSafeTransport())
     return _CLIENT
+
+
+def _reset_ssrf_safe_client() -> None:
+    """Reset the shared client singleton (internal use for tests)."""
+    global _CLIENT
+    if _CLIENT is not None:
+        _CLIENT.close()
+        _CLIENT = None
 
 
 def detect_media_type(url: str) -> MediaType:

--- a/tests/test_media.py
+++ b/tests/test_media.py
@@ -294,3 +294,33 @@ class TestSSRFProtection:
         transport = SSRFSafeTransport()
         transport.handle_request(httpx.Request("GET", "file:///etc/passwd"))
         assert called["validated"] is False
+
+
+def test_get_ssrf_safe_client_singleton() -> None:
+    """Verify that get_ssrf_safe_client always returns the same instance."""
+    from imagine_mcp.media import _reset_ssrf_safe_client, get_ssrf_safe_client
+
+    _reset_ssrf_safe_client()
+
+    client1 = get_ssrf_safe_client()
+    client2 = get_ssrf_safe_client()
+
+    assert client1 is client2
+    assert isinstance(client1, httpx.Client)
+
+
+def test_get_ssrf_safe_client_thread_safety() -> None:
+    """Verify that get_ssrf_safe_client is thread-safe and returns the same instance."""
+    import concurrent.futures
+
+    from imagine_mcp.media import _reset_ssrf_safe_client, get_ssrf_safe_client
+
+    _reset_ssrf_safe_client()
+
+    with concurrent.futures.ThreadPoolExecutor(max_workers=10) as executor:
+        futures = [executor.submit(get_ssrf_safe_client) for _ in range(20)]
+        results = [f.result() for f in futures]
+
+    first_client = results[0]
+    for client in results:
+        assert client is first_client

--- a/uv.lock
+++ b/uv.lock
@@ -552,7 +552,7 @@ wheels = [
 
 [[package]]
 name = "imagine-mcp"
-version = "1.6.1"
+version = "1.6.2b1"
 source = { editable = "." }
 dependencies = [
     { name = "diskcache" },


### PR DESCRIPTION
Implemented a robust thread-safe singleton pattern using double-checked locking with a threading.Lock in src/imagine_mcp/media.py. This ensures that only one httpx.Client instance is created and shared across the application, even under concurrent access. Added verification tests for singleton behavior and thread safety in tests/test_media.py. Also added a _reset_ssrf_safe_client internal helper to facilitate reliable testing of the singleton initialization.

---
*PR created automatically by Jules for task [15203017867819249096](https://jules.google.com/task/15203017867819249096) started by @n24q02m*