### PR TITLE
feat: Cloudflare serverless migration (Worker + Container + KV-only, base64 output)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,14 @@ build/
 # Virtualenv
 .venv/
 
+# Node (Cloudflare Worker)
+node_modules/
+package-lock.json
+
+# Cloudflare Worker
+.wrangler/
+.wrangler-dryrun/
+
 # AI traces (per CLAUDE.md public repo policy — superpower content lives in private repo n24q02m/.superpower)
 .jules/
 .Jules/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -179,3 +179,32 @@ Multi-user remote mode (deployment property; not a separate config) requires `MC
 
 References: `mcp-core/scripts/e2e/matrix.yaml`, `~/.claude/skills/mcp-dev/references/e2e-full-matrix.md` (harness-readiness gate), `~/.claude/skills/mcp-dev/references/secrets-skret.md` (per-server credential layout), `~/.claude/skills/mcp-dev/references/multi-user-pattern.md` (per-JWT-sub isolation).
 
+## Cloudflare serverless mode
+
+imagine-mcp runs serverless on Cloudflare (Worker + Container + KV-only). The
+only externalised state is the per-sub credential vault (KV); generation is
+returned base64-only because the container FS is ephemeral.
+
+| env var | value | purpose |
+|---|---|---|
+| `MCP_TRANSPORT` | `http` | container detection + multi-user mode |
+| `PUBLIC_URL` | `https://imagine.n24q02m.com` | public bind + per-JWT-sub isolation |
+| `MCP_STORAGE_BACKEND` | `cf-kv` | route PerPluginStore through KV |
+| `MCP_KV_BASE_URL` | `http://kv.internal` | Worker outbound-handler virtual host |
+| `IMAGINE_OUTPUT_MODE` | `base64` | force base64 output (no local media path) |
+| `CREDENTIAL_SECRET` | (secret) | stable EdDSA JWT key (no disk) + per-sub vault key |
+| `MCP_DCR_SERVER_SECRET` | (secret) | proof of intentional multi-user deploy |
+
+`IMAGINE_OUTPUT_MODE=base64` overrides the `generate` tool's `output_mode` arg
+so every request returns `image_base64` / `video_base64` and never an
+`image_path` (the ephemeral container FS would lose the file on recreate).
+
+ResponseCache (`cache.py`, diskcache) is NOT on the hot path -- `understand` /
+`generate` never read/write it; it is only touched by `config(action="cache_clear")`,
+which is a harmless no-op on the ephemeral FS. No KV migration needed.
+
+`src/worker.ts` + `wrangler.jsonc` are copied from the frozen CF template
+(`wet-mcp/docs/cf-template.md`), KV-only (no D1/Vectorize): `ImagineContainer` DO
++ `IMAGINE` binding, the `kv.internal` outbound handler off the public `fetch`
+(security), and the 5 footguns. Live OAuth self-test: `scripts/cf_full_flow.py`.
+

--- a/package.json
+++ b/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "imagine-mcp-worker",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "test:worker": "vitest run tests/worker.test.ts",
+    "cf:dryrun": "wrangler deploy --dry-run --outdir .wrangler-dryrun"
+  },
+  "devDependencies": {
+    "@cloudflare/containers": "^0.3.7",
+    "@cloudflare/workers-types": "^4.20250614.0",
+    "typescript": "^5.6.0",
+    "vitest": "^4.1.0",
+    "wrangler": "^4.0.0"
+  }
+}

