### PR TITLE
fix: apply ruff format to cf_full_flow harness

### DIFF
--- a/scripts/cf_full_flow.py
+++ b/scripts/cf_full_flow.py
@@ -287,8 +287,11 @@ async def run_save_only(endpoint: str) -> None:
     # prove THIS sub's creds survived in KV, hence we persist the token.
     _token_file().write_text(token)
     print(
-        "SAVE-ONLY OK: creds saved for sub=", _sub_of(token), "len(token)=", len(token),
-        "(token dumped for --auth-only)"
+        "SAVE-ONLY OK: creds saved for sub=",
+        _sub_of(token),
+        "len(token)=",
+        len(token),
+        "(token dumped for --auth-only)",
     )
 
 


### PR DESCRIPTION
## What

`scripts/cf_full_flow.py` was committed unformatted in the squash-merge of #317, turning `main` red on the `ruff format --check .` gate across macOS / Ubuntu / Windows.

## Fix

`ruff format scripts/cf_full_flow.py` — splits a multi-arg `print()` across lines. No logic change.

## Verify

- `ruff format --check .` → 56 files already formatted
- `ruff check scripts/cf_full_flow.py` → All checks passed