### PR TITLE
fix: centralize client initialization and credential resolution logic

### DIFF
--- a/src/imagine_mcp/providers/base.py
+++ b/src/imagine_mcp/providers/base.py
@@ -1,8 +1,8 @@
-"""Provider protocol -- each provider module exposes 4 action functions."""
+"""Provider protocol and client management utilities."""
 
 from __future__ import annotations
 
-from typing import Any, Protocol
+from typing import Any, Callable, Protocol
 
 
 class ImagineProvider(Protocol):
@@ -31,3 +31,77 @@ class ImagineProvider(Protocol):
         aspect_ratio: str = "16:9",
         duration_seconds: int = 8,
     ) -> dict[str, Any]: ...
+
+
+class ClientManager:
+    """Manages provider client instances and API key resolution.
+
+    Centralizes the logic for:
+    1. Resolving API keys from per-subject credentials (HTTP multi-user) or
+       environment variables/settings (single-user).
+    2. Caching client instances per subject or globally.
+    3. Raising CredentialMissingError with a consistent message.
+    """
+
+    def __init__(
+        self,
+        provider_name: str,
+        env_key: str,
+        settings_attr: str,
+        client_factory: Callable[[str], Any] | None = None,
+    ) -> None:
+        self.provider_name = provider_name
+        self.env_key = env_key
+        self.settings_attr = settings_attr
+        self.client_factory = client_factory
+        self._client: Any = None
+        self._sub_clients: dict[str, Any] = {}
+
+    def get_api_key(self) -> str:
+        """Resolve the API key for the current request scope."""
+        import os
+
+        from imagine_mcp.config import settings
+        from imagine_mcp.credential_state import (
+            credentials_for_current_request,
+            get_current_sub,
+        )
+        from imagine_mcp.errors import CredentialMissingError
+
+        sub = get_current_sub()
+        if sub is not None:
+            key = credentials_for_current_request().get(self.env_key)
+        else:
+            key = getattr(settings, self.settings_attr) or os.environ.get(self.env_key)
+
+        if not key:
+            raise CredentialMissingError(
+                f"{self.provider_name} API key missing. Run config(action='open_relay') for "
+                f"browser-based setup, or set {self.env_key}."
+            )
+        return key
+
+    def get_client(self) -> Any:
+        """Return a (cached) client instance for the current request scope."""
+        from imagine_mcp.credential_state import get_current_sub
+
+        if self.client_factory is None:
+            raise RuntimeError(f"No client_factory defined for {self.provider_name}")
+
+        sub = get_current_sub()
+        if sub is not None:
+            cached = self._sub_clients.get(sub)
+            if cached is not None:
+                return cached
+            client = self.client_factory(self.get_api_key())
+            self._sub_clients[sub] = client
+            return client
+
+        if self._client is None:
+            self._client = self.client_factory(self.get_api_key())
+        return self._client
+
+    def reset(self) -> None:
+        """Clear all cached client instances."""
+        self._client = None
+        self._sub_clients.clear()

--- a/src/imagine_mcp/providers/base.py
+++ b/src/imagine_mcp/providers/base.py
@@ -2,7 +2,8 @@
 
 from __future__ import annotations
 
-from typing import Any, Callable, Protocol
+from collections.abc import Callable
+from typing import Any, Protocol
 
 
 class ImagineProvider(Protocol):

--- a/src/imagine_mcp/providers/gemini.py
+++ b/src/imagine_mcp/providers/gemini.py
@@ -4,72 +4,38 @@ from __future__ import annotations
 
 import asyncio
 import base64
-import os
 import uuid
 from pathlib import Path
 from typing import Any
 
 import platformdirs
 
-from imagine_mcp.config import settings
-from imagine_mcp.errors import CredentialMissingError, ProviderAPIError
+from imagine_mcp.errors import ProviderAPIError
 from imagine_mcp.models import get_model_id
-
-_CLIENT: Any = None
-_SUB_CLIENTS: dict[str, Any] = {}
+from imagine_mcp.providers.base import ClientManager
 
 
-def _resolve_api_key() -> str | None:
-    """Return the GEMINI_API_KEY for the current request scope."""
-    from imagine_mcp.credential_state import (
-        credentials_for_current_request,
-        get_current_sub,
-    )
+def _client_factory(api_key: str) -> Any:
+    from google import genai
 
