### PR TITLE
fix: 🛡️ sentinel: [MEDIUM] add html parsing security enhancements to leaderboard script

### DIFF
--- a/scripts/fetch_leaderboards.py
+++ b/scripts/fetch_leaderboards.py
@@ -20,7 +20,7 @@ from pathlib import Path
 from typing import Any
 
 import httpx
-from bs4 import BeautifulSoup, Tag, SoupStrainer
+from bs4 import BeautifulSoup, SoupStrainer, Tag
 
 log = logging.getLogger("refresh_ranks")
 

--- a/scripts/fetch_leaderboards.py
+++ b/scripts/fetch_leaderboards.py
@@ -24,10 +24,11 @@ from bs4 import BeautifulSoup, SoupStrainer, Tag
 
 log = logging.getLogger("refresh_ranks")
 
+
 def _sanitize_text(text: str) -> str:
     """Sanitize parsed text to prevent terminal injection and ReDoS."""
     # Strip control characters
-    text = re.sub(r'[\x00-\x1f\x7f-\x9f]', '', text)
+    text = re.sub(r"[\x00-\x1f\x7f-\x9f]", "", text)
     # Truncate to a reasonable maximum length
     if len(text) > 500:
         return text[:500] + "..."
@@ -192,7 +193,9 @@ def parse_leaderboard(url: str, html: str) -> list[LBRow]:
         if not thead:
             log.warning("no thead: %s", url)
             return []
-        header_cells = [_sanitize_text(c.get_text(strip=True)).lower() for c in thead.find_all("th")]
+        header_cells = [
+            _sanitize_text(c.get_text(strip=True)).lower() for c in thead.find_all("th")
+        ]
 
         try:
             rank_i = header_cells.index("rank")
@@ -200,10 +203,18 @@ def parse_leaderboard(url: str, html: str) -> list[LBRow]:
             log.warning("no rank column: %s", url)
             return []
 
-        name_i = next((i for i, c in enumerate(header_cells) if c in ("model", "name")), 1)
-        provider_i = next((i for i, c in enumerate(header_cells) if "provider" in c), -1)
+        name_i = next(
+            (i for i, c in enumerate(header_cells) if c in ("model", "name")), 1
+        )
+        provider_i = next(
+            (i for i, c in enumerate(header_cells) if "provider" in c), -1
+        )
         score_i = next(
-            (i for i, c in enumerate(header_cells) if c in ("score", "elo", "arena score")),
+            (
+                i
+                for i, c in enumerate(header_cells)
+                if c in ("score", "elo", "arena score")
+            ),
             -1,
         )
 

--- a/scripts/fetch_leaderboards.py
+++ b/scripts/fetch_leaderboards.py
@@ -20,9 +20,18 @@ from pathlib import Path
 from typing import Any
 
 import httpx
-from bs4 import BeautifulSoup, Tag
+from bs4 import BeautifulSoup, Tag, SoupStrainer
 
 log = logging.getLogger("refresh_ranks")
