### PR TITLE
fix: resolve relay_skip reported using env vars for credentials

### DIFF
--- a/src/imagine_mcp/server.py
+++ b/src/imagine_mcp/server.py
@@ -43,13 +43,23 @@ def _creds_state() -> str:
 
 
 def _providers_configured() -> list[str]:
+    """Return list of providers configured via environment variables."""
+    from imagine_mcp.relay_setup import CREDENTIAL_KEYS
+
+    _key_to_provider = {
+        "GEMINI_API_KEY": "gemini",
+        "OPENAI_API_KEY": "openai",
+        "XAI_API_KEY": "grok",
+    }
+    seen: set[str] = set()
     out: list[str] = []
-    if os.environ.get("GEMINI_API_KEY"):
-        out.append("gemini")
-    if os.environ.get("OPENAI_API_KEY"):
-        out.append("openai")
-    if os.environ.get("XAI_API_KEY"):
-        out.append("grok")
+    for key in CREDENTIAL_KEYS:
+        provider = _key_to_provider.get(key, key)
+        if provider in seen:
+            continue
+        if os.environ.get(key):
+            out.append(provider)
+            seen.add(provider)
     return out
 
 
@@ -228,6 +238,7 @@ def build_app() -> FastMCP:
                     }
                 return {
                     "status": "using_env",
+                    "message": "Using env vars for credentials.",
                     "providers": _env_providers,
                 }
             case "relay_reset":

--- a/tests/test_g6_ux_status_accuracy.py
+++ b/tests/test_g6_ux_status_accuracy.py
@@ -88,7 +88,9 @@ class TestRelayStatusLiveDerivedState:
         assert isinstance(res["providers_configured"], list)
 
     @pytest.mark.anyio
-    async def test_no_duplicate_providers(self, app, monkeypatch: pytest.MonkeyPatch) -> None:
+    async def test_no_duplicate_providers(
+        self, app, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
         """If same key appears in both env and store, provider appears only once."""
         monkeypatch.setenv("GEMINI_API_KEY", "key-from-env")
 

--- a/tests/test_g6_ux_status_accuracy.py
+++ b/tests/test_g6_ux_status_accuracy.py
@@ -14,41 +14,24 @@ before claiming "using_env" and returns needs_setup if none are set.
 
 from __future__ import annotations
 
-from typing import Any
+import json
 from unittest.mock import patch
 
 import pytest
+from imagine_mcp.server import build_app
 
 
-def _relay_status() -> dict[str, Any]:
-    """Simulate config(action='relay_status') using module-level helper."""
-    from imagine_mcp.server import _providers_configured_live
-
-    live = _providers_configured_live()
-    return {
-        "status": "configured" if live else "pending",
-        "providers_configured": live,
-    }
-
-
-def _relay_skip() -> dict[str, Any]:
-    """Simulate config(action='relay_skip') using module-level helper."""
-    from imagine_mcp.server import _providers_configured
-
-    env_providers = _providers_configured()
-    if not env_providers:
-        return {
-            "status": "needs_setup",
-            "message": "No env vars set. Run config(action='open_relay') to configure via browser.",
-        }
-    return {"status": "using_env", "providers": env_providers}
+@pytest.fixture
+def app():
+    return build_app()
 
 
 class TestRelayStatusLiveDerivedState:
     """relay_status derives state from live PerPluginStore, not env-only."""
 
-    def test_returns_configured_when_store_has_keys(
-        self, monkeypatch: pytest.MonkeyPatch
+    @pytest.mark.anyio
+    async def test_returns_configured_when_store_has_keys(
+        self, app, monkeypatch: pytest.MonkeyPatch
     ) -> None:
         """relay_status returns configured when PerPluginStore has provider keys."""
         monkeypatch.delenv("GEMINI_API_KEY", raising=False)
@@ -59,13 +42,15 @@ class TestRelayStatusLiveDerivedState:
             "mcp_core.storage.per_plugin_store.PerPluginStore.load",
             return_value={"GEMINI_API_KEY": "test-key-123"},
         ):
-            result = _relay_status()
+            result = await app.call_tool("config", {"action": "relay_status"})
+            res = json.loads(result.content[0].text)
 
-        assert result["status"] == "configured"
-        assert "gemini" in result["providers_configured"]
+        assert res["status"] == "configured"
+        assert "gemini" in res["providers_configured"]
 
-    def test_returns_pending_when_store_empty(
-        self, monkeypatch: pytest.MonkeyPatch
+    @pytest.mark.anyio
+    async def test_returns_pending_when_store_empty(
+        self, app, monkeypatch: pytest.MonkeyPatch
     ) -> None:
         """relay_status returns pending when store empty and no env vars."""
         monkeypatch.delenv("GEMINI_API_KEY", raising=False)
@@ -76,13 +61,15 @@ class TestRelayStatusLiveDerivedState:
             "mcp_core.storage.per_plugin_store.PerPluginStore.load",
             return_value={},
         ):
-            result = _relay_status()
+            result = await app.call_tool("config", {"action": "relay_status"})
+            res = json.loads(result.content[0].text)
 
-        assert result["status"] == "pending"
-        assert result["providers_configured"] == []
+        assert res["status"] == "pending"
+        assert res["providers_configured"] == []
 
-    def test_response_includes_providers_configured_field(
-        self, monkeypatch: pytest.MonkeyPatch
+    @pytest.mark.anyio
+    async def test_response_includes_providers_configured_field(
+        self, app, monkeypatch: pytest.MonkeyPatch
     ) -> None:
         """relay_status always includes providers_configured key in response."""
         monkeypatch.delenv("GEMINI_API_KEY", raising=False)
@@ -93,12 +80,14 @@ class TestRelayStatusLiveDerivedState:
             "mcp_core.storage.per_plugin_store.PerPluginStore.load",
             return_value={},
         ):
-            result = _relay_status()
+            result = await app.call_tool("config", {"action": "relay_status"})
+            res = json.loads(result.content[0].text)
 
-        assert "providers_configured" in result
-        assert isinstance(result["providers_configured"], list)
+        assert "providers_configured" in res
+        assert isinstance(res["providers_configured"], list)
 
-    def test_no_duplicate_providers(self, monkeypatch: pytest.MonkeyPatch) -> None:
+    @pytest.mark.anyio
+    async def test_no_duplicate_providers(self, app, monkeypatch: pytest.MonkeyPatch) -> None:
         """If same key appears in both env and store, provider appears only once."""
         monkeypatch.setenv("GEMINI_API_KEY", "key-from-env")
 
@@ -106,36 +95,42 @@ class TestRelayStatusLiveDerivedState:
             "mcp_core.storage.per_plugin_store.PerPluginStore.load",
             return_value={"GEMINI_API_KEY": "key-from-store"},
         ):
