### PR TITLE
fix: correct credential storage and setup-transport docs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -75,7 +75,7 @@ Dispatched in `src/imagine_mcp/__main__.py:41-64`:
 - `OPENAI_API_KEY`
 - `XAI_API_KEY`
 
-Priority (`src/imagine_mcp/relay_setup.py`): env var > `config.enc` (via mcp-core) > optional `MCP_RELAY_URL` relay fetch > degraded mode. (Stdio mode reads env vars only.)
+Priority (`src/imagine_mcp/relay_setup.py`): env var > `~/.imagine-mcp/config.json` (per-plugin store, via mcp-core) > optional `MCP_RELAY_URL` relay fetch > degraded mode. (Stdio mode reads env vars only.)
 
 ## LLM backend (litellm passthrough)
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -75,7 +75,7 @@ Two transports, dispatched in `src/imagine_mcp/__main__.py:41-64`:
 - `OPENAI_API_KEY`
 - `GEMINI_API_KEY` (renamed from `GOOGLE_AI_STUDIO_API_KEY` 2026-04-26 for parity with wet/mnemo/crg)
 
-Source priority (`src/imagine_mcp/relay_setup.py`): env var > `config.enc` (per-plugin store, via mcp-core) > optional `MCP_RELAY_URL` remote-relay fetch > degraded mode. (Stdio mode reads env vars only.)
+Source priority (`src/imagine_mcp/relay_setup.py`): env var > `~/.imagine-mcp/config.json` (per-plugin store, via mcp-core) > optional `MCP_RELAY_URL` remote-relay fetch > degraded mode. (Stdio mode reads env vars only.)
 
 Auto-fallback provider (when `understand`/`generate` is called without an
 explicit `provider`): the first key present in this order wins —

--- a/README.md
+++ b/README.md
@@ -135,7 +135,7 @@ How imagine-mcp stacks up against direct competitors in each pillar:
 - **SSRF + LFI prevention** -- All `media_urls` and `reference_image_url` are validated at the dispatch boundary; only `http://` and `https://` schemes reach the providers. `file://`, `ftp://`, `gopher://`, and scheme-less URLs are rejected.
 - **No credentials in errors** -- Provider-side errors are sanitized before being returned.
 - **Degraded start** -- Missing credentials do not prevent the server from starting; affected actions surface actionable errors instead of crashing at boot.
-- **Relay transport** -- Credentials submitted through the local relay form are stored encrypted via `mcp-core` (`config.enc`, user-scoped `platformdirs`).
+- **Credential storage** -- Credentials submitted through the browser credential form are stored encrypted via `mcp-core` (AES-GCM, machine-bound key) at `~/.imagine-mcp/config.json`.
 
 ## Build from Source
 

--- a/src/imagine_mcp/docs/config.md
+++ b/src/imagine_mcp/docs/config.md
@@ -20,7 +20,7 @@ config(
 |--------|---------|
 | `open_relay` | Start relay session; server opens browser with credential form |
 | `relay_status` | Poll current relay session status |
-| `relay_complete` | Persist relay submission to encrypted config.enc |
+| `relay_complete` | Persist relay submission to the encrypted per-plugin store (`~/.imagine-mcp/config.json`) |
 | `relay_skip` | Skip relay; rely on env vars only |
 | `relay_reset` | Delete stored credentials (forces re-setup) |
 | `warmup` | Pre-load heavy resources (no-op in v1) |
@@ -38,13 +38,13 @@ config(
 ```python
 # First-time setup
 config(action="open_relay")
-# -> {"session_id": "...", "url": "http://localhost:8001/...", "expires_in_seconds": 300}
+# -> {"status": "saved", "providers_configured": [...]} or {"status": "degraded", "message": "..."}
 
 config(action="relay_status")
-# -> {"status": "pending"} or {"status": "done"}
+# -> {"status": "pending", "providers_configured": []} or {"status": "configured", "providers_configured": [...]}
 
 config(action="relay_complete")
-# -> {"status": "saved", "providers_configured": ["gemini", "openai", "grok"]}
+# -> {"status": "saved", "providers_configured": ["gemini", "openai", "grok"]} or {"status": "no_credentials", "providers_configured": []}
 
 config(action="status")
 # -> {"credentials_state": "CONFIGURED", "providers_configured": [...], ...}
@@ -59,6 +59,6 @@ config(action="status")
 
 ## Security
 
-- Credentials stored in `config.enc` via mcp-core (AES-256-GCM, machine-bound key).
-- Relay transport: ECDH P-256 key exchange + AES-256-GCM.
+- Credentials stored in `~/.imagine-mcp/config.json` via mcp-core (AES-256-GCM, machine-bound key); multi-user HTTP mode scopes them per JWT subject under `~/.imagine-mcp/subs/<sub>/config.json` (AES-256-GCM, PBKDF2 key from `CREDENTIAL_SECRET`).
+- Setup transport: in HTTP mode credentials are entered through the browser credential form served by the mcp-core OAuth Authorization Server (`/authorize`).
 - API keys **never** appear in logs or error messages.


### PR DESCRIPTION
## Summary

Documentation drift fixes so the credential-storage and setup-transport descriptions match the current `mcp-core` per-plugin store behaviour.

## Changes

- **Storage path**: `config.enc` -> `~/.imagine-mcp/config.json`. The credential store moved to `mcp-core`'s per-plugin store, which writes AES-GCM ciphertext (machine-bound key) to `~/.imagine-mcp/config.json`; the old shared `config.enc` no longer applies. Updated `README.md`, `CLAUDE.md`, `AGENTS.md`, and `src/imagine_mcp/docs/config.md`.
- **Setup transport**: the HTTP setup flow uses the browser credential form served by the `mcp-core` OAuth Authorization Server (`/authorize`); replaced the stale "ECDH P-256 relay transport" description in the config help doc.
- **Multi-user note**: documented the per-JWT-subject layout `~/.imagine-mcp/subs/<sub>/config.json` (AES-GCM, PBKDF2 key from `CREDENTIAL_SECRET`) used in multi-user HTTP mode.
- **config example flow**: corrected the `open_relay` / `relay_status` / `relay_complete` example return shapes to match `server.py`.

Docs-only; no code or behaviour changes.