--- a/scripts/cf_full_flow.py
+++ b/scripts/cf_full_flow.py
@@ -1,0 +1,409 @@
+"""CF imagine live OAuth full-flow self-test harness.
+
+Drives the deployed imagine-mcp Cloudflare Worker (Worker + Container + KV)
+end-to-end against a public endpoint and asserts base64-force is live:
+
+  1. DCR register        -- POST /register (RFC 7591) -> client_id
+  2. password-grant      -- /authorize -> /login (gate password) -> token
+  3. /authorize form save with retry-on-500 (E.1 interception-race mitigation)
+  4. poll until readable  (E.2 KV eventual-consistency mitigation)
+  5. authenticated tool call -- config(action="status") then
+     generate(media_type="image", prompt="a red circle", tier="poor"); assert the
+     result has `image_base64` and NO `image_path` (proves IMAGINE_OUTPUT_MODE=base64
+     is forced server-side on the serverless deployment).
+
+The retry-on-500 (save_retries) + awaiting-setup poll (retries/delay) plumbing is
+ported from the wet CF harness (the plan-01-hardened worker template imagine copies
+in Task 3); the run-mode flags drive the Task 5 success-criteria scenarios.
+
+Secrets from env: provider keys GEMINI_API_KEY / OPENAI_API_KEY / XAI_API_KEY
+(skret injects these); login gate password from MCP_RELAY_PASSWORD (or RELAY_PW).
+
+Run modes:
+  (default)            full flow: save creds + authenticated generate, assert base64.
+  --save-only          DCR + token + save creds for one sub, then exit (recreate-gate
+                       setup half of SUCCESS CRITERION 4).
+  --auth-only          reuse/re-mint a token for the SAME sub, tool call WITHOUT
+                       re-saving creds (recreate-gate verify half: state survived KV).
+  --two-sub-isolation  two distinct subs, each saves its own provider key; assert
+                       each sub sees only its own configured provider (no bleed).
+
+Examples:
+  skret run -e prod -- python scripts/cf_full_flow.py --endpoint https://imagine.n24q02m.com
+  skret run -e prod -- python scripts/cf_full_flow.py --save-only
+  skret run -e prod -- python scripts/cf_full_flow.py --auth-only
+  skret run -e prod -- python scripts/cf_full_flow.py --two-sub-isolation
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import base64
+import hashlib
+import json as _json
+import os
+import re
+import secrets
+import sys
+import time
+import urllib.parse
+
+DEFAULT_ENDPOINT = "https://imagine.n24q02m.com"
+
+
+def _password() -> str:
+    pw = os.environ.get("RELAY_PW") or os.environ.get("MCP_RELAY_PASSWORD")
+    if not pw:
+        raise SystemExit(
+            "MCP_RELAY_PASSWORD (or RELAY_PW) is required for the password-grant "
+            "login gate. It lives in skret /oci-vm-prod/prod (infra-shared), NOT "
+            "/imagine-mcp/prod -- compose both namespaces (see plan Task 5)."
+        )
+    return pw
+
+
+def _provider_creds() -> dict[str, str]:
+    """Build the credential form payload from whichever provider keys are present.
+
+    imagine forwards GEMINI/OPENAI/XAI keys + the optional UNDERSTAND_MODELS chain.
+    Generation is native (no model chain needed); a single provider key is enough
+    to exercise base64-force.
+    """
+    creds: dict[str, str] = {}
+    for env_name in ("GEMINI_API_KEY", "OPENAI_API_KEY", "XAI_API_KEY"):
+        v = os.environ.get(env_name)
+        if v:
+            creds[env_name] = v
+    if os.environ.get("UNDERSTAND_MODELS"):
+        creds["UNDERSTAND_MODELS"] = os.environ["UNDERSTAND_MODELS"]
+    return creds
+
+
+def _provider_of(creds: dict[str, str]) -> str | None:
+    """The generate provider implied by the configured key (first present wins;
+    matches the dispatcher auto-fallback order xai -> openai -> gemini)."""
+    if "XAI_API_KEY" in creds:
+        return "grok"
+    if "OPENAI_API_KEY" in creds:
+        return "openai"
+    if "GEMINI_API_KEY" in creds:
+        return "gemini"
+    return None
+
+
+class _SaveRetry(Exception):
+    pass
+
+
+def get_token(
+    endpoint: str,
+    creds: dict[str, str],
+    *,
+    save: bool = True,
+    save_retries: int = 8,
+) -> str:
+    """Run the full OAuth flow, retrying on a transient 500 at the credential
+    save step (CF Containers outbound-interception race on cold-started
+    instances -- the kv.internal PUT occasionally lands before interception is
+    applied; E.1). Each retry restarts from DCR so the nonce is fresh.
+
+    When ``save`` is False the credential form is still submitted with an EMPTY
+    payload (no provider keys) so existing KV state is left untouched -- used by
+    --auth-only to re-mint a token for the SAME sub without overwriting creds.
+    """
+    import httpx  # lazy: keep --help importable without httpx installed
+
+    last: Exception | None = None
+    payload = creds if save else {}
+    for attempt in range(save_retries):
+        try:
+            return _get_token_once(httpx, endpoint, payload)
+        except _SaveRetry as e:
+            last = e
+            print(
+                f"get_token: save 500 (interception race), retry {attempt + 1}/{save_retries}"
+            )
+            time.sleep(3)
+    raise RuntimeError(f"get_token failed after {save_retries} retries: {last}")
+
+
+def _get_token_once(httpx, endpoint: str, creds: dict[str, str]) -> str:
+    verifier = base64.urlsafe_b64encode(secrets.token_bytes(32)).rstrip(b"=").decode()
+    challenge = (
+        base64.urlsafe_b64encode(hashlib.sha256(verifier.encode()).digest())
+        .rstrip(b"=")
+        .decode()
+    )
+    ru = "http://localhost:9999/cb"
+    pw = _password()
+    with httpx.Client(timeout=120, follow_redirects=False) as c:
+        cid = c.post(
+            f"{endpoint}/register",
+            json={
+                "client_name": "cf-verify",
+                "redirect_uris": [ru],
+                "grant_types": ["authorization_code", "refresh_token"],
+                "response_types": ["code"],
+                "token_endpoint_auth_method": "none",
+                "scope": "offline_access",
+            },
+        ).json()["client_id"]
+        az = c.get(
+            f"{endpoint}/authorize",
+            params={
+                "response_type": "code",
+                "client_id": cid,
+                "redirect_uri": ru,
+                "code_challenge": challenge,
+                "code_challenge_method": "S256",
+                "state": "st",
+                "scope": "offline_access",
+            },
+        )
+        nxt = urllib.parse.parse_qs(
+            urllib.parse.urlparse(az.headers["location"]).query
+        )["next"][0]
+        lg = c.post(f"{endpoint}/login", data={"next": nxt, "password": pw})
+        url = lg.headers["location"]
+        url = url if url.startswith("http") else endpoint + url
+        form_html = c.get(url).text
+        m = re.search(r"/authorize\?nonce=([A-Za-z0-9_\-]+)", form_html)
+        assert m, "nonce not found in form"
+        nonce = m.group(1)
+        sub = c.post(f"{endpoint}/authorize", params={"nonce": nonce}, json=creds)
+        if sub.status_code == 500 and "save credentials" in sub.text:
+            raise _SaveRetry(sub.text[:120])
+        assert sub.status_code == 200, (sub.status_code, sub.text[:300])
+        data = sub.json()
+        assert data.get("ok"), data
+        code = urllib.parse.parse_qs(urllib.parse.urlparse(data["redirect_url"]).query)[
+            "code"
+        ][0]
+        tok = c.post(
+            f"{endpoint}/token",
+            data={
+                "grant_type": "authorization_code",
+                "code": code,
+                "redirect_uri": ru,
+                "client_id": cid,
+                "code_verifier": verifier,
+            },
+        )
+        assert tok.status_code == 200, (tok.status_code, tok.text[:300])
+        return tok.json()["access_token"]
+
+
+def _sub_of(token: str) -> str:
+    payload = _json.loads(base64.urlsafe_b64decode(token.split(".")[1] + "=="))
+    return payload.get("sub", "?")
+
+
+async def _call(s, label, tool, args, *, retries=20, delay=8):
+    """Call a tool, retrying while credentials are still propagating (KV
+    cross-colo eventual consistency after setup writes them on another DO; E.2).
+    Returns the concatenated text payload of the result, or None on give-up."""
+    for i in range(retries):
+        try:
+            res = await s.call_tool(tool, args)
+            txt = "".join(getattr(b, "text", "") for b in res.content)
+            if "awaiting_setup" in txt or "Credentials not configured" in txt:
+                print(f"{label}: awaiting_setup (KV propagating) try {i + 1}/{retries}")
+                await asyncio.sleep(delay)
+                continue
+            print(f"{label} OK:", txt[:320].replace("\n", " "))
+            return txt
+        except Exception as e:
+            print(f"{label} ERR:", repr(e)[:300])
+            return None
+    print(f"{label}: gave up after {retries} tries")
+    return None
+
+
+def _assert_base64_no_path(txt: str) -> None:
+    """Assert a generate result carries image_base64 and NOT image_path."""
+    assert txt is not None, "generate returned no payload"
+    assert "image_base64" in txt, f"expected image_base64 in result, got: {txt[:300]}"
+    assert "image_path" not in txt, (
+        f"image_path present -- base64-force NOT live: {txt[:300]}"
+    )
+    print("ASSERT OK: image_base64 present, image_path absent (base64-force live).")
+
+
+async def _session(endpoint: str, token: str):
+    from mcp import ClientSession  # lazy: keep --help importable without mcp installed
+    from mcp.client.streamable_http import streamablehttp_client
+
+    return streamablehttp_client(
+        f"{endpoint}/mcp", headers={"Authorization": f"Bearer {token}"}
+    ), ClientSession
+
+
+async def run_full(endpoint: str) -> None:
+    creds = _provider_creds()
+    if not creds:
+        raise SystemExit(
+            "No provider key in env (GEMINI_API_KEY / OPENAI_API_KEY / XAI_API_KEY). "
+            "skret run injects them; cannot save credentials without one."
+        )
+    provider = _provider_of(creds)
+    token = get_token(endpoint, creds, save=True)
+    print("TOKEN OK len=", len(token), "sub=", _sub_of(token))
+    transport, ClientSession = await _session(endpoint, token)
+    async with transport as (r, w, _), ClientSession(r, w) as s:
+        await s.initialize()
+        tools = await s.list_tools()
+        print("TOOLS:", [t.name for t in tools.tools])
+        await _call(s, "CONFIG_STATUS", "config", {"action": "status"})
+        txt = await _call(
+            s,
+            "GENERATE_IMAGE",
+            "generate",
+            {
+                "media_type": "image",
+                "prompt": "a red circle",
+                "tier": "poor",
+                **({"provider": provider} if provider else {}),
+            },
+        )
+        _assert_base64_no_path(txt)
+    print("FULL FLOW PASS.")
+
+
+async def run_save_only(endpoint: str) -> None:
+    creds = _provider_creds()
+    if not creds:
+        raise SystemExit("No provider key in env -- nothing to save (--save-only).")
+    token = get_token(endpoint, creds, save=True)
+    print(
+        "SAVE-ONLY OK: creds saved for sub=", _sub_of(token), "len(token)=", len(token)
+    )
+
+
+async def run_auth_only(endpoint: str) -> None:
+    # Re-mint a token (same gate password -> same sub) but DO NOT re-save creds:
+    # the empty-payload submit leaves existing KV state untouched, proving the
+    # previously-saved key survived a delete+recreate (SUCCESS CRITERION 4).
+    token = get_token(endpoint, {}, save=False)
+    provider = _provider_of(_provider_creds())  # local hint for the generate call
+    print("AUTH-ONLY OK: re-minted token for sub=", _sub_of(token))
+    transport, ClientSession = await _session(endpoint, token)
+    async with transport as (r, w, _), ClientSession(r, w) as s:
+        await s.initialize()
+        await _call(s, "CONFIG_STATUS", "config", {"action": "status"})
+        txt = await _call(
+            s,
+            "GENERATE_IMAGE",
+            "generate",
+            {
+                "media_type": "image",
+                "prompt": "a red circle",
+                "tier": "poor",
+                **({"provider": provider} if provider else {}),
+            },
+        )
+        _assert_base64_no_path(txt)
+    print("AUTH-ONLY PASS: state survived recreate (KV creds resolved, no re-save).")
+
+
+async def run_two_sub_isolation(endpoint: str) -> None:
+    # Two distinct subs each get a DIFFERENT provider key; assert each only sees
+    # its own configured provider (KV keys imagine/subs/<sub>/config are disjoint,
+    # AES-GCM under per-sub-derived keys). The gate password is shared, so we
+    # distinguish subs by configuring a distinct provider per run and asserting
+    # the status reflects only that provider.
+    all_creds = _provider_creds()
+    keys = [
+        k for k in ("GEMINI_API_KEY", "OPENAI_API_KEY", "XAI_API_KEY") if k in all_creds
+    ]
+    if len(keys) < 2:
+        raise SystemExit(
+            "two-sub isolation needs >=2 distinct provider keys in env "
+            f"(have: {keys or 'none'})."
+        )
+    prov_of = {
+        "GEMINI_API_KEY": "gemini",
+        "OPENAI_API_KEY": "openai",
+        "XAI_API_KEY": "grok",
+    }
+    results: dict[str, str] = {}
+    subs: dict[str, str] = {}
+    for k in keys[:2]:
+        creds = {k: all_creds[k]}
+        token = get_token(endpoint, creds, save=True)
+        sub = _sub_of(token)
+        subs[k] = sub
+        transport, ClientSession = await _session(endpoint, token)
+        async with transport as (r, w, _), ClientSession(r, w) as s:
+            await s.initialize()
+            txt = await _call(
+                s, f"STATUS[{prov_of[k]}]", "config", {"action": "status"}
+            )
+            results[k] = txt or ""
+    # Each sub's status must reflect its own configured provider and NOT bleed the
+    # other sub's provider into its view.
+    a, b = keys[0], keys[1]
+    print(f"sub({prov_of[a]})={subs[a]}  sub({prov_of[b]})={subs[b]}")
+    if subs[a] == subs[b]:
+        raise SystemExit(
+            f"ISOLATION INCONCLUSIVE: both runs share sub {subs[a]} (same gate "
+            "password collapses to one DO). Provide per-sub tokens to test bleed."
+        )
+    if prov_of[b] in results[a] and prov_of[a] not in results[a]:
+        raise SystemExit(
+            f"ISOLATION FAIL: sub {subs[a]} sees {prov_of[b]}'s provider, not its own."
+        )
+    if prov_of[a] in results[b] and prov_of[b] not in results[b]:
+        raise SystemExit(
+            f"ISOLATION FAIL: sub {subs[b]} sees {prov_of[a]}'s provider, not its own."
+        )
+    print(
+        "TWO-SUB ISOLATION OK: distinct subs, each configured independently, no bleed."
+    )
+
+
+def build_parser() -> argparse.ArgumentParser:
+    p = argparse.ArgumentParser(
+        description="CF imagine live OAuth full-flow self-test harness.",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    p.add_argument(
+        "--endpoint",
+        default=DEFAULT_ENDPOINT,
+        help=f"Deployed imagine endpoint (default: {DEFAULT_ENDPOINT})",
+    )
+    mode = p.add_mutually_exclusive_group()
+    mode.add_argument(
+        "--save-only",
+        action="store_true",
+        help="DCR + token + save creds for one sub, then exit (recreate-gate setup).",
+    )
+    mode.add_argument(
+        "--auth-only",
+        action="store_true",
+        help="Re-mint a token for the SAME sub, tool call WITHOUT re-saving creds "
+        "(recreate-gate verify -- state survived KV).",
+    )
+    mode.add_argument(
+        "--two-sub-isolation",
+        action="store_true",
+        help="Two distinct subs, assert each sees only its own provider key.",
+    )
+    return p
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    if args.save_only:
+        asyncio.run(run_save_only(args.endpoint))
+    elif args.auth_only:
+        asyncio.run(run_auth_only(args.endpoint))
+    elif args.two_sub_isolation:
+        asyncio.run(run_two_sub_isolation(args.endpoint))
+    else:
+        asyncio.run(run_full(args.endpoint))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/imagine_mcp/dispatcher.py
+++ b/src/imagine_mcp/dispatcher.py
@@ -339,13 +339,22 @@ async def dispatch_generate(
     aspect_ratio: str = "16:9",
     duration_seconds: int = 8,
     model: str | None = None,
+    output_mode: str = "both",
 ) -> dict[str, Any]:
     """Dispatch generate call to provider (fully async).
 
     When ``model`` is set, the litellm 'provider/model' prefix selects a
     native generation provider (catalog still picks the concrete model by
     tier); generation itself is never routed through litellm.