-            result = _relay_status()
+            result = await app.call_tool("config", {"action": "relay_status"})
+            res = json.loads(result.content[0].text)
 
-        assert result["providers_configured"].count("gemini") == 1
+        assert res["providers_configured"].count("gemini") == 1
 
 
 class TestRelaySkipHonesty:
     """relay_skip reports needs_setup when no env vars are set (Bug 2 fix)."""
 
-    def test_returns_needs_setup_when_no_env_vars(
-        self, monkeypatch: pytest.MonkeyPatch
+    @pytest.mark.anyio
+    async def test_returns_needs_setup_when_no_env_vars(
+        self, app, monkeypatch: pytest.MonkeyPatch
     ) -> None:
         """relay_skip returns needs_setup status when no provider env vars set."""
         monkeypatch.delenv("GEMINI_API_KEY", raising=False)
         monkeypatch.delenv("OPENAI_API_KEY", raising=False)
         monkeypatch.delenv("XAI_API_KEY", raising=False)
 
-        result = _relay_skip()
+        result = await app.call_tool("config", {"action": "relay_skip"})
+        res = json.loads(result.content[0].text)
 
-        assert result["status"] == "needs_setup"
-        assert "open_relay" in result["message"]
+        assert res["status"] == "needs_setup"
+        assert "open_relay" in res["message"]
 
-    def test_returns_using_env_when_env_vars_set(
-        self, monkeypatch: pytest.MonkeyPatch
+    @pytest.mark.anyio
+    async def test_returns_using_env_when_env_vars_set(
+        self, app, monkeypatch: pytest.MonkeyPatch
     ) -> None:
         """relay_skip returns using_env status when provider env vars are set."""
         monkeypatch.setenv("OPENAI_API_KEY", "sk-test")
         monkeypatch.delenv("GEMINI_API_KEY", raising=False)
         monkeypatch.delenv("XAI_API_KEY", raising=False)
 
-        result = _relay_skip()
+        result = await app.call_tool("config", {"action": "relay_skip"})
+        res = json.loads(result.content[0].text)
 
-        assert result["status"] == "using_env"
-        assert "openai" in result["providers"]
+        assert res["status"] == "using_env"
+        assert res["message"] == "Using env vars for credentials."
+        assert "openai" in res["providers"]

--- a/tests/test_g6_ux_status_accuracy.py
+++ b/tests/test_g6_ux_status_accuracy.py
@@ -18,6 +18,7 @@ import json
 from unittest.mock import patch
 
 import pytest
+
 from imagine_mcp.server import build_app
 
 


### PR DESCRIPTION
I have fixed the issue where \`relay_skip\` reported an inaccurate status and message regarding environment variables.

### Changes:
- **Robust Credential Check**: Refactored \`_providers_configured\` in \`src/imagine_mcp/server.py\` to use the centralized \`CREDENTIAL_KEYS\` from \`relay_setup\`, ensuring consistency with the live credential check and avoiding hardcoded keys.
- **Informative Messaging**: Updated the \`relay_skip\` tool action to include the explicit message "Using env vars for credentials." when successful, aligning the response with the expected UX.
- **Real-world Testing**: Overhauled \`tests/test_g6_ux_status_accuracy.py\` to replace simulated helpers with actual \`FastMCP\` tool calls. This ensures that the fix is verified against the real implementation rather than just a simulation of it.
- **Verification**: Confirmed that \`relay_status\` and \`relay_complete\` correctly leverage \`_providers_configured_live()\` to avoid stale state issues.

All tests passed, and the full test suite remains green.

---
*PR created automatically by Jules for task [17002036942974811268](https://jules.google.com/task/17002036942974811268) started by @n24q02m*