### PR TITLE
fix: refactor deeply nested download_to_path functions

### DIFF
--- a/src/imagine_mcp/media.py
+++ b/src/imagine_mcp/media.py
@@ -353,23 +353,41 @@ def _extract_extension(url: str) -> str:
     return ext.lower()
 
 
+def _write_response(resp: httpx.Response, dest: Path, max_size: int) -> None:
+    """Write httpx.Response content to dest path with max size limit."""
+    bytes_read = 0
+    with dest.open("wb") as f:
+        for chunk in resp.iter_bytes(chunk_size=65536):
+            bytes_read += len(chunk)
+            if bytes_read > max_size:
+                raise httpx.HTTPError(
+                    f"Download failed: Exceeded maximum size of {max_size} bytes"
+                )
+            f.write(chunk)
+
+
+async def _write_response_async(resp: httpx.Response, dest: Path, max_size: int) -> None:
+    """Async version of _write_response."""
+    bytes_read = 0
+    with dest.open("wb") as f:
+        async for chunk in resp.aiter_bytes(chunk_size=65536):
+            bytes_read += len(chunk)
+            if bytes_read > max_size:
+                raise httpx.HTTPError(
+                    f"Download failed: Exceeded maximum size of {max_size} bytes"
+                )
+            await asyncio.to_thread(f.write, chunk)
+
+
 def download_to_path(url: str, dest: Path) -> Path:
     """Download URL content to dest path. Returns path."""
     dest.parent.mkdir(parents=True, exist_ok=True)
     max_size = 50 * 1024 * 1024  # 50MB limit to prevent DoS
-    bytes_read = 0
     try:
         client = get_ssrf_safe_client()
         with client.stream("GET", url, follow_redirects=True, timeout=60) as resp:
             resp.raise_for_status()
-            with dest.open("wb") as f:
-                for chunk in resp.iter_bytes(chunk_size=65536):
-                    bytes_read += len(chunk)
-                    if bytes_read > max_size:
-                        raise httpx.HTTPError(
-                            f"Download failed: Exceeded maximum size of {max_size} bytes"
-                        )
-                    f.write(chunk)
+            _write_response(resp, dest, max_size)
     except InvalidURLError as e:
         raise httpx.HTTPError(f"Download failed due to invalid redirect: {e}") from e
     except Exception:
@@ -383,22 +401,11 @@ async def download_to_path_async(url: str, dest: Path) -> Path:
     """Async version of download_to_path."""
     await asyncio.to_thread(dest.parent.mkdir, parents=True, exist_ok=True)
     max_size = 50 * 1024 * 1024  # 50MB limit to prevent DoS
-    bytes_read = 0
     try:
         client = get_ssrf_safe_async_client()
         async with client.stream("GET", url, follow_redirects=True, timeout=60) as resp:
             resp.raise_for_status()
-
-            # Stream to disk with a sync file handle; offload each blocking
-            # write to a thread. The `with` block guarantees the handle closes.
-            with dest.open("wb") as f:
-                async for chunk in resp.aiter_bytes(chunk_size=65536):
-                    bytes_read += len(chunk)
-                    if bytes_read > max_size:
-                        raise httpx.HTTPError(
-                            f"Download failed: Exceeded maximum size of {max_size} bytes"
-                        )
-                    await asyncio.to_thread(f.write, chunk)
+            await _write_response_async(resp, dest, max_size)
     except InvalidURLError as e:
         raise httpx.HTTPError(f"Download failed due to invalid redirect: {e}") from e
     except Exception:

--- a/src/imagine_mcp/media.py
+++ b/src/imagine_mcp/media.py
@@ -366,7 +366,9 @@ def _write_response(resp: httpx.Response, dest: Path, max_size: int) -> None:
             f.write(chunk)
 
 
-async def _write_response_async(resp: httpx.Response, dest: Path, max_size: int) -> None:
+async def _write_response_async(
+    resp: httpx.Response, dest: Path, max_size: int
+) -> None:
     """Async version of _write_response."""
     bytes_read = 0
     with dest.open("wb") as f:


### PR DESCRIPTION
Refactored the deeply nested chunk writing logic in 'download_to_path' and 'download_to_path_async' into dedicated internal helper functions '_write_response' and '_write_response_async'. This change improves code readability and maintainability while preserving existing functionality and security checks (e.g., the 50MB size limit).

---
*PR created automatically by Jules for task [13889561204999174356](https://jules.google.com/task/13889561204999174356) started by @n24q02m*