### PR TITLE
[FIX] relay_skip reported Using env vars for credentials

### DIFF
--- a/src/imagine_mcp/server.py
+++ b/src/imagine_mcp/server.py
@@ -35,11 +35,9 @@ def _get_version() -> str:
 
 
 def _creds_state() -> str:
-    # Read from os.environ -- settings singleton is frozen at import time
-    # and does not observe post-startup relay-saved credentials.
-    if any(
-        os.environ.get(k) for k in ("GEMINI_API_KEY", "OPENAI_API_KEY", "XAI_API_KEY")
-    ):
+    # Derive state from live providers so it reflects post-startup
+    # relay-saved credentials even if env vars were not populated.
+    if _providers_configured_live():
         return "CONFIGURED"
     return "NEEDS_SETUP"
 
@@ -195,7 +193,7 @@ def build_app() -> FastMCP:
                     }
                 return {
                     "status": "saved",
-                    "providers_configured": _providers_configured(),
+                    "providers_configured": _providers_configured_live(),
                 }
             case "relay_status":
                 # Derive providers from live PerPluginStore + env so status
@@ -234,7 +232,7 @@ def build_app() -> FastMCP:
                 return {
                     "version": _get_version(),
                     "credentials_state": _creds_state(),
-                    "providers_configured": _providers_configured(),
+                    "providers_configured": _providers_configured_live(),
                     "default_provider": settings.default_provider,
                     "default_tier": settings.default_tier,
                     "cache_ttl_seconds": settings.cache_ttl_seconds,

--- a/uv.lock
+++ b/uv.lock
@@ -552,7 +552,7 @@ wheels = [
 
 [[package]]
 name = "imagine-mcp"
-version = "1.6.1"
+version = "1.6.2b1"
 source = { editable = "." }
 dependencies = [
     { name = "diskcache" },


### PR DESCRIPTION
This PR fixes a bug where the `imagine-mcp` server reported stale or inaccurate credential status when API keys were only present in the `PerPluginStore` and not in environment variables at startup.

Changes:
- Modified `_creds_state()` in `src/imagine_mcp/server.py` to derive state from `_providers_configured_live()`.
- Updated the `config` tool's `open_relay` and `status` actions to use `_providers_configured_live()` for the `providers_configured` field.
- Verified that `relay_skip` already correctly uses `_providers_configured()` to report environment-only status as intended.

These updates ensure that the server's status reports are accurate and consistent with the live state of configured providers.

---
*PR created automatically by Jules for task [11790850746561895430](https://jules.google.com/task/11790850746561895430) started by @n24q02m*