### PR TITLE
🛡️ Sentinel: [MEDIUM] fix unsafe bind address

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2026-06-13 - [Unsafe Bind Address]
+**Vulnerability:** The server used a hardcoded 0.0.0.0 bind address in the Dockerfile and (historically) in the server code, exposing it to the entire network when not behind a proxy.
+**Learning:** Hardcoding 0.0.0.0 is a common convenience that bypasses local binding restrictions but introduces significant risk in production environments without proper networking controls.
+**Prevention:** Always default to 127.0.0.1 for server bindings. Require explicit opt-in for 0.0.0.0 through environment variables or configuration files, and ensure that security-sensitive configurations are regularly audited.

--- a/Dockerfile
+++ b/Dockerfile
@@ -63,6 +63,6 @@ ENTRYPOINT ["python", "-m", "imagine_mcp"]
 FROM runtime AS http
 ENV MCP_TRANSPORT=http \
     MCP_PORT=8080 \
-    MCP_HOST=0.0.0.0
+    MCP_HOST=127.0.0.1
 EXPOSE 8080
 ENTRYPOINT ["python", "-m", "imagine_mcp"]


### PR DESCRIPTION
Severity: MEDIUM
Vulnerability: Unsafe Bind Address
Impact: Exposes the server to the entire network when not behind a secure proxy.
Fix: Updated the Dockerfile to default \`MCP_HOST\` to \`127.0.0.1\` instead of \`0.0.0.0\`. The server code already defaults to \`127.0.0.1\`.
Verification: Ran \`bandit\` and full test suite with \`uv run pytest\`. Both passed. Verified Dockerfile modification with \`grep\`.
Recorded learning in .jules/sentinel.md.

---
*PR created automatically by Jules for task [17277947939749412427](https://jules.google.com/task/17277947939749412427) started by @n24q02m*