+
+def _sanitize_text(text: str) -> str:
+    """Sanitize parsed text to prevent terminal injection and ReDoS."""
+    # Strip control characters
+    text = re.sub(r'[\x00-\x1f\x7f-\x9f]', '', text)
+    # Truncate to a reasonable maximum length
+    if len(text) > 500:
+        return text[:500] + "..."
+    return text
 
 
 LB_URLS: list[str] = [
@@ -126,14 +135,16 @@ def _parse_row(
     if len(cells) <= rank_i:
         return None
 
-    rank_match = re.search(r"\d+", cells[rank_i].get_text())
+    rank_text = _sanitize_text(cells[rank_i].get_text())
+    rank_match = re.search(r"\d+", rank_text)
     if not rank_match:
         return None
     rank = int(rank_match.group())
 
     name_cell = cells[name_i]
     link = name_cell.find("a")
-    display = link.get_text(strip=True) if link else name_cell.get_text(strip=True)
+    raw_display = link.get_text(strip=True) if link else name_cell.get_text(strip=True)
+    display = _sanitize_text(raw_display)
     # Strip trailing "provider . type" annotations LMArena embeds
     display = re.split(r"\s*·\s*|\s+xAI\s+|\s+OpenAI\s+|\s+Google\s+", display)[
         0
@@ -146,7 +157,7 @@ def _parse_row(
 
     provider: str | None = None
     if provider_i >= 0:
-        provider_raw = cells[provider_i].get_text(strip=True)
+        provider_raw = _sanitize_text(cells[provider_i].get_text(strip=True))
         if provider_raw:
             provider = _normalize_provider(provider_raw)
     if not provider:
@@ -156,7 +167,8 @@ def _parse_row(
 
     score: float | None = None
     if score_i >= 0:
-        score_match = re.search(r"[\d.]+", cells[score_i].get_text())
+        score_text = _sanitize_text(cells[score_i].get_text())
+        score_match = re.search(r"[\d.]+", score_text)
         if score_match:
             with contextlib.suppress(ValueError):
                 score = float(score_match.group())
@@ -166,47 +178,54 @@ def _parse_row(
 
 def parse_leaderboard(url: str, html: str) -> list[LBRow]:
     """Extract ranked rows filtered to {gemini, openai, grok}."""
-    soup = BeautifulSoup(html, "html.parser")
-    table = soup.find("table")
-    if not table:
-        log.warning("no table found: %s", url)
-        return []
-
-    thead = table.find("thead")
-    if not thead:
-        log.warning("no thead: %s", url)
-        return []
-    header_cells = [c.get_text(strip=True).lower() for c in thead.find_all("th")]
-
+    old_limit = sys.getrecursionlimit()
     try:
-        rank_i = header_cells.index("rank")
-    except ValueError:
-        log.warning("no rank column: %s", url)
-        return []
+        sys.setrecursionlimit(2000)
+        strainer = SoupStrainer("table")
+        soup = BeautifulSoup(html, "html.parser", parse_only=strainer)
+        table = soup.find("table")
+        if not table:
+            log.warning("no table found: %s", url)
+            return []
 
-    name_i = next((i for i, c in enumerate(header_cells) if c in ("model", "name")), 1)
-    provider_i = next((i for i, c in enumerate(header_cells) if "provider" in c), -1)
-    score_i = next(
-        (i for i, c in enumerate(header_cells) if c in ("score", "elo", "arena score")),
-        -1,
-    )
+        thead = table.find("thead")
+        if not thead:
+            log.warning("no thead: %s", url)
+            return []
+        header_cells = [_sanitize_text(c.get_text(strip=True)).lower() for c in thead.find_all("th")]
 
-    tbody = table.find("tbody")
-    if not tbody:
-        return []
+        try:
+            rank_i = header_cells.index("rank")
+        except ValueError:
+            log.warning("no rank column: %s", url)
+            return []
 
-    rows: list[LBRow] = []
-    for tr in tbody.find_all("tr"):
-        row = _parse_row(
-            tr.find_all("td"),
-            rank_i=rank_i,
-            name_i=name_i,
-            provider_i=provider_i,
-            score_i=score_i,
-            url=url,
+        name_i = next((i for i, c in enumerate(header_cells) if c in ("model", "name")), 1)
+        provider_i = next((i for i, c in enumerate(header_cells) if "provider" in c), -1)
+        score_i = next(
+            (i for i, c in enumerate(header_cells) if c in ("score", "elo", "arena score")),
+            -1,
         )
-        if row:
-            rows.append(row)
+
+        tbody = table.find("tbody")
+        if not tbody:
+            return []
+
+        rows: list[LBRow] = []
+        for tr in tbody.find_all("tr"):
+            row = _parse_row(
+                tr.find_all("td"),
+                rank_i=rank_i,
+                name_i=name_i,
+                provider_i=provider_i,
+                score_i=score_i,
+                url=url,
+            )
+            if row:
+                rows.append(row)
+
+    finally:
+        sys.setrecursionlimit(old_limit)
 
     return rows
 
@@ -227,11 +246,21 @@ def merge_ranks(rows_aa: list[LBRow], rows_lmarena: list[LBRow]) -> dict[str, in
 
 def fetch_all(client: httpx.Client) -> dict[str, list[LBRow]]:
     out: dict[str, list[LBRow]] = {}
+    max_size = 5 * 1024 * 1024  # 5MB limit
     for url in LB_URLS:
         try:
-            r = client.get(url, timeout=30.0, follow_redirects=True)
-            r.raise_for_status()
-            out[url] = parse_leaderboard(url, r.text)
+            html_chunks = []
+            bytes_read = 0
+            with client.stream("GET", url, timeout=30.0, follow_redirects=True) as r:
+                r.raise_for_status()
+                for chunk in r.iter_text():
+                    bytes_read += len(chunk.encode("utf-8"))
+                    if bytes_read > max_size:
+                        raise ValueError(f"Response exceeded 5MB limit: {url}")
+                    html_chunks.append(chunk)
+
+            html = "".join(html_chunks)
+            out[url] = parse_leaderboard(url, html)
             log.info("fetched %s: %d rows after filter", url, len(out[url]))
         except Exception as exc:
             log.error("fetch failed %s: %s", url, exc)

--- a/uv.lock
+++ b/uv.lock
@@ -726,7 +726,7 @@ wheels = [
 
 [[package]]
 name = "imagine-mcp"
-version = "1.7.0b2"
+version = "1.7.0b3"
 source = { editable = "." }
 dependencies = [
     { name = "diskcache" },


### PR DESCRIPTION
🚨 Severity: MEDIUM
💡 Vulnerability: The internal `scripts/fetch_leaderboards.py` script was vulnerable to DoS (resource exhaustion) via unconstrained response body reading, and ReDoS/terminal injection via unvalidated HTML/text parsing from external leaderboards.
🎯 Impact: An attacker controlling the remote servers (or via MITM) could serve excessively large responses leading to out-of-memory errors (DoS). Additionally, maliciously crafted deep HTML trees or responses containing terminal control characters could crash the parser (ReDoS) or execute terminal injection attacks when parsed data is logged or displayed.
🔧 Fix:
- Added a 5MB size limit on the incoming HTTP response stream in `fetch_all` using `client.stream()`.
- Used `BeautifulSoup` with `SoupStrainer("table")` to only parse necessary sections of the document.
- Set a temporary `sys.setrecursionlimit(2000)` around `BeautifulSoup` parsing to prevent crash errors.
- Added a `_sanitize_text` helper function to strip terminal control characters (`[\x00-\x1f\x7f-\x9f]`) and strictly cap lengths at 500 characters on extracted leaderboard data.
✅ Verification: Ran `uv run pytest` successfully and verified script execution directly using `uv run python scripts/fetch_leaderboards.py`.

---
*PR created automatically by Jules for task [457895883528297056](https://jules.google.com/task/457895883528297056) started by @n24q02m*