### PR TITLE
fix: sync imagine docs with code (drop removed config models action + add model param)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -32,8 +32,8 @@ help(topic: str = "understand") -> str
 ```
 
 `model` (optional, litellm `provider/model` format) overrides the provider/tier
-catalog for open passthrough. `config(action="models")` lists available models;
-any litellm model works via passthrough even if unlisted.
+catalog — bypasses `VALID_PROVIDERS` + the model-ID table for open passthrough.
+Any litellm `provider/model` works via passthrough even if not in the model-ID table.
 
 ## Model IDs (verified 2026-04-18; rank from Artificial Analysis + LMArena, refreshed weekly)
 

--- a/src/imagine_mcp/docs/config.md
+++ b/src/imagine_mcp/docs/config.md
@@ -38,7 +38,7 @@ config(
 ```python
 # First-time setup
 config(action="open_relay")
-# -> {"session_id": "...", "url": "http://localhost:8001/...", "expires_in_seconds": 600}
+# -> {"session_id": "...", "url": "http://localhost:8001/...", "expires_in_seconds": 300}
 
 config(action="relay_status")
 # -> {"status": "pending"} or {"status": "done"}

--- a/src/imagine_mcp/docs/understand.md
+++ b/src/imagine_mcp/docs/understand.md
@@ -6,11 +6,12 @@ Understand images and/or videos via a multimodal LLM.
 
 ```python
 understand(
-    media_urls: list[str],       # HTTP(S) URLs -- max 5
+    media_urls: list[str],       # HTTP(S) URLs -- default max 5, configurable 1-20 via max_media_urls
     prompt: str,                 # Your question or instruction
     provider: str | None = None, # "gemini" | "openai" | "grok" (auto-fallback when None)
     tier: str = "poor",          # "poor" | "rich"
     max_tokens: int = 2048,
+    model: str | None = None,    # litellm "provider/model" passthrough; bypasses provider/tier catalog
 ) -> dict
 ```
 


### PR DESCRIPTION
## Vấn đề (docs-vs-code drift)
- `AGENTS.md`: vẫn nhắc `config(action="models")` — đã DROP ở v1.7.0-beta.3 (#288); CLAUDE.md đã clean, AGENTS.md miss.
- `docs/understand.md`: thiếu `model` passthrough param (có ở `server.py:126`); mô tả `media_urls` "max 5" trong khi default=5, configurable 1-20 (`config.py:36 max_media_urls`).
- `docs/config.md`: `expires_in_seconds: 600` nhưng `RELAY_TIMEOUT_S = 300` (`relay_setup.py:24`).

## Fix
Sync docs với code. Verify bằng đọc `server.py`, `config.py`, `relay_setup.py`, CHANGELOG #288.

🤖 Generated with [Claude Code](https://claude.com/claude-code)