### PR TITLE
feat: model-chain selection (imagine, understand-only)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,7 +47,7 @@ dependencies = [
     "pillow>=12.2.0",
     "diskcache>=5.6.3",
     "loguru>=0.7.3",
-    "n24q02m-mcp-core[llm]>=1.18.0b1,<2",
+    "n24q02m-mcp-core[llm]>=1.18.0b2,<2",
     "platformdirs>=4.10.0",
     # Security floors: transitive deps pinned to patched releases.
     # urllib3 < 2.7.0 -> PYSEC-2026-141/142; idna < 3.15 -> CVE-2026-45409.

--- a/src/imagine_mcp/config.py
+++ b/src/imagine_mcp/config.py
@@ -23,6 +23,10 @@ class Settings(BaseSettings):
     openai_api_key: str | None = Field(default=None)
     xai_api_key: str | None = Field(default=None)
 
+    # Ordered understand model chain (litellm ``provider/model``, comma-sep);
+    # primary + fallbacks. Empty -> provider/tier catalog default.
+    understand_models: str | None = Field(default=None)
+
     # Runtime
     log_level: Literal["DEBUG", "INFO", "WARNING", "ERROR"] = Field(default="INFO")
     cache_ttl_seconds: int = Field(default=3600, ge=0)

--- a/src/imagine_mcp/dispatcher.py
+++ b/src/imagine_mcp/dispatcher.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import asyncio
 import base64
 import importlib
+import os
 from typing import Any
 
 from imagine_mcp.errors import (
@@ -112,6 +113,17 @@ def _default_provider() -> str:
     )
 
 
+def resolve_understand_chain() -> list[str]:
+    """Ordered ``UNDERSTAND_MODELS`` chain (litellm ``provider/model`` entries).
+
+    Empty / unset -> empty list, which preserves the provider/tier catalog
+    default. The first entry is the primary model; the rest are litellm
+    fallbacks.
+    """
+    raw = (os.getenv("UNDERSTAND_MODELS") or "").strip()
+    return [m.strip() for m in raw.split(",") if m.strip()] if raw else []
+
+
 def _load_provider(provider: str) -> Any:
     return importlib.import_module(f"imagine_mcp.providers.{provider}")
 
@@ -129,12 +141,17 @@ async def _passthrough_understand(
     prompt: str,
     model: str,
     max_tokens: int,
+    fallbacks: list[str] | None = None,
 ) -> dict[str, Any]:
     """Understand via an explicit litellm passthrough ``model``.
 
     Bypasses the provider/tier catalog. Images are downloaded through the
     SSRF-safe client and sent as base64 data URLs (vision message format).
     Registry-missing models pass through with a ``warning`` in the response.
+
+    ``fallbacks`` (the rest of an ``UNDERSTAND_MODELS`` chain after the
+    primary) is forwarded to litellm's native ``fallbacks`` kwarg via
+    ``acompletion``'s ``**kwargs`` passthrough.
     """
     from mcp_core.llm import (
         ModelCapabilityError,
@@ -170,6 +187,7 @@ async def _passthrough_understand(
         messages=[{"role": "user", "content": content}],
         max_tokens=max_tokens,
         api_key=_passthrough_api_key(model),
+        fallbacks=fallbacks or None,
     )
     out: dict[str, Any] = {
         "text": resp.choices[0].message.content,
@@ -202,6 +220,13 @@ async def dispatch_understand(
     """
     if model is not None:
         return await _passthrough_understand(media_urls, prompt, model, max_tokens)
+
+    if model is None and provider is None:
+        chain = resolve_understand_chain()
+        if chain:
+            return await _passthrough_understand(
+                media_urls, prompt, chain[0], max_tokens, fallbacks=chain[1:]
+            )
 
     if provider is None:
         provider = _default_provider()

--- a/src/imagine_mcp/relay_schema.py
+++ b/src/imagine_mcp/relay_schema.py
@@ -1,70 +1,82 @@
-"""Config schema for the relay setup page (3 optional API key fields)."""
+"""Config schema for the relay setup page.
+
+ONE model-chain task: ``understand`` (order = litellm fallback chain). The
+three provider key fields are *derived* — they surface automatically for the
+providers the chosen understand models use, and the SAME keys also drive the
+native ``generate`` path (provider/tier catalog).
+"""
 
 from __future__ import annotations
 
 from typing import Any
 
+# Catalog understand IMAGE models, explicit ``provider/`` prefixes.
+_UNDERSTAND_SUGGESTED = [
+    "xai/grok-4.20-0309-non-reasoning",
+    "xai/grok-4.20-0309-reasoning",
+    "gemini/gemini-3.1-flash-lite-preview",
+    "gemini/gemini-3.1-pro-preview",
+    "openai/gpt-5.4-mini",
+    "openai/gpt-5.4",
+]
+
+
+def _key_field(key: str, label: str, ph: str, url: str) -> dict[str, Any]:
+    return {
+        "key": key,
+        "label": label,
+        "type": "password",
+        "placeholder": ph,
+        "helpUrl": url,
+        "derived": True,
+        "required": False,
+    }
+
+
 RELAY_SCHEMA: dict[str, Any] = {
     "server": "imagine-mcp",
     "displayName": "Imagine MCP",
     "description": (
-        "Enter API keys for the providers you want to use. "
-        "All fields are optional -- the server starts in degraded mode with no keys "
-        "and individual providers fail with CredentialMissingError when called."
+        "Pick understand models (order = fallback). Leave empty to use the "
+        "provider/tier catalog default. Key fields appear automatically for "
+        "the providers your models use — the same keys also power generation."
     ),
     "fields": [
         {
-            "key": "GEMINI_API_KEY",
-            "label": "Gemini API Key",
-            "type": "password",
-            "placeholder": "AIza...",
-            "helpUrl": "https://aistudio.google.com/apikey",
-            "helpText": (
-                "Gemini understand (image/video) + image/video generation. "
-                "Free tier available."
-            ),
-            "required": False,
+            "key": "UNDERSTAND_MODELS",
+            "label": "Understand models",
+            "type": "model-chain",
+            "task": "understand",
+            "suggestedModels": _UNDERSTAND_SUGGESTED,
+            "hasLocal": False,
+            "placeholder": "add understand model…",
         },
-        {
-            "key": "OPENAI_API_KEY",
-            "label": "OpenAI API Key",
-            "type": "password",
-            "placeholder": "sk-...",
-            "helpUrl": "https://platform.openai.com/api-keys",
-            "helpText": (
-                "GPT-5.4 image understanding + gpt-image-1 generation. "
-                "Video paths are not supported."
-            ),
-            "required": False,
-        },
-        {
-            "key": "XAI_API_KEY",
-            "label": "xAI (Grok) API Key",
-            "type": "password",
-            "placeholder": "xai-...",
-            "helpUrl": "https://console.x.ai",
-            "helpText": (
-                "Grok 4.20 image understanding + Aurora/Grok Imagine generation. "
-                "Video understanding is not supported."
-            ),
-            "required": False,
-        },
+        _key_field(
+            "GEMINI_API_KEY",
+            "Gemini API Key",
+            "AIza...",
+            "https://aistudio.google.com/apikey",
+        ),
+        _key_field(
+            "OPENAI_API_KEY",
+            "OpenAI API Key",
+            "sk-...",
+            "https://platform.openai.com/api-keys",
+        ),
+        _key_field(
+            "XAI_API_KEY",
+            "xAI (Grok) API Key",
+            "xai-...",
+            "https://console.x.ai",
+        ),
     ],
     "capabilityInfo": [
         {
             "label": "Image understanding",
-            "priority": "Gemini > OpenAI > Grok",
+            "priority": "configurable",
             "description": (
-                "Multi-image vision QA. Gemini 3 Pro is native multimodal and "
-                "handles video natively."
-            ),
-        },
-        {
-            "label": "Image generation",
-            "priority": "Gemini > OpenAI > Grok",
-            "description": (
-                "Text-to-image and reference-image editing. "
-                "Gemini (Nano Banana) leads leaderboards as of baseline."
+                "Multi-image vision QA across Gemini / OpenAI / Grok via the "
+                "UNDERSTAND_MODELS chain (order = fallback)."
             ),
         },
         {
@@ -76,11 +88,12 @@ RELAY_SCHEMA: dict[str, Any] = {
             ),
         },
         {
-            "label": "Video generation",
-            "priority": "Gemini (Veo 3.1) > Grok (Imagine)",
+            "label": "Image / video generation",
+            "priority": "native (provider/tier catalog)",
             "description": (
-                "Async generate: submit returns job_id, poll via "
-                "generate(media_type='video', job_id=...)."
+                "Generation stays native and uses the SAME provider keys above "
+                "(no model chain): Gemini image + Veo video, OpenAI image, "
+                "Grok image/video. Provider auto-fallback XAI > OpenAI > Gemini."
             ),
         },
     ],

--- a/tests/test_dispatcher.py
+++ b/tests/test_dispatcher.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import os
 from unittest.mock import AsyncMock
 
 import pytest
@@ -8,6 +9,7 @@ from imagine_mcp.dispatcher import (
     _default_provider,
     dispatch_generate,
     dispatch_understand,
+    resolve_understand_chain,
 )
 from imagine_mcp.errors import (
     CredentialMissingError,
@@ -489,6 +491,153 @@ async def test_passthrough_generate_unknown_prefix_raises_litellm_gap() -> None:
             tier="poor",
             model="cohere/some-image-model",
         )
+
+
+def test_understand_chain_from_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv(
+        "UNDERSTAND_MODELS",
+        "xai/grok-4.20-0309-non-reasoning,gemini/gemini-3.1-flash-lite-preview",
+    )
+    assert resolve_understand_chain()[0] == "xai/grok-4.20-0309-non-reasoning"
+
+
+def test_understand_chain_empty(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("UNDERSTAND_MODELS", raising=False)
+    assert resolve_understand_chain() == []
+
+
+def test_understand_chain_strips_and_skips_blanks(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("UNDERSTAND_MODELS", " xai/grok , , gemini/flash ,")
+    assert resolve_understand_chain() == ["xai/grok", "gemini/flash"]
+
+
+def test_understand_chain_blank_string_is_empty(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("UNDERSTAND_MODELS", "   ")
+    assert resolve_understand_chain() == []
+    # Sanity: env var is genuinely present (not absent) for this case.
+    assert os.getenv("UNDERSTAND_MODELS") == "   "
+
+
+@pytest.mark.asyncio
+async def test_dispatch_understand_uses_chain_default(
+    clean_provider_env: None, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """No explicit model/provider + UNDERSTAND_MODELS set -> chain passthrough."""
+    from unittest.mock import MagicMock
+
+    monkeypatch.setenv(
+        "UNDERSTAND_MODELS",
+        "xai/grok-4.20-0309-non-reasoning,gemini/gemini-3.1-flash-lite-preview",
+    )
+    monkeypatch.setenv("XAI_API_KEY", "xai-test")
+
+    msg = MagicMock()
+    msg.content = "chain cat"
+    choice = MagicMock()
+    choice.message = msg
+    resp = MagicMock()
+    resp.choices = [choice]
+
+    captured: dict[str, object] = {}
+
+    async def fake_acompletion(**kwargs: object) -> object:
+        captured.update(kwargs)
+        return resp
+
+    monkeypatch.setattr("mcp_core.llm.acompletion", fake_acompletion)
+    mock_resp = MagicMock()
+    mock_resp.content = b"x"
+    mock_resp.headers = {"content-type": "image/png"}
+    mock_client = AsyncMock()
+    mock_client.get.return_value = mock_resp
+    monkeypatch.setattr(
+        "imagine_mcp.media.get_ssrf_safe_async_client", lambda: mock_client
+    )
+
+    result = await dispatch_understand(
+        media_urls=["https://example.com/cat.png"],
+        prompt="describe",
+        provider=None,
+        tier="poor",
+    )
+    assert result["provider"] == "passthrough"
+    assert captured["model"] == "xai/grok-4.20-0309-non-reasoning"
+    assert captured["fallbacks"] == ["gemini/gemini-3.1-flash-lite-preview"]
+
+
+@pytest.mark.asyncio
+async def test_dispatch_understand_single_chain_no_fallbacks(
+    clean_provider_env: None, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A one-entry chain forwards fallbacks=None (no empty-list noise)."""
+    from unittest.mock import MagicMock
+
+    monkeypatch.setenv("UNDERSTAND_MODELS", "xai/grok-4.20-0309-non-reasoning")
+    monkeypatch.setenv("XAI_API_KEY", "xai-test")
+
+    msg = MagicMock()
+    msg.content = "ok"
+    choice = MagicMock()
+    choice.message = msg
+    resp = MagicMock()
+    resp.choices = [choice]
+
+    captured: dict[str, object] = {}
+
+    async def fake_acompletion(**kwargs: object) -> object:
+        captured.update(kwargs)
+        return resp
+
+    monkeypatch.setattr("mcp_core.llm.acompletion", fake_acompletion)
+    mock_resp = MagicMock()
+    mock_resp.content = b"x"
+    mock_resp.headers = {"content-type": "image/png"}
+    mock_client = AsyncMock()
+    mock_client.get.return_value = mock_resp
+    monkeypatch.setattr(
+        "imagine_mcp.media.get_ssrf_safe_async_client", lambda: mock_client
+    )
+
+    result = await dispatch_understand(
+        media_urls=["https://example.com/cat.png"],
+        prompt="describe",
+        provider=None,
+        tier="poor",
+    )
+    assert result["model"] == "xai/grok-4.20-0309-non-reasoning"
+    assert captured["fallbacks"] is None
+
+
+@pytest.mark.asyncio
+async def test_dispatch_understand_explicit_provider_ignores_chain(
+    clean_provider_env: None, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """An explicit provider preserves the catalog path even with a chain set."""
+    monkeypatch.setenv("UNDERSTAND_MODELS", "xai/grok-4.20-0309-non-reasoning")
+
+    async def mock_fn(url: str, prompt: str, tier: str, max_tokens: int = 2048) -> dict:
+        return {"text": "a cat", "model": "gemini-x", "provider": "gemini"}
+
+    import imagine_mcp.providers.gemini as gemini_mod
+
+    monkeypatch.setattr(gemini_mod, "understand_image", mock_fn, raising=False)
+    monkeypatch.setattr(
+        "imagine_mcp.dispatcher.detect_media_type_async",
+        AsyncMock(return_value="image"),
+    )
+
+    result = await dispatch_understand(
+        media_urls=["https://example.com/cat.png"],
+        prompt="describe",
+        provider="gemini",
+        tier="poor",
+    )
+    # Catalog path, NOT passthrough chain.
+    assert result["provider"] == "gemini"
 
 
 @pytest.mark.asyncio

--- a/tests/test_relay_schema.py
+++ b/tests/test_relay_schema.py
@@ -17,25 +17,32 @@ def test_top_level_keys_present():
     assert RELAY_SCHEMA["server"] == "imagine-mcp"
 
 
-def test_three_credential_fields_match_known_keys():
-    fields = RELAY_SCHEMA["fields"]
-    assert len(fields) == 3
-    assert {f["key"] for f in fields} == _CREDENTIAL_KEYS
+def test_exactly_one_model_chain_task_understand():
+    tasks = {
+        f["task"] for f in RELAY_SCHEMA["fields"] if f.get("type") == "model-chain"
+    }
+    assert tasks == {"understand"}
 
 
-def test_all_fields_are_optional_password_inputs():
+def test_derived_keys_are_the_three_providers():
+    derived = {f["key"] for f in RELAY_SCHEMA["fields"] if f.get("derived")}
+    assert derived == _CREDENTIAL_KEYS
+
+
+def test_no_priority_arrow_strings():
+    for cap in RELAY_SCHEMA["capabilityInfo"]:
+        assert ">" not in cap.get("priority", ""), cap
+
+
+def test_every_suggested_model_has_a_provider_prefix():
     for field in RELAY_SCHEMA["fields"]:
-        assert field["type"] == "password", field["key"]
-        assert field["required"] is False, field["key"]
-        # Every field must give the user a way to obtain the key.
-        assert field["helpUrl"].startswith("https://"), field["key"]
-        assert field["helpText"], field["key"]
-        assert field["label"], field["key"]
+        for model in field.get("suggestedModels", []):
+            assert "/" in model, model
 
 
 def test_capability_info_entries_well_formed():
     caps = RELAY_SCHEMA["capabilityInfo"]
-    assert len(caps) == 4
+    assert caps
     for cap in caps:
         assert cap["label"]
         assert cap["priority"]

--- a/uv.lock
+++ b/uv.lock
@@ -726,7 +726,7 @@ wheels = [
 
 [[package]]
 name = "imagine-mcp"
-version = "1.6.2b2"
+version = "1.7.0b1"
 source = { editable = "." }
 dependencies = [
     { name = "diskcache" },
@@ -769,7 +769,7 @@ requires-dist = [
     { name = "idna", specifier = ">=3.18" },
     { name = "loguru", specifier = ">=0.7.3" },
     { name = "mcp", extras = ["cli"], specifier = ">=1.27.2" },
-    { name = "n24q02m-mcp-core", extras = ["llm"], specifier = ">=1.18.0b1,<2" },
+    { name = "n24q02m-mcp-core", extras = ["llm"], specifier = ">=1.18.0b2,<2" },
     { name = "openai", specifier = ">=2.41.0" },
     { name = "pillow", specifier = ">=12.2.0" },
     { name = "platformdirs", specifier = ">=4.10.0" },
@@ -1149,7 +1149,7 @@ wheels = [
 
 [[package]]
 name = "n24q02m-mcp-core"
-version = "1.18.0b1"
+version = "1.18.0b2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "authlib" },
@@ -1164,9 +1164,9 @@ dependencies = [
     { name = "starlette" },
     { name = "tomli-w" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/a9/aa/e8eb296141165057abb74f2e62f392c341b14e3259cb1677547b3a6760f1/n24q02m_mcp_core-1.18.0b1.tar.gz", hash = "sha256:832b29c70cae6a610a83c3a5c06bcb7220e6eaf43ea5dfa91ef47adc75ac332e", size = 252457, upload-time = "2026-06-10T13:31:50.457Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/ce/ed/59f51b85af63f4986918e6d76ccd7e8bb177706aeb397629d7cc76da5bcd/n24q02m_mcp_core-1.18.0b2.tar.gz", hash = "sha256:30baf5173e460ef20f1b24ac91e6310b8d7737696be033138a4b05785cb4b5a9", size = 256688, upload-time = "2026-06-11T05:07:18.225Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/50/22/ce4c37b7c120eb6e0aee229665841bfcb2482bc650d49168c74a22253a77/n24q02m_mcp_core-1.18.0b1-py3-none-any.whl", hash = "sha256:6d4f84e4369aab5aa5d1213a1c7b34d5c61672eaa3834ee92bc9b4414626eb79", size = 135751, upload-time = "2026-06-10T13:31:49.33Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/47/1182dda7b70180245e57d5e6316940e219faf46d6692be2d8edf8d2c603d/n24q02m_mcp_core-1.18.0b2-py3-none-any.whl", hash = "sha256:905efd3e25ceb8ab6d14132a8f6e660bde6ba324bf0363342b1a5d87f09dd242", size = 139516, upload-time = "2026-06-11T05:07:19.407Z" },
 ]
 
 [package.optional-dependencies]


### PR DESCRIPTION
Phase 2 selection redesign. `UNDERSTAND_MODELS` chain default for understand (litellm fallbacks wired), relay model-chain widget (understand task) + derived keys GEMINI/OPENAI/XAI. Generate stays NATIVE (zero diff). Pin mcp-core[llm]>=1.18.0b2. 227 tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)