### PR TITLE
fix: bump mcp-core floor to 1.18.0b14 for the key-rotation primitive

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,7 +47,7 @@ dependencies = [
     "pillow>=12.2.0",
     "diskcache>=5.6.3",
     "loguru>=0.7.3",
-    "n24q02m-mcp-core[llm]>=1.18.0b2,<2",
+    "n24q02m-mcp-core[llm]>=1.18.0b14,<2",
     "platformdirs>=4.10.0",
     # Security floors: transitive deps pinned to patched releases.
     # urllib3 < 2.7.0 -> PYSEC-2026-141/142; idna < 3.15 -> CVE-2026-45409.

--- a/uv.lock
+++ b/uv.lock
@@ -724,7 +724,7 @@ wheels = [
 
 [[package]]
 name = "imagine-mcp"
-version = "1.7.0b6"
+version = "1.7.0b7"
 source = { editable = "." }
 dependencies = [
     { name = "diskcache" },
@@ -767,7 +767,7 @@ requires-dist = [
     { name = "idna", specifier = ">=3.18" },
     { name = "loguru", specifier = ">=0.7.3" },
     { name = "mcp", extras = ["cli"], specifier = ">=1.28.0" },
-    { name = "n24q02m-mcp-core", extras = ["llm"], specifier = ">=1.18.0b2,<2" },
+    { name = "n24q02m-mcp-core", extras = ["llm"], specifier = ">=1.18.0b14,<2" },
     { name = "openai", specifier = ">=2.43.0" },
     { name = "pillow", specifier = ">=12.2.0" },
     { name = "platformdirs", specifier = ">=4.10.0" },
@@ -1147,7 +1147,7 @@ wheels = [
 
 [[package]]
 name = "n24q02m-mcp-core"
-version = "1.18.0b10"
+version = "1.18.0b14"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "authlib" },
@@ -1162,9 +1162,9 @@ dependencies = [
     { name = "starlette" },
     { name = "tomli-w" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/b0/70/043942c59667fce1b53f269f5df16cf9fb12bde1a4bbb81f52c51baac10e/n24q02m_mcp_core-1.18.0b10.tar.gz", hash = "sha256:62a7f759ddade906eb9603a67e6155b87dee79163bb7c732db0698b395214f88", size = 282027, upload-time = "2026-06-17T08:19:56.029Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/2e/af/4ab96169a7446124cf1689bea50e1c6cc20cabbcf1889a4d6cc962b61411/n24q02m_mcp_core-1.18.0b14.tar.gz", hash = "sha256:846c194051c2cb640ecd61b787ab96e3857c5aba29d944845db5cddf9ff2b91b", size = 294342, upload-time = "2026-06-19T11:59:22.552Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/62/c4/fd1626e9ab0afe60ae9880b8f5a855ad14ef1785a2598d8010b55cbee62c/n24q02m_mcp_core-1.18.0b10-py3-none-any.whl", hash = "sha256:44ea32698b985384181676ee4c3e2f2d58abae8dfc94b47eaaeee371d978b1f0", size = 156789, upload-time = "2026-06-17T08:19:54.678Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/bc/7488455a8935cdc5e1de52d7b8aeebc6812f28e0f9a1f186383f78eb5a7a/n24q02m_mcp_core-1.18.0b14-py3-none-any.whl", hash = "sha256:29a283e8e820c55688404edecb3ff3fb94a5384db9b998da1c8733a00086a08c", size = 163276, upload-time = "2026-06-19T11:59:21.395Z" },
 ]
 
 [package.optional-dependencies]


### PR DESCRIPTION
Bump n24q02m-mcp-core[llm] floor to 1.18.0b14, which ships the mcp_core.llm.key_rotation primitive. The transparent AI dispatch rotation (aembedding/arerank/aimage_generation/avideo_generation rotate provider API keys on HTTP 429/401/403) is inherited automatically through mcp_core.llm — no per-server code change. uv.lock relocked to b14; full pre-commit suite green against b14.