-    if get_current_sub() is not None:
-        return credentials_for_current_request().get("GEMINI_API_KEY")
-    return settings.gemini_api_key or os.environ.get("GEMINI_API_KEY")
+    return genai.Client(api_key=api_key)
+
+
+_manager = ClientManager(
+    provider_name="Gemini",
+    env_key="GEMINI_API_KEY",
+    settings_attr="gemini_api_key",
+    client_factory=_client_factory,
+)
 
 
 def _client() -> Any:
-    global _CLIENT
-    from imagine_mcp.credential_state import get_current_sub
-
-    sub = get_current_sub()
-    if sub is not None:
-        cached = _SUB_CLIENTS.get(sub)
-        if cached is not None:
-            return cached
-        api_key = _resolve_api_key()
-        if not api_key:
-            raise CredentialMissingError(
-                "Gemini API key missing. Run config(action='open_relay') for "
-                "browser-based setup, or set GEMINI_API_KEY."
-            )
-        from google import genai
-
-        client = genai.Client(api_key=api_key)
-        _SUB_CLIENTS[sub] = client
-        return client
-
-    if _CLIENT is None:
-        api_key = _resolve_api_key()
-        if not api_key:
-            raise CredentialMissingError(
-                "Gemini API key missing. Run config(action='open_relay') for "
-                "browser-based setup, or set GEMINI_API_KEY."
-            )
-        from google import genai
-
-        _CLIENT = genai.Client(api_key=api_key)
-    return _CLIENT
+    return _manager.get_client()
 
 
 def _reset_client() -> None:
     """Test hook: force _client() to re-read settings."""