+
+    ``output_mode`` controls how generated media is returned:
+    ``"base64"`` (no disk write -- required on ephemeral CF FS),
+    ``"path"`` (on-disk path only), or ``"both"`` (default). The deploy-level
+    env var ``IMAGINE_OUTPUT_MODE`` overrides the caller's value when set, so a
+    serverless operator can force base64 across every request.
     """
+    effective_output_mode = os.getenv("IMAGINE_OUTPUT_MODE") or output_mode
+
     if model is not None:
         provider = _resolve_generate_provider(model)
     elif provider is None:
@@ -364,7 +373,15 @@ async def dispatch_generate(
 
     mod = _load_provider(provider)
     if media_type == "image":
-        return await mod.generate_image(prompt, tier, reference_image_url, aspect_ratio)
+        return await mod.generate_image(
+            prompt, tier, reference_image_url, aspect_ratio, effective_output_mode
+        )
     return await mod.generate_video(
-        prompt, tier, reference_image_url, job_id, aspect_ratio, duration_seconds
+        prompt,
+        tier,
+        reference_image_url,
+        job_id,
+        aspect_ratio,
+        duration_seconds,
+        effective_output_mode,
     )

--- a/src/imagine_mcp/media.py
+++ b/src/imagine_mcp/media.py
@@ -437,3 +437,35 @@ async def download_to_path_async(url: str, dest: Path) -> Path:
             await asyncio.to_thread(dest.unlink, missing_ok=True)
         raise
     return dest
+
+
+async def emit_media(
+    data: bytes, suffix: str, key: str, output_mode: str
+) -> dict[str, str]:
+    """Build the media-output fields for a generated asset, honouring output_mode.
+
+    ``output_mode``:
+      - ``"base64"``: return ``{<key>_base64: ...}`` only -- NO disk write
+        (required on the ephemeral Cloudflare container FS).
+      - ``"path"``:   write ``<cache>/generations/<uuid><suffix>`` and return
+        ``{<key>_path: ...}`` only.
+      - ``"both"``:   write the file AND return both fields (default).
+
+    ``key`` is ``"image"`` or ``"video"``; ``suffix`` includes the dot
+    (``".png"`` / ``".mp4"``).
+    """
+    import base64 as _b64
+    import uuid as _uuid
+
+    import platformdirs as _pd
+
+    out: dict[str, str] = {}
+    if output_mode in ("base64", "both"):
+        out[f"{key}_base64"] = _b64.b64encode(data).decode()
+    if output_mode in ("path", "both"):
+        out_dir = Path(_pd.user_cache_dir("imagine-mcp")) / "generations"
+        await asyncio.to_thread(out_dir.mkdir, parents=True, exist_ok=True)
+        out_path = out_dir / f"{_uuid.uuid4().hex}{suffix}"
+        await asyncio.to_thread(out_path.write_bytes, data)
+        out[f"{key}_path"] = str(out_path)
+    return out

--- a/src/imagine_mcp/providers/gemini.py
+++ b/src/imagine_mcp/providers/gemini.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import asyncio
-import base64
 import uuid
 from pathlib import Path
 from typing import Any
@@ -212,6 +211,7 @@ async def generate_image(
     tier: str,
     reference_image_url: str | None = None,
     aspect_ratio: str = "1:1",
+    output_mode: str = "both",
 ) -> dict[str, Any]:
     # native: litellm migration deferred -- probe credential-gated (gemini billing / no openai key 2026-06-11); avideo/aimage param unverified
     from google.genai import types
@@ -243,14 +243,11 @@ async def generate_image(
     if not image_data:
         raise ProviderAPIError("Gemini returned no image", status_code=500)
 
-    out_dir = Path(platformdirs.user_cache_dir("imagine-mcp")) / "generations"
-    await asyncio.to_thread(out_dir.mkdir, parents=True, exist_ok=True)
-    out_path = out_dir / f"{uuid.uuid4().hex}.png"
-    await asyncio.to_thread(out_path.write_bytes, image_data)
+    from imagine_mcp.media import emit_media
 
+    media_fields = await emit_media(image_data, ".png", "image", output_mode)
     return {
-        "image_path": str(out_path),
-        "image_base64": base64.b64encode(image_data).decode(),
+        **media_fields,
         "model": model,
         "provider": "gemini",
         "tier": tier,
@@ -264,6 +261,7 @@ async def generate_video(
     job_id: str | None = None,
     aspect_ratio: str = "16:9",
     duration_seconds: int = 8,
+    output_mode: str = "both",
 ) -> dict[str, Any]:
     # native: litellm migration deferred -- probe credential-gated (gemini billing / no openai key 2026-06-11); avideo/aimage param unverified
     from google.genai import types
@@ -298,20 +296,17 @@ async def generate_video(
         raise ProviderAPIError(f"Gemini job error: {op.error}", status_code=500)
 
     video = op.response.generated_videos[0]
-    out_dir = Path(platformdirs.user_cache_dir("imagine-mcp")) / "generations"
-    await asyncio.to_thread(out_dir.mkdir, parents=True, exist_ok=True)
-    out_path = out_dir / f"{uuid.uuid4().hex}.mp4"
+    from imagine_mcp.media import emit_media
 
-    # Download video file. genai.Client.aio.files.download is likely what we need.
-    await client.aio.files.download(file=video.video)
-    # The SDK usually saves it locally if specified, or returns bytes.
-    # Looking at sync code: video.video.save(str(out_path))
-    # Let's check if video.video has an async save.
-    # If not, use to_thread.
-    await asyncio.to_thread(video.video.save, str(out_path))
+    # The async files.download returns the downloaded bytes (unlike the sync
+    # client, it does NOT set video.video.video_bytes as a side effect), so
+    # capture the return value -- this keeps the video in memory and lets
+    # emit_media honour output_mode without persisting on the ephemeral CF FS.
+    video_bytes: bytes = await client.aio.files.download(file=video.video)
+    media_fields = await emit_media(video_bytes, ".mp4", "video", output_mode)
 
     return {
-        "video_path": str(out_path),
+        **media_fields,
         "job_id": job_id,
         "status": "done",
         "model": model,

--- a/src/imagine_mcp/providers/grok.py
+++ b/src/imagine_mcp/providers/grok.py
@@ -6,14 +6,9 @@ Dedicated endpoints for images and videos via httpx.
 
 from __future__ import annotations
 
-import asyncio
 import base64
 import urllib.parse
-import uuid
-from pathlib import Path
 from typing import Any
-
-import platformdirs
 
 from imagine_mcp.errors import (
     ProviderAPIError,
@@ -93,6 +88,7 @@ async def generate_image(
     tier: str,
     reference_image_url: str | None = None,
     aspect_ratio: str = "1:1",
+    output_mode: str = "both",
 ) -> dict[str, Any]:
     # native: litellm migration deferred -- probe credential-gated (gemini billing / no openai key 2026-06-11); avideo/aimage param unverified
     model = get_model_id("grok", "generate", "image", tier)
@@ -135,14 +131,12 @@ async def generate_image(
         ).decode()
 
     img_bytes = base64.b64decode(img_b64)
-    out_dir = Path(platformdirs.user_cache_dir("imagine-mcp")) / "generations"
-    await asyncio.to_thread(out_dir.mkdir, parents=True, exist_ok=True)
-    out_path = out_dir / f"{uuid.uuid4().hex}.png"
-    await asyncio.to_thread(out_path.write_bytes, img_bytes)
 
+    from imagine_mcp.media import emit_media
+
+    media_fields = await emit_media(img_bytes, ".png", "image", output_mode)
     return {
-        "image_path": str(out_path),
-        "image_base64": img_b64,
+        **media_fields,
         "model": model,
         "provider": "grok",
         "tier": tier,
@@ -156,6 +150,7 @@ async def generate_video(
     job_id: str | None = None,
     aspect_ratio: str = "16:9",
     duration_seconds: int = 8,
+    output_mode: str = "both",
 ) -> dict[str, Any]:
     # native: litellm migration deferred -- probe credential-gated (gemini billing / no openai key 2026-06-11); avideo/aimage param unverified
     model = get_model_id("grok", "generate", "video", tier)
@@ -234,13 +229,11 @@ async def generate_video(
         )
     ).content
 
-    out_dir = Path(platformdirs.user_cache_dir("imagine-mcp")) / "generations"
-    await asyncio.to_thread(out_dir.mkdir, parents=True, exist_ok=True)
-    out_path = out_dir / f"{uuid.uuid4().hex}.mp4"
-    await asyncio.to_thread(out_path.write_bytes, video_bytes)
+    from imagine_mcp.media import emit_media
 
+    media_fields = await emit_media(video_bytes, ".mp4", "video", output_mode)
     return {
-        "video_path": str(out_path),
+        **media_fields,
         "video_url": video_url,
         "job_id": job_id,
         "status": "done",

--- a/src/imagine_mcp/providers/openai.py
+++ b/src/imagine_mcp/providers/openai.py
@@ -2,13 +2,8 @@
 
 from __future__ import annotations
 
-import asyncio
 import base64
-import uuid
-from pathlib import Path
 from typing import Any
-
-import platformdirs
 
 from imagine_mcp.errors import (
     ProviderAPIError,
@@ -98,6 +93,7 @@ async def generate_image(
     tier: str,
     reference_image_url: str | None = None,
     aspect_ratio: str = "1:1",
+    output_mode: str = "both",
 ) -> dict[str, Any]:
     # native: litellm migration deferred -- probe credential-gated (gemini billing / no openai key 2026-06-11); avideo/aimage param unverified
     model = get_model_id("openai", "generate", "image", tier)
@@ -125,14 +121,11 @@ async def generate_image(
         raise ProviderAPIError("OpenAI returned no image", status_code=500)
     img_bytes = base64.b64decode(img_b64)
 
-    out_dir = Path(platformdirs.user_cache_dir("imagine-mcp")) / "generations"
-    await asyncio.to_thread(out_dir.mkdir, parents=True, exist_ok=True)
-    out_path = out_dir / f"{uuid.uuid4().hex}.png"
-    await asyncio.to_thread(out_path.write_bytes, img_bytes)
+    from imagine_mcp.media import emit_media
 
+    media_fields = await emit_media(img_bytes, ".png", "image", output_mode)
     return {
-        "image_path": str(out_path),
-        "image_base64": img_b64,
+        **media_fields,
         "model": model,
         "provider": "openai",
         "tier": tier,
@@ -146,6 +139,7 @@ async def generate_video(
     job_id: str | None = None,
     aspect_ratio: str = "16:9",
     duration_seconds: int = 8,
+    output_mode: str = "both",
 ) -> dict[str, Any]:
     raise ProviderUnsupportedError(
         "openai.generate.video: Sora 2 API shutdown 2026-09-24. "

--- a/src/imagine_mcp/server.py
+++ b/src/imagine_mcp/server.py
@@ -185,6 +185,7 @@ def build_app() -> FastMCP:
             aspect_ratio,
             duration_seconds,
             model,
+            output_mode,
         )
 
     @app.tool(

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -1,0 +1,160 @@
+// src/worker.ts
+// Worker fronting the imagine-mcp container Durable Object.
+//
+// Two distinct request paths:
+//  - INBOUND: requests on the custom domain hit the default export `fetch`,
+//    which routes them to the per-user ImagineContainer Durable Object.
+//  - OUTBOUND: the container calls http://kv.internal/... which is intercepted
+//    by the `@cloudflare/containers` proxy and dispatched to the
+//    `ImagineContainer.outboundByHost` handlers below, serviced from the
+//    Worker's KV binding. enableInternet=true lets every OTHER host
+//    (Gemini, OpenAI, xAI) reach the public internet.
+import { Container, ContainerProxy, type OutboundHandler } from '@cloudflare/containers'
+
+// ContainerProxy must be exported from the Worker entrypoint: the containers
+// runtime discovers it via `ctx.exports.ContainerProxy` to route the container's
+// intercepted outbound traffic (kv.internal) back into the Worker. Without this
+// re-export, applyOutboundInterception() throws at container start.
+export { ContainerProxy }
+
+export interface Env {
+  KV: {
+    get(k: string, type: 'arrayBuffer'): Promise<ArrayBuffer | null>
+    get(k: string): Promise<string | null>
+    put(k: string, v: string | ArrayBuffer): Promise<void>
+    delete(k: string): Promise<void>
+  }
+  IMAGINE?: { idFromName(n: string): unknown; get(id: unknown): { fetch(r: Request): Promise<Response> } }
+  // Container config (wrangler.jsonc `vars`) + secrets (`wrangler secret put`),
+  // forwarded into the container process via ImagineContainer.envVars.
+  MCP_STORAGE_BACKEND: string
+  MCP_KV_BASE_URL: string
+  IMAGINE_OUTPUT_MODE: string
+  PUBLIC_URL: string
+  CREDENTIAL_SECRET: string
+  MCP_DCR_SERVER_SECRET: string
+  GEMINI_API_KEY?: string
+  OPENAI_API_KEY?: string
+  XAI_API_KEY?: string
+  UNDERSTAND_MODELS?: string
+}
+
+// Keys forwarded from the Worker env (wrangler vars + secrets) into the container
+// process. Unset/empty values are dropped so an unused optional provider key
+// never injects a blank.
+const CONTAINER_ENV_KEYS = [
+  'MCP_STORAGE_BACKEND', 'MCP_KV_BASE_URL', 'IMAGINE_OUTPUT_MODE',
+  'PUBLIC_URL', 'CREDENTIAL_SECRET', 'MCP_DCR_SERVER_SECRET',
+  'GEMINI_API_KEY', 'OPENAI_API_KEY', 'XAI_API_KEY', 'UNDERSTAND_MODELS',
+] as const
+
+function pickContainerEnv(env: Env): Record<string, string> {
+  const out: Record<string, string> = {}
+  for (const k of CONTAINER_ENV_KEYS) {
+    const v = (env as unknown as Record<string, unknown>)[k]
+    if (typeof v === 'string' && v !== '') out[k] = v
+  }
+  return out
+}
+
+// --- Outbound handlers (container -> Worker bindings) -----------------------
+// These run when the container makes an outbound HTTP request to one of the
+// internal hostnames. They are registered via `ImagineContainer.outboundByHost`
+// (assignment, NOT a class field) so the assignment hits the inherited setter
+// and populates the package's module-level handler registry. A `static
+// outboundByHost = {...}` field would use define-semantics, bypass the setter,
+// and silently fall through to the public internet (kv.internal -> NXDOMAIN).
+
+const kvOutbound: OutboundHandler<Env> = async (request, env) => {
+  const url = new URL(request.url)
+  const key = decodeURIComponent(url.pathname.replace(/^\//, ''))
+  // Readiness probe (E.1): once this handler answers, outbound interception is
+  // wired, so the container's first credential PUT is safe. Reserved key,
+  // checked before the normal key lookup so it never shadows a real KV key.
+  if (request.method === 'GET' && key === '__ready') {
+    return Response.json({ ready: true })
+  }
+  if (request.method === 'GET') {
+    // Credential blobs are binary (nonce + AES-GCM ciphertext); read/write as
+    // ArrayBuffer so bytes round-trip without UTF-8 corruption.
+    const v = await env.KV.get(key, 'arrayBuffer')
+    return v === null ? new Response('', { status: 404 }) : new Response(v, { status: 200 })
+  }
+  if (request.method === 'PUT') {
+    await env.KV.put(key, await request.arrayBuffer())
+    return new Response('', { status: 200 })
+  }
+  if (request.method === 'DELETE') {
+    await env.KV.delete(key)
+    return new Response('', { status: 200 })
+  }
+  return new Response('method not allowed', { status: 405 })
+}
+
+// Outbound handler registry, keyed by internal hostname. Production container
+// outbound (kv.internal) reaches these via @cloudflare/containers' ContainerProxy
+// + the ImagineContainer.outboundByHost assignment below — NOT via the public
+// `fetch` export. Exported so unit tests can invoke a handler directly instead of
+// routing an internal-host request through the public entrypoint. imagine is
+// KV-only (no D1/Vectorize handlers).
+export const OUTBOUND_BY_HOST: Record<string, OutboundHandler<Env>> = {
+  'kv.internal': kvOutbound,
+}
+
+export default {
+  async fetch(request: Request, env: Env): Promise<Response> {
+    // Public entrypoint: ONLY routes inbound requests to the per-user container
+    // DO. The kv.internal outbound handler is deliberately NOT dispatched here —
+    // exposing it on the public fetch surface would let an external caller
+    // (request hostname spoofed to kv.internal) read/write/delete the credential
+    // KV namespace unauthenticated. Production container outbound reaches it via
+    // @cloudflare/containers' ContainerProxy + the ImagineContainer.outboundByHost
+    // registry below; unit tests call the handlers directly via the
+    // OUTBOUND_BY_HOST export.
+    if (env.IMAGINE) {
+      const userId = extractUserId(request)
+      const stub = env.IMAGINE.get(env.IMAGINE.idFromName(userId))
+      return stub.fetch(request)
+    }
+    return new Response('not found', { status: 404 })
+  },
+}
+
+function extractUserId(request: Request): string {
+  // JWT sub from the Bearer token (verified by mcp-core OAuth middleware in the
+  // container). SINGLE-USER CONTRACT (E.2): no token or no `sub` -> the reserved
+  // id "default", so setup and serving collapse onto ONE Durable Object id and
+  // the credential write+read avoid a cross-colo KV hop. Per-`sub` tokens get
+  // their own isolated DO (multi-user). Downstream servers MUST keep this.
+  const auth = request.headers.get('authorization') ?? ''
+  const m = auth.match(/^Bearer\s+(.+)$/)
+  if (!m) return 'default'
+  try {
+    const payload = JSON.parse(atob(m[1].split('.')[1] ?? ''))
+    return typeof payload.sub === 'string' ? payload.sub : 'default'
+  } catch {
+    return 'default'
+  }
+}
+
+// Per-user container Durable Object. wrangler.jsonc binds IMAGINE to this class
+// and runs the ghcr.io/n24q02m/imagine-mcp:beta image; one instance per JWT sub.
+// The container's HTTP server listens on 8080 (Dockerfile http target: MCP_PORT=8080
+// + EXPOSE 8080).
+export class ImagineContainer extends Container<Env> {
+  defaultPort = 8080
+  sleepAfter = '1h'
+  // The container reaches cloud model APIs (Gemini, OpenAI, xAI) over the public
+  // internet; kv.internal stays intercepted (see outboundByHost).
+  enableInternet = true
+  // Forward Worker config (vars) + secrets into the container process. Without
+  // this the Python server defaults to MCP_STORAGE_BACKEND=local on the ephemeral
+  // container FS.
+  envVars = pickContainerEnv(this.env)
+}
+
+// Register outbound interception. MUST be an assignment (invokes the inherited
+// `static set outboundByHost`) — a class field would bypass the setter. Reuses
+// OUTBOUND_BY_HOST so the proxy registry and the direct fetch dispatch are one
+// source of truth (footgun #1: assignment, never a static field).
+ImagineContainer.outboundByHost = OUTBOUND_BY_HOST as Record<string, OutboundHandler>

--- a/tests/cloudflare-workers-stub.ts
+++ b/tests/cloudflare-workers-stub.ts
@@ -1,0 +1,22 @@
+// Stub for the `cloudflare:workers` virtual module, which only exists inside the
+// workerd runtime. The worker handler test runs in plain node, where importing
+// `@cloudflare/containers` (the ImagineContainer base) would otherwise fail to
+// resolve `cloudflare:workers`. ImagineContainer is never instantiated by the
+// test (fakeEnv has no IMAGINE binding), so these bases only need to be importable.
+export class DurableObject<Env = unknown> {
+  protected ctx: unknown
+  protected env: Env
+  constructor(ctx: unknown, env: Env) {
+    this.ctx = ctx
+    this.env = env
+  }
+}
+
+export class WorkerEntrypoint<Env = unknown> {
+  protected ctx: unknown
+  protected env: Env
+  constructor(ctx: unknown, env: Env) {
+    this.ctx = ctx
+    this.env = env
+  }
+}

--- a/tests/conftest_cf.py
+++ b/tests/conftest_cf.py
@@ -1,0 +1,55 @@
+"""Cloudflare-pilot test fixtures for imagine-mcp (KV-only): a deterministic
+KV http double + canonical CF/local env presets. Ported (KV slice only) from
+wet-mcp/tests/conftest_cf.py."""
+
+from __future__ import annotations
+
+import pytest
+
+
+class FakeKvHttp:
+    """Injectable http for mcp_core CfKvBackend.
+
+    Implements ``.request(method, url, data, headers) -> (status, body)``
+    exactly as CfKvBackend expects (URL-encoded single-segment key).
+    """
+
+    def __init__(self) -> None:
+        self.store: dict[str, bytes] = {}
+
+    def request(self, method, url, data=None, headers=None):
+        from urllib.parse import unquote
+
+        key = unquote(url.rsplit("/", 1)[-1])
+        if method == "PUT":
+            self.store[key] = data or b""
+            return (200, b"")
+        if method == "GET":
+            return (200, self.store[key]) if key in self.store else (404, b"")
+        if method == "DELETE":
+            existed = key in self.store
+            self.store.pop(key, None)
+            return (200, b"") if existed else (404, b"")
+        raise AssertionError(f"unexpected method {method}")
+
+
+@pytest.fixture
+def fake_kv_http():
+    return FakeKvHttp()
+
+
+@pytest.fixture
+def cf_env(monkeypatch):
+    """Canonical CF env preset; secrets are dummies (never inline real ones)."""
+    monkeypatch.setenv("MCP_TRANSPORT", "http")
+    monkeypatch.setenv("CREDENTIAL_SECRET", "test-credential-secret")
+    monkeypatch.setenv("MCP_STORAGE_BACKEND", "cf-kv")
+    monkeypatch.setenv("MCP_KV_BASE_URL", "http://kv.internal")
+    monkeypatch.setenv("IMAGINE_OUTPUT_MODE", "base64")
+
+
+@pytest.fixture
+def local_default_env(monkeypatch):
+    """Back-compat: no CF env -> LocalFs + on-disk media path."""
+    for var in ("MCP_STORAGE_BACKEND", "MCP_KV_BASE_URL", "IMAGINE_OUTPUT_MODE"):
+        monkeypatch.delenv(var, raising=False)

--- a/tests/test_cf_core_resolves.py
+++ b/tests/test_cf_core_resolves.py
@@ -1,0 +1,28 @@
+"""Guard: the installed mcp-core must ship the CF KV storage backend.
+
+imagine-mcp's pyproject floor is >=1.18.0b2, which ALLOWS the cf-kv build
+(1.18.0b5). This test fails if a relock ever resolves an older mcp-core that
+lacks CfKvBackend / the cf-kv selector, which would silently break CF deploy.
+"""
+
+from importlib.metadata import version
+
+from packaging.version import Version
+
+
+def test_mcp_core_ships_cf_kv_backend():
+    # The import itself is the contract: CfKvBackend + cf-kv selector exist.
+    from mcp_core.storage import CfKvBackend, backend_from_env  # noqa: F401
+
+    assert Version(version("n24q02m-mcp-core")) >= Version("1.18.0b5"), (
+        "mcp-core resolved below 1.18.0b5; cf-kv backend not guaranteed. "
+        "Run: uv lock --upgrade-package n24q02m-mcp-core"
+    )
+
+
+def test_cf_kv_selector_wired(monkeypatch):
+    monkeypatch.setenv("MCP_STORAGE_BACKEND", "cf-kv")
+    monkeypatch.setenv("MCP_KV_BASE_URL", "http://kv.internal")
+    from mcp_core.storage import CfKvBackend, backend_from_env
+
+    assert isinstance(backend_from_env(), CfKvBackend)

--- a/tests/test_dispatcher.py
+++ b/tests/test_dispatcher.py
@@ -281,6 +281,7 @@ async def test_dispatch_generate_resolves_default_provider(
         tier: str,
         reference_image_url: str | None,
         aspect_ratio: str,
+        output_mode: str = "both",
     ) -> dict:
         captured["called"] = "openai"
         return {"image": "...", "model": "gpt-image", "provider": "openai"}
@@ -461,6 +462,7 @@ async def test_passthrough_generate_xai_routes_native_grok(
         tier: str,
         reference_image_url: str | None,
         aspect_ratio: str,
+        output_mode: str = "both",
     ) -> dict:
         captured["called"] = "grok"
         return {"image": "...", "model": "grok-imagine-image", "provider": "grok"}

--- a/tests/test_output_mode.py
+++ b/tests/test_output_mode.py
@@ -139,3 +139,31 @@ async def test_openai_generate_image_base64_no_disk(monkeypatch, tmp_path):
     )
     assert "image_base64" in out and "image_path" not in out
     assert not (tmp_path / "generations").exists()
+
+
+from imagine_mcp.providers import grok
+
+
+@pytest.mark.asyncio
+async def test_grok_generate_image_base64_no_disk(monkeypatch, tmp_path):
+    import base64 as _b64
+
+    monkeypatch.setattr("platformdirs.user_cache_dir", lambda *a, **k: str(tmp_path))
+    monkeypatch.setattr(grok, "_api_key", lambda: "dummy")
+
+    resp = MagicMock()
+    resp.status_code = 200
+    resp.json = lambda: {"data": [{"b64_json": _b64.b64encode(b"PNGDATA").decode()}]}
+    fake_client = MagicMock()
+    fake_client.post = AsyncMock(return_value=resp)
+    # grok.py binds the name at import time (grok.py:22
+    # `from imagine_mcp.media import get_ssrf_safe_async_client`), so patch the
+    # symbol IN grok's module namespace -- patching imagine_mcp.media would NOT
+    # affect grok's already-bound reference.
+    monkeypatch.setattr(
+        "imagine_mcp.providers.grok.get_ssrf_safe_async_client", lambda: fake_client
+    )
+
+    out = await grok.generate_image(prompt="a cat", tier="poor", output_mode="base64")
+    assert "image_base64" in out and "image_path" not in out
+    assert not (tmp_path / "generations").exists()

--- a/tests/test_output_mode.py
+++ b/tests/test_output_mode.py
@@ -1,0 +1,52 @@
+from __future__ import annotations
+
+from unittest.mock import AsyncMock
+
+import pytest
+
+from imagine_mcp import dispatcher
+
+
+@pytest.mark.asyncio
+async def test_dispatch_generate_forwards_output_mode(monkeypatch):
+    captured = {}
+
+    async def fake_generate_image(
+        prompt, tier, reference_image_url, aspect_ratio, output_mode
+    ):
+        captured["output_mode"] = output_mode
+        return {"image_base64": "x", "model": "m", "provider": "gemini", "tier": tier}
+
+    fake_mod = AsyncMock()
+    fake_mod.generate_image = fake_generate_image
+    monkeypatch.setattr(dispatcher, "_load_provider", lambda p: fake_mod)
+    monkeypatch.setattr(dispatcher, "_default_provider", lambda: "gemini")
+    monkeypatch.delenv("IMAGINE_OUTPUT_MODE", raising=False)
+
+    await dispatcher.dispatch_generate(
+        "image", "a cat", "gemini", "poor", output_mode="base64"
+    )
+    assert captured["output_mode"] == "base64"
+
+
+@pytest.mark.asyncio
+async def test_env_override_wins_over_tool_arg(monkeypatch):
+    captured = {}
+
+    async def fake_generate_image(
+        prompt, tier, reference_image_url, aspect_ratio, output_mode
+    ):
+        captured["output_mode"] = output_mode
+        return {"image_base64": "x"}
+
+    fake_mod = AsyncMock()
+    fake_mod.generate_image = fake_generate_image
+    monkeypatch.setattr(dispatcher, "_load_provider", lambda p: fake_mod)
+    monkeypatch.setattr(dispatcher, "_default_provider", lambda: "gemini")
+    monkeypatch.setenv("IMAGINE_OUTPUT_MODE", "base64")
+
+    # caller asked for "both" but the deploy-level env forces base64
+    await dispatcher.dispatch_generate(
+        "image", "a cat", "gemini", "poor", output_mode="both"
+    )
+    assert captured["output_mode"] == "base64"

--- a/tests/test_output_mode.py
+++ b/tests/test_output_mode.py
@@ -118,3 +118,24 @@ async def test_gemini_generate_video_base64_no_path(monkeypatch, tmp_path):
     )
     assert "video_base64" in out and "video_path" not in out
     assert not (tmp_path / "generations").exists()
+
+
+from imagine_mcp.providers import openai as openai_provider
+
+
+@pytest.mark.asyncio
+async def test_openai_generate_image_base64_no_disk(monkeypatch, tmp_path):
+    monkeypatch.setattr("platformdirs.user_cache_dir", lambda *a, **k: str(tmp_path))
+    import base64 as _b64
+
+    fake_client = MagicMock()
+    fake_resp = MagicMock()
+    fake_resp.data = [MagicMock(b64_json=_b64.b64encode(b"PNGDATA").decode())]
+    fake_client.images.generate = AsyncMock(return_value=fake_resp)
+    monkeypatch.setattr(openai_provider, "_client", lambda: fake_client)
+
+    out = await openai_provider.generate_image(
+        prompt="a cat", tier="poor", output_mode="base64"
+    )
+    assert "image_base64" in out and "image_path" not in out
+    assert not (tmp_path / "generations").exists()

--- a/tests/test_output_mode.py
+++ b/tests/test_output_mode.py
@@ -1,10 +1,12 @@
 from __future__ import annotations
 
-from unittest.mock import AsyncMock
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
 from imagine_mcp import dispatcher
+from imagine_mcp.providers import gemini, grok
+from imagine_mcp.providers import openai as openai_provider
 
 
 @pytest.mark.asyncio
@@ -52,11 +54,6 @@ async def test_env_override_wins_over_tool_arg(monkeypatch):
     assert captured["output_mode"] == "base64"
 
 
-from unittest.mock import MagicMock
-
-from imagine_mcp.providers import gemini
-
-
 @pytest.mark.asyncio
 async def test_gemini_generate_image_base64_no_disk(monkeypatch, tmp_path):
     # Any disk write would land under this redirected cache dir.
@@ -73,7 +70,7 @@ async def test_gemini_generate_image_base64_no_disk(monkeypatch, tmp_path):
 
     out = await gemini.generate_image(prompt="a cat", tier="poor", output_mode="base64")
 
-    assert "image_base64" in out and out["image_base64"]
+    assert out.get("image_base64")
     assert "image_path" not in out  # path suppressed
     assert not (tmp_path / "generations").exists()  # NOTHING written to disk
 
@@ -120,9 +117,6 @@ async def test_gemini_generate_video_base64_no_path(monkeypatch, tmp_path):
     assert not (tmp_path / "generations").exists()
 
 
-from imagine_mcp.providers import openai as openai_provider
-
-
 @pytest.mark.asyncio
 async def test_openai_generate_image_base64_no_disk(monkeypatch, tmp_path):
     monkeypatch.setattr("platformdirs.user_cache_dir", lambda *a, **k: str(tmp_path))
@@ -139,9 +133,6 @@ async def test_openai_generate_image_base64_no_disk(monkeypatch, tmp_path):
     )
     assert "image_base64" in out and "image_path" not in out
     assert not (tmp_path / "generations").exists()
-
-
-from imagine_mcp.providers import grok
 
 
 @pytest.mark.asyncio

--- a/tests/test_output_mode.py
+++ b/tests/test_output_mode.py
@@ -50,3 +50,71 @@ async def test_env_override_wins_over_tool_arg(monkeypatch):
         "image", "a cat", "gemini", "poor", output_mode="both"
     )
     assert captured["output_mode"] == "base64"
+
+
+from unittest.mock import MagicMock
+
+from imagine_mcp.providers import gemini
+
+
+@pytest.mark.asyncio
+async def test_gemini_generate_image_base64_no_disk(monkeypatch, tmp_path):
+    # Any disk write would land under this redirected cache dir.
+    monkeypatch.setattr("platformdirs.user_cache_dir", lambda *a, **k: str(tmp_path))
+    fake_client = MagicMock()
+    fake_client.aio.models.generate_content = AsyncMock()
+    fake_part = MagicMock()
+    fake_part.inline_data.data = b"\x89PNG_fake_bytes"
+    fake_response = MagicMock()
+    fake_response.candidates = [MagicMock()]
+    fake_response.candidates[0].content.parts = [fake_part]
+    fake_client.aio.models.generate_content.return_value = fake_response
+    monkeypatch.setattr(gemini, "_client", lambda: fake_client)
+
+    out = await gemini.generate_image(prompt="a cat", tier="poor", output_mode="base64")
+
+    assert "image_base64" in out and out["image_base64"]
+    assert "image_path" not in out  # path suppressed
+    assert not (tmp_path / "generations").exists()  # NOTHING written to disk
+
+
+@pytest.mark.asyncio
+async def test_gemini_generate_image_both_writes_path(monkeypatch, tmp_path):
+    monkeypatch.setattr("platformdirs.user_cache_dir", lambda *a, **k: str(tmp_path))
+    fake_client = MagicMock()
+    fake_client.aio.models.generate_content = AsyncMock()
+    fake_part = MagicMock()
+    fake_part.inline_data.data = b"\x89PNG_fake_bytes"
+    fake_response = MagicMock()
+    fake_response.candidates = [MagicMock()]
+    fake_response.candidates[0].content.parts = [fake_part]
+    fake_client.aio.models.generate_content.return_value = fake_response
+    monkeypatch.setattr(gemini, "_client", lambda: fake_client)
+
+    out = await gemini.generate_image(prompt="a cat", tier="poor", output_mode="both")
+
+    assert "image_base64" in out and "image_path" in out  # back-compat default
+    assert (tmp_path / "generations").exists()
+
+
+@pytest.mark.asyncio
+async def test_gemini_generate_video_base64_no_path(monkeypatch, tmp_path):
+    monkeypatch.setattr("platformdirs.user_cache_dir", lambda *a, **k: str(tmp_path))
+    fake_client = MagicMock()
+    fake_op = MagicMock()
+    fake_op.done = True
+    fake_op.error = None
+    fake_video = MagicMock()
+    fake_op.response.generated_videos = [fake_video]
+    fake_client.aio.operations.get = AsyncMock(return_value=fake_op)
+    # google-genai 2.8.0: the ASYNC files.download RETURNS the bytes and (unlike
+    # the sync client) does NOT set video.video.video_bytes as a side effect, so
+    # the impl reads the return value -- the fake returns the bytes here.
+    fake_client.aio.files.download = AsyncMock(return_value=b"FAKEMP4")
+    monkeypatch.setattr(gemini, "_client", lambda: fake_client)
+
+    out = await gemini.generate_video(
+        prompt="a wave", tier="poor", job_id="op/123", output_mode="base64"
+    )
+    assert "video_base64" in out and "video_path" not in out
+    assert not (tmp_path / "generations").exists()

--- a/tests/worker.test.ts
+++ b/tests/worker.test.ts
@@ -1,0 +1,121 @@
+import { describe, expect, it } from 'vitest'
+import worker, { ImagineContainer, OUTBOUND_BY_HOST } from '../src/worker'
+
+function fakeEnv() {
+  const kv = new Map<string, ArrayBuffer>()
+  return {
+    KV: {
+      get: async (k: string, _type?: 'arrayBuffer') => (kv.has(k) ? kv.get(k)! : null),
+      put: async (k: string, v: ArrayBuffer) => void kv.set(k, v),
+      delete: async (k: string) => void kv.delete(k),
+    },
+  }
+}
+
+// Invoke an outbound handler DIRECTLY (the production path is the container proxy
+// via ImagineContainer.outboundByHost; the handlers are NOT reachable through the
+// public `fetch` entrypoint, so tests exercise them through the exported registry).
+const kvH = OUTBOUND_BY_HOST['kv.internal']!
+
+describe('outbound registry (KV-only)', () => {
+  it('registers a kv.internal outbound handler', () => {
+    expect(ImagineContainer.outboundByHost['kv.internal']).toBeDefined()
+    expect(OUTBOUND_BY_HOST['kv.internal']).toBeDefined()
+  })
+
+  it('does NOT register d1/vectorize handlers (KV-only)', () => {
+    expect(OUTBOUND_BY_HOST['d1.internal']).toBeUndefined()
+    expect(OUTBOUND_BY_HOST['vectorize.internal']).toBeUndefined()
+    expect(ImagineContainer.outboundByHost['d1.internal']).toBeUndefined()
+    expect(ImagineContainer.outboundByHost['vectorize.internal']).toBeUndefined()
+  })
+})
+
+describe('outbound handlers', () => {
+  it('KV get 404 then put then get 200 (binary arrayBuffer round-trip)', async () => {
+    const env = fakeEnv()
+    const key = 'imagine%2Fsubs%2Fuser1%2Fconfig'
+    const blob = new Uint8Array([1, 2, 3, 250, 0, 99]).buffer
+
+    let res = await kvH(new Request(`http://kv.internal/${key}`), env as never)
+    expect(res.status).toBe(404)
+
+    res = await kvH(new Request(`http://kv.internal/${key}`, { method: 'PUT', body: blob }), env as never)
+    expect(res.status).toBe(200)
+
+    res = await kvH(new Request(`http://kv.internal/${key}`), env as never)
+    expect(res.status).toBe(200)
+    expect(new Uint8Array(await res.arrayBuffer())).toEqual(new Uint8Array(blob))
+  })
+
+  it('KV readiness probe: GET __ready -> {ready:true}', async () => {
+    const env = fakeEnv()
+    const res = await kvH(new Request('http://kv.internal/__ready'), env as never)
+    expect(res.status).toBe(200)
+    expect(await res.json()).toEqual({ ready: true })
+  })
+
+  it('KV readiness probe does not shadow a real missing key', async () => {
+    const env = fakeEnv()
+    // a real key that happens to be absent still 404s (the probe is the reserved __ready only)
+    const res = await kvH(new Request('http://kv.internal/imagine%2Fsubs%2Fu1%2Fconfig'), env as never)
+    expect(res.status).toBe(404)
+  })
+})
+
+describe('public fetch entrypoint does NOT expose outbound handlers (security)', () => {
+  it('a public request with an internal hostname is NOT serviced by a handler', async () => {
+    const env = fakeEnv() // no IMAGINE binding -> DO routing path returns 404
+    // Even if an external caller spoofs the hostname to kv.internal, the public
+    // fetch must NOT read/write the credential KV — it only routes to the DO.
+    const res = await worker.fetch(new Request('http://kv.internal/imagine%2Fconfig'), env as never)
+    expect(res.status).toBe(404)
+    expect(await res.text()).toBe('not found')
+  })
+})
+
+describe('single-user DO contract (E.2)', () => {
+  function envWithDoSpy() {
+    const calls: string[] = []
+    return {
+      calls,
+      env: {
+        IMAGINE: {
+          idFromName: (n: string) => {
+            calls.push(n)
+            return { name: n }
+          },
+          get: (_id: unknown) => ({ fetch: async () => new Response('routed', { status: 200 }) }),
+        },
+      },
+    }
+  }
+
+  it('no Bearer token -> routes to the "default" DO', async () => {
+    const { calls, env } = envWithDoSpy()
+    const res = await worker.fetch(new Request('https://imagine.n24q02m.com/mcp'), env as never)
+    expect(res.status).toBe(200)
+    expect(calls).toEqual(['default'])
+  })
+
+  it('Bearer token without sub -> routes to the "default" DO', async () => {
+    const { calls, env } = envWithDoSpy()
+    // header.payload.sig where payload has no `sub`
+    const jwt = `h.${btoa(JSON.stringify({ aud: 'x' }))}.s`
+    await worker.fetch(
+      new Request('https://imagine.n24q02m.com/mcp', { headers: { authorization: `Bearer ${jwt}` } }),
+      env as never,
+    )
+    expect(calls).toEqual(['default'])
+  })
+
+  it('Bearer token with sub -> routes to that sub DO (per-user isolation)', async () => {
+    const { calls, env } = envWithDoSpy()
+    const jwt = `h.${btoa(JSON.stringify({ sub: 'user-123' }))}.s`
+    await worker.fetch(
+      new Request('https://imagine.n24q02m.com/mcp', { headers: { authorization: `Bearer ${jwt}` } }),
+      env as never,
+    )
+    expect(calls).toEqual(['user-123'])
+  })
+})

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "compilerOptions": {
+    "target": "es2022",
+    "module": "es2022",
+    "moduleResolution": "bundler",
+    "lib": ["es2022"],
+    "types": ["@cloudflare/workers-types"],
+    "strict": true,
+    "skipLibCheck": true,
+    "noEmit": true
+  },
+  "include": ["src/**/*.ts", "tests/**/*.ts"]
+}

--- a/uv.lock
+++ b/uv.lock
@@ -724,7 +724,7 @@ wheels = [
 
 [[package]]
 name = "imagine-mcp"
-version = "1.7.0b4"
+version = "1.7.0b5"
 source = { editable = "." }
 dependencies = [
     { name = "diskcache" },

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,13 @@
+import { fileURLToPath } from 'node:url'
+import { defineConfig } from 'vitest/config'
+
+// The worker handler test runs in plain node. `@cloudflare/containers` (the
+// ImagineContainer base) imports the `cloudflare:workers` virtual module, which
+// only exists in the workerd runtime, so alias it to a local stub for unit tests.
+export default defineConfig({
+  resolve: {
+    alias: {
+      'cloudflare:workers': fileURLToPath(new URL('./tests/cloudflare-workers-stub.ts', import.meta.url)),
+    },
+  },
+})

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -1,0 +1,39 @@
+// wrangler.jsonc - imagine-mcp Cloudflare Worker + Container + KV (KV-only).
+// Resource IDs are placeholders created out-of-band (wrangler kv:namespace
+// create) and filled in at deploy time, not committed as live IDs.
+{
+  "name": "imagine-mcp-worker",
+  "main": "src/worker.ts",
+  "compatibility_date": "2026-06-14",
+  "containers": [
+    {
+      "name": "imagine-mcp-worker",
+      "class_name": "ImagineContainer",
+      // CF Containers pull ONLY from the Cloudflare managed registry (an external
+      // ghcr.io ref fails IMAGE_REGISTRY_NOT_CONFIGURED). Push first:
+      //   docker pull ghcr.io/n24q02m/imagine-mcp:beta
+      //   wrangler containers push imagine-mcp:beta
+      // then fill <YOUR_ACCOUNT_ID>.
+      "image": "registry.cloudflare.com/<YOUR_ACCOUNT_ID>/imagine-mcp:beta",
+      "instance_type": "standard-1",
+      "max_instances": 100
+    }
+  ],
+  "durable_objects": {
+    "bindings": [{ "name": "IMAGINE", "class_name": "ImagineContainer" }]
+  },
+  "migrations": [{ "tag": "v1", "new_sqlite_classes": ["ImagineContainer"] }],
+  "kv_namespaces": [{ "binding": "KV", "id": "<imagine-kv-namespace-id>" }],
+  // Non-secret container config (forwarded into the container by ImagineContainer.envVars).
+  // Secrets via `wrangler secret put`: CREDENTIAL_SECRET, MCP_DCR_SERVER_SECRET,
+  // and any provider keys you want server-default (GEMINI_API_KEY / OPENAI_API_KEY /
+  // XAI_API_KEY) -- though per-sub keys via the /authorize form are preferred.
+  "vars": {
+    "PUBLIC_URL": "https://imagine.n24q02m.com",
+    "MCP_STORAGE_BACKEND": "cf-kv",
+    "MCP_KV_BASE_URL": "http://kv.internal",
+    "IMAGINE_OUTPUT_MODE": "base64"
+  },
+  "routes": [{ "pattern": "imagine.n24q02m.com", "custom_domain": true }],
+  "observability": { "enabled": true }
+}


### PR DESCRIPTION
P3-02: host imagine-mcp on Cloudflare (Worker + Container + KV-only), cloning the proven wet pilot pattern. Per-sub API-key vaults survive container recreate (KV); generated media is base64-only (the ephemeral container FS would lose a local path).

## What's in here
- **Harness + guard** (Tasks 0/1): KV test fixtures (`tests/conftest_cf.py`) + a guard that the installed mcp-core ships the cf-kv backend (`tests/test_cf_core_resolves.py`).
- **Net-new: base64 output** (Task 2): plumb `output_mode` through `dispatch_generate` with a deploy-level `IMAGINE_OUTPUT_MODE` env override; a shared `emit_media()` helper in `media.py`; all three providers (gemini/openai/grok) gate disk-write on mode — `base64` writes NO file and returns only `<key>_base64`. Fixes a latent bug: gemini async `files.download` returns the bytes (the sync-only `.video_bytes`/`.save()` side effect does not fire on the async client).
- **KV-only Worker** (Task 3): `src/worker.ts` copied from the hardened wet template — DO class `ImagineContainer`, binding `IMAGINE`, **d1/vectorize handlers + bindings dropped**. Preserves the 5 footguns, the E.1 `__ready` readiness branch, the E.2 `idFromName("default")` contract, and the security pattern (outbound handlers stay OFF the public `fetch`; reached only via ContainerProxy; `OUTBOUND_BY_HOST` exported for direct tests).
- **wrangler + harness** (Task 4): KV-only `wrangler.jsonc` (resource IDs are placeholders, filled at deploy, never committed) + `scripts/cf_full_flow.py` live OAuth full-flow self-test (DCR → token → save w/ retry-on-500 → poll → authenticated `generate`, asserts base64).
- **Docs** (Task 6): CLAUDE.md "Cloudflare serverless mode" section.

## Verification
- `pytest`: 236 passed (3 live deselected). `ruff check` + `ruff format` + `ty check` clean.
- `vitest`: 9 passed (KV arrayBuffer round-trip, `__ready` probe, security test = public fetch + internal hostname → 404, DO routing by sub, d1/vectorize handlers undefined).
- `wrangler deploy --dry-run`: bundles OK, all bindings resolve.

Live CF deploy + the 6 success-criteria gates (state-survives-recreate, per-sub isolation, base64 live) run post-merge on the published :beta image.