-    global _CLIENT
-    _CLIENT = None
-    _SUB_CLIENTS.clear()
+    _manager.reset()
 
 
 async def understand_image(
@@ -94,7 +60,7 @@ async def understand_image(
 
     # Normalise empty string to None: a non-None api_key suppresses litellm's
     # provider env-var fallback (would 401 on "").
-    resolved_api_key = _resolve_api_key() or None
+    resolved_api_key = _manager.get_api_key() or None
 
     resp = await acompletion(
         model=f"gemini/{model}",

--- a/src/imagine_mcp/providers/grok.py
+++ b/src/imagine_mcp/providers/grok.py
@@ -8,7 +8,6 @@ from __future__ import annotations
 
 import asyncio
 import base64
-import os
 import urllib.parse
 import uuid
 from pathlib import Path
@@ -16,34 +15,26 @@ from typing import Any
 
 import platformdirs
 
-from imagine_mcp.config import settings
-from imagine_mcp.credential_state import (
-    credentials_for_current_request,
-    get_current_sub,
-)
 from imagine_mcp.errors import (
-    CredentialMissingError,
     ProviderAPIError,
     ProviderUnsupportedError,
 )
 from imagine_mcp.media import get_ssrf_safe_async_client
 from imagine_mcp.models import get_model_id
+from imagine_mcp.providers.base import ClientManager
 
 _BASE_URL = "https://api.x.ai/v1"
+
+_manager = ClientManager(
+    provider_name="xAI (Grok)",
+    env_key="XAI_API_KEY",
+    settings_attr="xai_api_key",
+)
 
 
 def _api_key() -> str:
     """Return XAI_API_KEY for the current request scope."""
-    if get_current_sub() is not None:
-        key = credentials_for_current_request().get("XAI_API_KEY")
-    else:
-        key = settings.xai_api_key or os.environ.get("XAI_API_KEY")
-    if not key:
-        raise CredentialMissingError(
-            "xAI (Grok) API key missing. Run config(action='open_relay') for "
-            "browser-based setup, or set XAI_API_KEY."
-        )
-    return key
+    return _manager.get_api_key()
 
 
 async def understand_image(

--- a/src/imagine_mcp/providers/openai.py
+++ b/src/imagine_mcp/providers/openai.py
@@ -4,76 +4,40 @@ from __future__ import annotations
 
 import asyncio
 import base64
-import os
 import uuid
 from pathlib import Path
 from typing import Any
 
 import platformdirs
 
-from imagine_mcp.config import settings
 from imagine_mcp.errors import (
-    CredentialMissingError,
     ProviderAPIError,
     ProviderUnsupportedError,
 )
 from imagine_mcp.models import get_model_id
-
-_CLIENT: Any = None
-_SUB_CLIENTS: dict[str, Any] = {}
+from imagine_mcp.providers.base import ClientManager
 
 
-def _resolve_api_key() -> str | None:
-    """Return OPENAI_API_KEY for the current request scope (per-sub or env)."""
-    from imagine_mcp.credential_state import (
-        credentials_for_current_request,
-        get_current_sub,
-    )
+def _client_factory(api_key: str) -> Any:
+    from openai import AsyncOpenAI
 
-    if get_current_sub() is not None:
-        return credentials_for_current_request().get("OPENAI_API_KEY")
-    return settings.openai_api_key or os.environ.get("OPENAI_API_KEY")
+    return AsyncOpenAI(api_key=api_key)
+
+
+_manager = ClientManager(
+    provider_name="OpenAI",
+    env_key="OPENAI_API_KEY",
+    settings_attr="openai_api_key",
+    client_factory=_client_factory,
+)
 
 
 def _client() -> Any:
-    global _CLIENT
-    from imagine_mcp.credential_state import get_current_sub
-
-    sub = get_current_sub()
-    if sub is not None:
-        cached = _SUB_CLIENTS.get(sub)
-        if cached is not None:
-            return cached
-        api_key = _resolve_api_key()
-        if not api_key:
-            raise CredentialMissingError(
-                "OpenAI API key missing. Run config(action='open_relay') for "
-                "browser-based setup, or set OPENAI_API_KEY."
-            )
-        from openai import AsyncOpenAI
-
-        client = AsyncOpenAI(api_key=api_key)
-        _SUB_CLIENTS[sub] = client
-        return client
-
-    if _CLIENT is None:
-        api_key = _resolve_api_key()
-        if not api_key:
-            raise CredentialMissingError(
-                "OpenAI API key missing. Run config(action='open_relay') for "
-                "browser-based setup, or set OPENAI_API_KEY."
-            )
-        from openai import AsyncOpenAI
-
-        _CLIENT = AsyncOpenAI(api_key=api_key)
-    return _CLIENT
+    return _manager.get_client()
 
 
 def _reset_client() -> None:
-    global _reset_client
-    global _CLIENT
-    _CLIENT = None
-    _SUB_CLIENTS.clear()
+    _manager.reset()
 
 
 async def understand_image(
@@ -96,7 +60,7 @@ async def understand_image(
 
     # Normalise empty string to None: a non-None api_key suppresses litellm's
     # provider env-var fallback (would 401 on "").
-    resolved_api_key = _resolve_api_key() or None
+    resolved_api_key = _manager.get_api_key() or None
 
     resp = await acompletion(
         model=f"openai/{model}",


### PR DESCRIPTION
### Refactoring: Centralized Client Initialization

This PR addresses duplicate code in the provider modules by centralizing client initialization and API key resolution logic into a shared utility.

#### Changes:
1.  **Added `ClientManager` to `src/imagine_mcp/providers/base.py`**:
    *   Handles API key resolution with priority: `get_current_sub()` -> `credentials_for_current_request()` -> `settings` -> `os.environ`.
    *   Provides per-subject client caching for HTTP multi-user mode and global caching for single-user mode.
    *   Standardizes `CredentialMissingError` messages.
2.  **Refactored `openai.py` and `gemini.py`**:
    *   Replaced manual `_CLIENT` and `_SUB_CLIENTS` state with a module-level `ClientManager`.
    *   Simplified `_client()` and `_reset_client()` implementations.
3.  **Refactored `grok.py`**:
    *   Integrated `ClientManager` for consistent API key resolution, even though it uses a stateless HTTP client.

#### Impact:
*   Reduces code duplication across provider modules.
*   Centralizes credential management logic, making it easier to maintain and update.
*   Ensures consistent error messaging for missing API keys.

#### Verification:
*   Full test suite execution: `uv run pytest` -> 227 passed.
*   Specific provider tests: `tests/test_providers_openai.py`, `tests/test_providers_gemini.py`, `tests/test_providers_grok.py` -> All passed.

---
*PR created automatically by Jules for task [5057494403899515557](https://jules.google.com/task/5057494403899515557) started by @n24q02m*