### PR TITLE
fix: sub-aware understand/generate model selection + relay re-submit overwrite

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -96,8 +96,9 @@ capability-checked via `mcp_core.llm.check_capability`, graceful on registry-mis
   `provider/model,provider/model`; order = litellm fallback (first entry is the
   primary model, the rest are fallbacks). Provider is inferred from the model
   prefix. **Empty/unset = understand off** (falls back to the provider/tier
-  catalog default). imagine has NO local fallback — generation stays native
-  (below) and is NOT affected by this chain.
+  catalog default). imagine has NO local fallback. In multi-user HTTP mode the
+  chain is resolved per-sub (from the relay-submitted config, never
+  `os.environ`); single-user / stdio reads the env var.
 - API keys follow the litellm convention `<PROVIDER>_API_KEY`. The 6 providers
   the server suggests for the understand chain:
 
@@ -116,6 +117,17 @@ capability-checked via `mcp_core.llm.check_capability`, graceful on registry-mis
 gemini image + Veo video via `google-genai`, openai image via the OpenAI SDK,
 grok image/video via raw httpx x.ai endpoints (xAI generation is a verified
 litellm gap). `google-genai` + `openai` deps are retained for these paths.
+
+- `GENERATE_MODELS` -- ordered model chain for generation, CSV
+  `provider/model,provider/model`. The FIRST entry selects the native provider
+  from its `provider/` prefix AND overrides the catalog `model_id` with its
+  model segment (generation is never routed through litellm). **Empty/unset =
+  use the provider/tier catalog default.** Sub-aware (per-sub in multi-user
+  HTTP; env var single-user / stdio).
+- `GENERATE_PROVIDER_PRIORITY` -- optional CSV of provider names
+  (`grok,openai,gemini`) reordering the generation auto-fallback when no
+  explicit provider and no `GENERATE_MODELS` chain are given. Defaults to the
+  native order (XAI, OpenAI, Gemini). Sub-aware like the chains above.
 
 - `LLM_API_BASE` -- custom OpenAI-compatible base URL for the understand path
   (optional; vetted through `mcp_core.http.vet_api_base` SSRF guard).

--- a/src/imagine_mcp/credential_state.py
+++ b/src/imagine_mcp/credential_state.py
@@ -140,6 +140,26 @@ def read_for_sub(sub: str) -> dict[str, str]:
     return PerPluginStore(PLUGIN_NAME, sub).load() or {}
 
 
+def config_value_for_current_request(key: str) -> str | None:
+    """Resolve a non-credential config value for the active request.
+
+    Mirrors ``credentials_for_current_request`` resolution but for arbitrary
+    config keys (e.g. ``UNDERSTAND_MODELS`` / ``GENERATE_MODELS`` /
+    ``GENERATE_PROVIDER_PRIORITY``):
+
+    * Multi-user HTTP (``_current_sub`` set): return the value from the per-sub
+      config (``~/.imagine-mcp/subs/<sub>/config.json``). ``os.environ`` is NOT
+      consulted -- a per-sub chain must never bleed into another sub's request.
+    * Single-user / stdio (no sub): return ``os.environ.get(key)``.
+
+    Returns ``None`` when the key is absent in the active scope.
+    """
+    sub = _current_sub.get()
+    if sub is None:
+        return os.environ.get(key)
+    return read_for_sub(sub).get(key)
+
+
 # ---------------------------------------------------------------------------
 # Public helpers (used by relay_setup + server)
 # ---------------------------------------------------------------------------

--- a/src/imagine_mcp/dispatcher.py
+++ b/src/imagine_mcp/dispatcher.py
@@ -98,6 +98,13 @@ def _validate(provider: str, tier: str) -> None:
         raise InvalidTierError(f"Unknown tier {tier!r}. Valid: {VALID_TIERS}")
 
 
+# Native generation provider -> its API-key env var. Built from the auto-
+# fallback priority so the two stay in lock-step.
+_PROVIDER_TO_ENV: dict[str, str] = {
+    provider: env_var for env_var, provider in _DEFAULT_PROVIDER_PRIORITY
+}
+
+
 def _default_provider() -> str:
     """Return the first provider whose API key is present for this request."""
     from imagine_mcp.credential_state import credentials_for_current_request
@@ -113,15 +120,78 @@ def _default_provider() -> str:
     )
 
 
+def _default_generate_provider() -> str:
+    """Auto-fallback provider for generation, honouring the sub-aware order.
+
+    Walks ``resolve_generate_provider_priority()`` (default = the native
+    ``_DEFAULT_PROVIDER_PRIORITY`` order) and returns the first provider whose
+    API key is present for this request. Raises ``CredentialMissingError`` when
+    none of the ordered providers has a key.
+    """
+    from imagine_mcp.credential_state import credentials_for_current_request
+
+    creds = credentials_for_current_request()
+    order = resolve_generate_provider_priority()
+    for provider in order:
+        env_var = _PROVIDER_TO_ENV.get(provider)
+        if env_var and creds.get(env_var):
+            return provider
+    keys = ", ".join(_PROVIDER_TO_ENV.values())
+    raise CredentialMissingError(
+        "No provider API key configured. Set one of: "
+        f"{keys}, or run config(action='open_relay') to configure via browser."
+    )
+
+
+def _csv_chain(raw: str | None) -> list[str]:
+    """Split a CSV config value into a clean ordered list (blanks dropped)."""
+    raw = (raw or "").strip()
+    return [m.strip() for m in raw.split(",") if m.strip()] if raw else []
+
+
 def resolve_understand_chain() -> list[str]:
     """Ordered ``UNDERSTAND_MODELS`` chain (litellm ``provider/model`` entries).
+
+    Sub-aware: in multi-user HTTP mode the relay-submitted chain is stored
+    per-sub (``credential_state.store_for_sub``) and read back via the per-sub
+    accessor -- never from ``os.environ`` (that would leak one sub's chain to a
+    concurrent request of another). Single-user / stdio reads ``os.getenv``.
 
     Empty / unset -> empty list, which preserves the provider/tier catalog
     default. The first entry is the primary model; the rest are litellm
     fallbacks.
     """
-    raw = (os.getenv("UNDERSTAND_MODELS") or "").strip()
-    return [m.strip() for m in raw.split(",") if m.strip()] if raw else []
+    from imagine_mcp.credential_state import config_value_for_current_request
+
+    return _csv_chain(config_value_for_current_request("UNDERSTAND_MODELS"))
+
+
+def resolve_generate_chain() -> list[str]:
+    """Ordered ``GENERATE_MODELS`` chain (litellm ``provider/model`` entries).
+
+    Sub-aware (same isolation contract as ``resolve_understand_chain``). When
+    set, the first entry's ``provider/`` prefix selects the native generation
+    provider and its model segment OVERRIDES the catalog ``model_id``. Empty /
+    unset -> empty list (catalog default preserved).
+    """
+    from imagine_mcp.credential_state import config_value_for_current_request
+
+    return _csv_chain(config_value_for_current_request("GENERATE_MODELS"))
+
+
+def resolve_generate_provider_priority() -> list[str]:
+    """Ordered generation provider auto-fallback for the active request.
+
+    Sub-aware ``GENERATE_PROVIDER_PRIORITY`` (CSV of provider names). When
+    unset, defaults to the native ``_DEFAULT_PROVIDER_PRIORITY`` order. Only
+    used when no explicit provider and no ``GENERATE_MODELS`` chain is given.
+    """
+    from imagine_mcp.credential_state import config_value_for_current_request
+
+    custom = _csv_chain(config_value_for_current_request("GENERATE_PROVIDER_PRIORITY"))
+    if custom:
+        return custom
+    return [provider for _env, provider in _DEFAULT_PROVIDER_PRIORITY]
 
 
 def _load_provider(provider: str) -> Any:
@@ -343,9 +413,17 @@ async def dispatch_generate(
 ) -> dict[str, Any]:
     """Dispatch generate call to provider (fully async).
 
-    When ``model`` is set, the litellm 'provider/model' prefix selects a
-    native generation provider (catalog still picks the concrete model by
-    tier); generation itself is never routed through litellm.
+    Provider + model resolution precedence (highest first):
+
+    1. Explicit ``model`` ('provider/model'): prefix selects the native
+       generation provider and its model segment overrides the catalog
+       ``model_id``; generation itself is never routed through litellm.
+    2. Explicit ``provider``: catalog path (catalog picks the model by tier).
+    3. ``GENERATE_MODELS`` chain (sub-aware): the first entry's prefix selects
+       the provider and its model segment overrides the catalog ``model_id``.
+    4. Auto-fallback: ``resolve_generate_provider_priority()`` (sub-aware,
+       defaults to the native priority) picks the first provider with a key;
+       the catalog supplies the model.
 
     ``output_mode`` controls how generated media is returned:
     ``"base64"`` (no disk write -- required on ephemeral CF FS),
@@ -355,10 +433,18 @@ async def dispatch_generate(
     """
     effective_output_mode = os.getenv("IMAGINE_OUTPUT_MODE") or output_mode
 
+    model_id_override: str | None = None
     if model is not None:
         provider = _resolve_generate_provider(model)
+        model_id_override = model.split("/", 1)[1] if "/" in model else model
     elif provider is None:
-        provider = _default_provider()
+        chain = resolve_generate_chain()
+        if chain:
+            entry = chain[0]
+            provider = _resolve_generate_provider(entry)
+            model_id_override = entry.split("/", 1)[1] if "/" in entry else entry
+        else:
+            provider = _default_generate_provider()
     _validate(provider, tier)
     if media_type not in VALID_MEDIA_TYPES:
         raise InvalidMediaTypeError(
@@ -367,6 +453,8 @@ async def dispatch_generate(
     if reference_image_url is not None:
         await _validate_url(reference_image_url, "reference_image_url")
 
+    # When an explicit model override is supplied, the catalog lookup is only a
+    # support guard (an UNSUPPORTED combo still cannot be served natively).
     catalog_model = get_model_id(provider, "generate", media_type, tier)
     if catalog_model is UNSUPPORTED:
         raise _unsupported(provider, media_type, "generate")
@@ -374,7 +462,12 @@ async def dispatch_generate(
     mod = _load_provider(provider)
     if media_type == "image":
         return await mod.generate_image(
-            prompt, tier, reference_image_url, aspect_ratio, effective_output_mode
+            prompt,
+            tier,
+            reference_image_url,
+            aspect_ratio,
+            effective_output_mode,
+            model_id=model_id_override,
         )
     return await mod.generate_video(
         prompt,
@@ -384,4 +477,5 @@ async def dispatch_generate(
         aspect_ratio,
         duration_seconds,
         effective_output_mode,
+        model_id=model_id_override,
     )

--- a/src/imagine_mcp/providers/gemini.py
+++ b/src/imagine_mcp/providers/gemini.py
@@ -212,6 +212,7 @@ async def generate_image(
     reference_image_url: str | None = None,
     aspect_ratio: str = "1:1",
     output_mode: str = "both",
+    model_id: str | None = None,
 ) -> dict[str, Any]:
     # native: litellm migration deferred -- probe credential-gated (gemini billing / no openai key 2026-06-11); avideo/aimage param unverified
     from google.genai import types
@@ -219,7 +220,9 @@ async def generate_image(
     from imagine_mcp.media import get_ssrf_safe_async_client, resolve_image_mime
 
     client = _client()
-    model = get_model_id("gemini", "generate", "image", tier)
+    # ``model_id`` (from a GENERATE_MODELS chain or explicit override) wins over
+    # the provider/tier catalog default.
+    model = model_id or get_model_id("gemini", "generate", "image", tier)
     contents: list[Any] = [prompt]
 
     if reference_image_url:
@@ -262,11 +265,14 @@ async def generate_video(
     aspect_ratio: str = "16:9",
     duration_seconds: int = 8,
     output_mode: str = "both",
+    model_id: str | None = None,
 ) -> dict[str, Any]:
     # native: litellm migration deferred -- probe credential-gated (gemini billing / no openai key 2026-06-11); avideo/aimage param unverified
     from google.genai import types
 
-    model = get_model_id("gemini", "generate", "video", tier)
+    # ``model_id`` (from a GENERATE_MODELS chain or explicit override) wins over
+    # the provider/tier catalog default.
+    model = model_id or get_model_id("gemini", "generate", "video", tier)
     client = _client()
 
     if job_id is None:

--- a/src/imagine_mcp/providers/grok.py
+++ b/src/imagine_mcp/providers/grok.py
@@ -89,9 +89,12 @@ async def generate_image(
     reference_image_url: str | None = None,
     aspect_ratio: str = "1:1",
     output_mode: str = "both",
+    model_id: str | None = None,
 ) -> dict[str, Any]:
     # native: litellm migration deferred -- probe credential-gated (gemini billing / no openai key 2026-06-11); avideo/aimage param unverified
-    model = get_model_id("grok", "generate", "image", tier)
+    # ``model_id`` (from a GENERATE_MODELS chain or explicit override) wins over
+    # the provider/tier catalog default.
+    model = model_id or get_model_id("grok", "generate", "image", tier)
     headers = {"Authorization": f"Bearer {_api_key()}"}
     payload: dict[str, Any] = {"model": model, "prompt": prompt, "n": 1}
 
@@ -151,9 +154,12 @@ async def generate_video(
     aspect_ratio: str = "16:9",
     duration_seconds: int = 8,
     output_mode: str = "both",
+    model_id: str | None = None,
 ) -> dict[str, Any]:
     # native: litellm migration deferred -- probe credential-gated (gemini billing / no openai key 2026-06-11); avideo/aimage param unverified
-    model = get_model_id("grok", "generate", "video", tier)
+    # ``model_id`` (from a GENERATE_MODELS chain or explicit override) wins over
+    # the provider/tier catalog default.
+    model = model_id or get_model_id("grok", "generate", "video", tier)
     headers = {"Authorization": f"Bearer {_api_key()}"}
 
     if job_id is None:

--- a/src/imagine_mcp/providers/openai.py
+++ b/src/imagine_mcp/providers/openai.py
@@ -94,9 +94,12 @@ async def generate_image(
     reference_image_url: str | None = None,
     aspect_ratio: str = "1:1",
     output_mode: str = "both",
+    model_id: str | None = None,
 ) -> dict[str, Any]:
     # native: litellm migration deferred -- probe credential-gated (gemini billing / no openai key 2026-06-11); avideo/aimage param unverified
-    model = get_model_id("openai", "generate", "image", tier)
+    # ``model_id`` (from a GENERATE_MODELS chain or explicit override) wins over
+    # the provider/tier catalog default.
+    model = model_id or get_model_id("openai", "generate", "image", tier)
     size_map = {"1:1": "1024x1024", "16:9": "1792x1024", "9:16": "1024x1792"}
     size = size_map.get(aspect_ratio, "1024x1024")
 
@@ -140,6 +143,7 @@ async def generate_video(
     aspect_ratio: str = "16:9",
     duration_seconds: int = 8,
     output_mode: str = "both",
+    model_id: str | None = None,
 ) -> dict[str, Any]:
     raise ProviderUnsupportedError(
         "openai.generate.video: Sora 2 API shutdown 2026-09-24. "

--- a/src/imagine_mcp/relay_schema.py
+++ b/src/imagine_mcp/relay_schema.py
@@ -1,9 +1,10 @@
 """Config schema for the relay setup page.
 
-ONE model-chain task: ``understand`` (order = litellm fallback chain). The
-three provider key fields are *derived* — they surface automatically for the
-providers the chosen understand models use, and the SAME keys also drive the
-native ``generate`` path (provider/tier catalog).
+TWO model-chain tasks: ``understand`` (litellm fallback chain) and ``generate``
+(native provider/model selection -- the first entry's prefix picks the provider
+and its model segment overrides the catalog model_id). The three provider key
+fields are *derived* — they surface automatically for the providers the chosen
+models use, and the SAME keys drive both the understand and generate paths.
 """
 
 from __future__ import annotations
@@ -18,6 +19,21 @@ _UNDERSTAND_SUGGESTED = [
     "gemini/gemini-3.1-pro-preview",
     "openai/gpt-5.4-mini",
     "openai/gpt-5.4",
+]
+
+# Catalog generate models, explicit ``provider/`` prefixes. The first entry of
+# a chosen GENERATE_MODELS chain selects the native provider + overrides the
+# catalog model_id; leaving it empty keeps the provider/tier catalog default.
+_GENERATE_SUGGESTED = [
+    "gemini/gemini-3.1-flash-image-preview",
+    "gemini/gemini-3-pro-image-preview",
+    "gemini/veo-3.1-lite-generate-preview",
+    "gemini/veo-3.1-generate-preview",
+    "openai/gpt-image-1-mini",
+    "openai/gpt-image-1.5",
+    "grok/grok-imagine-image",
+    "grok/grok-imagine-image-pro",
+    "grok/grok-imagine-video",
 ]
 
 
@@ -50,6 +66,15 @@ RELAY_SCHEMA: dict[str, Any] = {
             "suggestedModels": _UNDERSTAND_SUGGESTED,
             "hasLocal": False,
             "placeholder": "add understand model…",
+        },
+        {
+            "key": "GENERATE_MODELS",
+            "label": "Generate models",
+            "type": "model-chain",
+            "task": "generate",
+            "suggestedModels": _GENERATE_SUGGESTED,
+            "hasLocal": False,
+            "placeholder": "add generate model…",
         },
         _key_field(
             "GEMINI_API_KEY",
@@ -89,11 +114,14 @@ RELAY_SCHEMA: dict[str, Any] = {
         },
         {
             "label": "Image / video generation",
-            "priority": "native (provider/tier catalog)",
+            "priority": "configurable (native)",
             "description": (
-                "Generation stays native and uses the SAME provider keys above "
-                "(no model chain): Gemini image + Veo video, OpenAI image, "
-                "Grok image/video. Provider auto-fallback XAI > OpenAI > Gemini."
+                "Generation stays native and uses the SAME provider keys above. "
+                "Pick GENERATE_MODELS to choose a provider + model (first entry "
+                "wins); leave empty to use the provider/tier catalog default. "
+                "Gemini image + Veo video, OpenAI image, Grok image/video. "
+                "Provider auto-fallback order XAI, OpenAI, Gemini "
+                "(override via GENERATE_PROVIDER_PRIORITY)."
             ),
         },
     ],

--- a/src/imagine_mcp/relay_setup.py
+++ b/src/imagine_mcp/relay_setup.py
@@ -37,9 +37,16 @@ def load_config_from_file() -> dict[str, str] | None:
 
 
 def apply_config(config: dict[str, str]) -> None:
-    """Apply config dict to environment variables (does not overwrite existing)."""
+    """Apply a single-user config dict to ``os.environ``.
+
+    Overwrites an existing key when the submitted value differs so a relay
+    re-submit (e.g. a rotated key) is honoured rather than silently dropped;
+    skips empty values and identical re-submits (no churn). This is the
+    single-user path only -- multi-user mode scopes config per-sub via
+    ``credential_state.store_for_sub`` and never touches ``os.environ``.
+    """
     for key, value in config.items():
-        if value and key not in os.environ:
+        if value and os.environ.get(key) != value:
             os.environ[key] = value
             logger.debug("Applied relay config: {}", key)
 

--- a/tests/test_dispatcher.py
+++ b/tests/test_dispatcher.py
@@ -282,6 +282,7 @@ async def test_dispatch_generate_resolves_default_provider(
         reference_image_url: str | None,
         aspect_ratio: str,
         output_mode: str = "both",
+        model_id: str | None = None,
     ) -> dict:
         captured["called"] = "openai"
         return {"image": "...", "model": "gpt-image", "provider": "openai"}
@@ -463,6 +464,7 @@ async def test_passthrough_generate_xai_routes_native_grok(
         reference_image_url: str | None,
         aspect_ratio: str,
         output_mode: str = "both",
+        model_id: str | None = None,
     ) -> dict:
         captured["called"] = "grok"
         return {"image": "...", "model": "grok-imagine-image", "provider": "grok"}

--- a/tests/test_generate_selection.py
+++ b/tests/test_generate_selection.py
@@ -1,0 +1,243 @@
+"""GENERATE_MODELS chain + provider-priority dispatch behaviour.
+
+Covers the generate-side model selection gap: a configured GENERATE_MODELS
+chain resolves the provider from the entry prefix and OVERRIDES the catalog
+``model_id`` with the entry's model segment; an unset chain keeps the catalog
+default but lets GENERATE_PROVIDER_PRIORITY reorder the auto-fallback.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from imagine_mcp.dispatcher import dispatch_generate
+
+
+@pytest.fixture
+def clean_provider_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    for var in (
+        "XAI_API_KEY",
+        "OPENAI_API_KEY",
+        "GEMINI_API_KEY",
+        "GENERATE_MODELS",
+        "GENERATE_PROVIDER_PRIORITY",
+    ):
+        monkeypatch.delenv(var, raising=False)
+
+
+@pytest.mark.asyncio
+async def test_generate_chain_overrides_catalog_model_id(
+    clean_provider_env: None, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """GENERATE_MODELS entry's model segment replaces the catalog model_id."""
+    monkeypatch.setenv("GEMINI_API_KEY", "gem-test")
+    monkeypatch.setenv("GENERATE_MODELS", "gemini/my-custom-image-model")
+
+    captured: dict[str, object] = {}
+
+    async def mock_fn(
+        prompt: str,
+        tier: str,
+        reference_image_url: str | None,
+        aspect_ratio: str,
+        output_mode: str = "both",
+        model_id: str | None = None,
+    ) -> dict:
+        captured["provider"] = "gemini"
+        captured["model_id"] = model_id
+        return {"image": "...", "model": model_id, "provider": "gemini"}
+
+    import imagine_mcp.providers.gemini as gemini_mod
+
+    monkeypatch.setattr(gemini_mod, "generate_image", mock_fn, raising=False)
+
+    result = await dispatch_generate(
+        media_type="image",
+        prompt="a cat",
+        provider=None,
+        tier="poor",
+    )
+    assert captured["provider"] == "gemini"
+    assert captured["model_id"] == "my-custom-image-model"
+    assert result["model"] == "my-custom-image-model"
+
+
+@pytest.mark.asyncio
+async def test_generate_chain_resolves_provider_from_prefix(
+    clean_provider_env: None, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A grok/ GENERATE_MODELS entry routes to the native grok provider."""
+    monkeypatch.setenv("XAI_API_KEY", "xai-test")
+    monkeypatch.setenv("GENERATE_MODELS", "grok/grok-imagine-image-custom")
+
+    captured: dict[str, object] = {}
+
+    async def mock_fn(
+        prompt: str,
+        tier: str,
+        reference_image_url: str | None,
+        aspect_ratio: str,
+        output_mode: str = "both",
+        model_id: str | None = None,
+    ) -> dict:
+        captured["called"] = "grok"
+        captured["model_id"] = model_id
+        return {"image": "...", "model": model_id, "provider": "grok"}
+
+    import imagine_mcp.providers.grok as grok_mod
+
+    monkeypatch.setattr(grok_mod, "generate_image", mock_fn, raising=False)
+
+    result = await dispatch_generate(
+        media_type="image",
+        prompt="a cat",
+        provider=None,
+        tier="poor",
+    )
+    assert captured["called"] == "grok"
+    assert captured["model_id"] == "grok-imagine-image-custom"
+    assert result["provider"] == "grok"
+
+
+@pytest.mark.asyncio
+async def test_generate_chain_video_override(
+    clean_provider_env: None, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """GENERATE_MODELS also overrides the model_id on the video path."""
+    monkeypatch.setenv("GEMINI_API_KEY", "gem-test")
+    monkeypatch.setenv("GENERATE_MODELS", "gemini/veo-custom")
+
+    captured: dict[str, object] = {}
+
+    async def mock_fn(
+        prompt: str,
+        tier: str,
+        reference_image_url: str | None,
+        job_id: str | None,
+        aspect_ratio: str,
+        duration_seconds: int,
+        output_mode: str = "both",
+        model_id: str | None = None,
+    ) -> dict:
+        captured["model_id"] = model_id
+        return {"job_id": "j1", "status": "pending", "model": model_id}
+
+    import imagine_mcp.providers.gemini as gemini_mod
+
+    monkeypatch.setattr(gemini_mod, "generate_video", mock_fn, raising=False)
+
+    await dispatch_generate(
+        media_type="video",
+        prompt="a dog running",
+        provider=None,
+        tier="poor",
+    )
+    assert captured["model_id"] == "veo-custom"
+
+
+@pytest.mark.asyncio
+async def test_generate_chain_explicit_provider_ignores_chain(
+    clean_provider_env: None, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """An explicit provider keeps the catalog model_id (chain ignored)."""
+    monkeypatch.setenv("GENERATE_MODELS", "gemini/should-be-ignored")
+
+    captured: dict[str, object] = {}
+
+    async def mock_fn(
+        prompt: str,
+        tier: str,
+        reference_image_url: str | None,
+        aspect_ratio: str,
+        output_mode: str = "both",
+        model_id: str | None = None,
+    ) -> dict:
+        captured["model_id"] = model_id
+        return {"image": "...", "model": "catalog", "provider": "openai"}
+
+    import imagine_mcp.providers.openai as openai_mod
+
+    monkeypatch.setattr(openai_mod, "generate_image", mock_fn, raising=False)
+
+    await dispatch_generate(
+        media_type="image",
+        prompt="a cat",
+        provider="openai",
+        tier="poor",
+    )
+    # Explicit provider -> catalog path -> no model_id override.
+    assert captured["model_id"] is None
+
+
+@pytest.mark.asyncio
+async def test_generate_provider_priority_reorders_default(
+    clean_provider_env: None, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """With multiple keys, GENERATE_PROVIDER_PRIORITY drives the auto pick.
+
+    Default priority is XAI > OPENAI > GEMINI; here we flip it so GEMINI wins
+    even though all three keys are present.
+    """
+    monkeypatch.setenv("XAI_API_KEY", "x")
+    monkeypatch.setenv("OPENAI_API_KEY", "o")
+    monkeypatch.setenv("GEMINI_API_KEY", "g")
+    monkeypatch.setenv("GENERATE_PROVIDER_PRIORITY", "gemini,openai,grok")
+
+    captured: dict[str, str] = {}
+
+    async def mock_fn(
+        prompt: str,
+        tier: str,
+        reference_image_url: str | None,
+        aspect_ratio: str,
+        output_mode: str = "both",
+        model_id: str | None = None,
+    ) -> dict:
+        captured["called"] = "gemini"
+        return {"image": "...", "model": "x", "provider": "gemini"}
+
+    import imagine_mcp.providers.gemini as gemini_mod
+
+    monkeypatch.setattr(gemini_mod, "generate_image", mock_fn, raising=False)
+
+    result = await dispatch_generate(
+        media_type="image",
+        prompt="a cat",
+        provider=None,
+        tier="poor",
+    )
+    assert captured["called"] == "gemini"
+    assert result["provider"] == "gemini"
+
+
+@pytest.mark.asyncio
+async def test_generate_no_chain_keeps_catalog_default(
+    clean_provider_env: None, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """No GENERATE_MODELS -> catalog model_id (model_id override is None)."""
+    monkeypatch.setenv("OPENAI_API_KEY", "sk-test")
+
+    captured: dict[str, object] = {}
+
+    async def mock_fn(
+        prompt: str,
+        tier: str,
+        reference_image_url: str | None,
+        aspect_ratio: str,
+        output_mode: str = "both",
+        model_id: str | None = None,
+    ) -> dict:
+        captured["model_id"] = model_id
+        return {"image": "...", "model": "gpt-image", "provider": "openai"}
+
+    import imagine_mcp.providers.openai as openai_mod
+
+    monkeypatch.setattr(openai_mod, "generate_image", mock_fn, raising=False)
+
+    await dispatch_generate(
+        media_type="image",
+        prompt="a cat",
+        provider=None,
+        tier="poor",
+    )
+    assert captured["model_id"] is None

--- a/tests/test_output_mode.py
+++ b/tests/test_output_mode.py
@@ -14,7 +14,7 @@ async def test_dispatch_generate_forwards_output_mode(monkeypatch):
     captured = {}
 
     async def fake_generate_image(
-        prompt, tier, reference_image_url, aspect_ratio, output_mode
+        prompt, tier, reference_image_url, aspect_ratio, output_mode, model_id=None
     ):
         captured["output_mode"] = output_mode
         return {"image_base64": "x", "model": "m", "provider": "gemini", "tier": tier}
@@ -36,7 +36,7 @@ async def test_env_override_wins_over_tool_arg(monkeypatch):
     captured = {}
 
     async def fake_generate_image(
-        prompt, tier, reference_image_url, aspect_ratio, output_mode
+        prompt, tier, reference_image_url, aspect_ratio, output_mode, model_id=None
     ):
         captured["output_mode"] = output_mode
         return {"image_base64": "x"}

--- a/tests/test_relay_schema.py
+++ b/tests/test_relay_schema.py
@@ -17,11 +17,11 @@ def test_top_level_keys_present():
     assert RELAY_SCHEMA["server"] == "imagine-mcp"
 
 
-def test_exactly_one_model_chain_task_understand():
+def test_model_chain_tasks_are_understand_and_generate():
     tasks = {
         f["task"] for f in RELAY_SCHEMA["fields"] if f.get("type") == "model-chain"
     }
-    assert tasks == {"understand"}
+    assert tasks == {"understand", "generate"}
 
 
 def test_derived_keys_are_the_three_providers():

--- a/tests/test_relay_setup.py
+++ b/tests/test_relay_setup.py
@@ -68,12 +68,26 @@ def test_apply_config_sets_missing_env(monkeypatch):
     assert os.environ["OPENAI_API_KEY"] == "ok"
 
 
-def test_apply_config_does_not_overwrite_existing_env(monkeypatch):
+def test_apply_config_overwrites_existing_env_when_value_differs(monkeypatch):
+    """Single-user relay re-submit must refresh a stale env key (Fix 3).
+
+    Previously apply_config skipped any key already in os.environ, so a user
+    re-submitting a rotated key via the browser form was silently ignored.
+    """
     monkeypatch.setenv("XAI_API_KEY", "original")
     apply_config({"XAI_API_KEY": "replacement"})
     import os
 
-    assert os.environ["XAI_API_KEY"] == "original"
+    assert os.environ["XAI_API_KEY"] == "replacement"
+
+
+def test_apply_config_noop_when_value_unchanged(monkeypatch):
+    """An identical re-submit is a no-op (no needless churn)."""
+    monkeypatch.setenv("OPENAI_API_KEY", "same")
+    apply_config({"OPENAI_API_KEY": "same"})
+    import os
+
+    assert os.environ["OPENAI_API_KEY"] == "same"
 
 
 def test_apply_config_skips_empty_values():

--- a/tests/test_subaware_chains.py
+++ b/tests/test_subaware_chains.py
@@ -1,0 +1,178 @@
+"""Sub-aware model-chain + generate-selection resolution.
+
+Multi-user HTTP mode stores the relay-submitted ``UNDERSTAND_MODELS`` /
+``GENERATE_MODELS`` / ``GENERATE_PROVIDER_PRIORITY`` per JWT subject (never in
+``os.environ`` -- that would leak one sub's chain to a concurrent request of
+another sub). These tests pin that the resolvers read the per-sub config when a
+sub is active and fall back to ``os.environ`` only in single-user / stdio mode.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from collections.abc import Iterator
+
+import pytest
+
+from imagine_mcp.credential_state import (
+    CLOUD_KEYS,
+    _current_sub,
+    set_current_sub,
+    store_for_sub,
+)
+from imagine_mcp.dispatcher import (
+    _DEFAULT_PROVIDER_PRIORITY,
+    resolve_generate_chain,
+    resolve_generate_provider_priority,
+    resolve_understand_chain,
+)
+
+
+@pytest.fixture(autouse=True)
+def _isolate(tmp_path, monkeypatch) -> Iterator[None]:
+    """Pin PerPluginStore, force HTTP mode, clear chain + key env vars."""
+    monkeypatch.setattr("pathlib.Path.home", lambda: tmp_path)
+    monkeypatch.setenv("CREDENTIAL_SECRET", "test-secret-value")
+    monkeypatch.setenv("MCP_TRANSPORT", "http")
+    for key in (
+        *CLOUD_KEYS,
+        "UNDERSTAND_MODELS",
+        "GENERATE_MODELS",
+        "GENERATE_PROVIDER_PRIORITY",
+    ):
+        monkeypatch.delenv(key, raising=False)
+    token = _current_sub.set(None)
+    yield
+    _current_sub.reset(token)
+
+
+# ---------------------------------------------------------------------------
+# Fix 1: sub-aware UNDERSTAND_MODELS chain
+# ---------------------------------------------------------------------------
+def test_understand_chain_reads_per_sub_config() -> None:
+    """A sub's stored UNDERSTAND_MODELS reaches resolve_understand_chain()."""
+    store_for_sub(
+        "sub-a",
+        {"UNDERSTAND_MODELS": "xai/grok-4.20-0309-non-reasoning,gemini/flash"},
+    )
+    set_current_sub("sub-a")
+    assert resolve_understand_chain() == [
+        "xai/grok-4.20-0309-non-reasoning",
+        "gemini/flash",
+    ]
+
+
+def test_understand_chain_other_sub_does_not_see_first() -> None:
+    """A different sub does NOT inherit the first sub's chain."""
+    store_for_sub("sub-a", {"UNDERSTAND_MODELS": "xai/grok-a"})
+    store_for_sub("sub-b", {"UNDERSTAND_MODELS": "openai/gpt-b"})
+
+    set_current_sub("sub-a")
+    assert resolve_understand_chain() == ["xai/grok-a"]
+
+    set_current_sub("sub-b")
+    assert resolve_understand_chain() == ["openai/gpt-b"]
+
+
+def test_understand_chain_sub_without_config_is_empty() -> None:
+    """A sub with no stored chain resolves to an empty list (not env leak)."""
+    store_for_sub("sub-a", {"UNDERSTAND_MODELS": "xai/grok-a"})
+    set_current_sub("sub-b")
+    assert resolve_understand_chain() == []
+
+
+def test_understand_chain_does_not_write_os_environ() -> None:
+    """Resolving a per-sub chain must never mutate the process-global env."""
+    import os
+
+    store_for_sub("sub-a", {"UNDERSTAND_MODELS": "xai/grok-a"})
+    set_current_sub("sub-a")
+    resolve_understand_chain()
+    assert "UNDERSTAND_MODELS" not in os.environ
+
+
+def test_understand_chain_single_user_reads_env(monkeypatch) -> None:
+    """No sub set (single-user/stdio): falls back to os.getenv."""
+    set_current_sub(None)
+    monkeypatch.setenv("UNDERSTAND_MODELS", "gemini/from-env")
+    assert resolve_understand_chain() == ["gemini/from-env"]
+
+
+# ---------------------------------------------------------------------------
+# Fix 2: sub-aware GENERATE_MODELS chain
+# ---------------------------------------------------------------------------
+def test_generate_chain_reads_per_sub_config() -> None:
+    store_for_sub(
+        "sub-a",
+        {"GENERATE_MODELS": "gemini/imagen-x,openai/gpt-image-y"},
+    )
+    set_current_sub("sub-a")
+    assert resolve_generate_chain() == ["gemini/imagen-x", "openai/gpt-image-y"]
+
+
+def test_generate_chain_other_sub_does_not_see_first() -> None:
+    store_for_sub("sub-a", {"GENERATE_MODELS": "gemini/gen-a"})
+    store_for_sub("sub-b", {})
+
+    set_current_sub("sub-a")
+    assert resolve_generate_chain() == ["gemini/gen-a"]
+
+    set_current_sub("sub-b")
+    assert resolve_generate_chain() == []
+
+
+def test_generate_chain_single_user_reads_env(monkeypatch) -> None:
+    set_current_sub(None)
+    monkeypatch.setenv("GENERATE_MODELS", "grok/grok-imagine-image")
+    assert resolve_generate_chain() == ["grok/grok-imagine-image"]
+
+
+def test_generate_chain_empty_unset(monkeypatch) -> None:
+    set_current_sub(None)
+    monkeypatch.delenv("GENERATE_MODELS", raising=False)
+    assert resolve_generate_chain() == []
+
+
+# ---------------------------------------------------------------------------
+# Fix 2: sub-aware GENERATE_PROVIDER_PRIORITY
+# ---------------------------------------------------------------------------
+def test_generate_provider_priority_default_is_catalog_tuple() -> None:
+    """Unset -> the existing _DEFAULT_PROVIDER_PRIORITY order."""
+    set_current_sub(None)
+    expected = [provider for _env, provider in _DEFAULT_PROVIDER_PRIORITY]
+    assert resolve_generate_provider_priority() == expected
+
+
+def test_generate_provider_priority_per_sub_override() -> None:
+    store_for_sub("sub-a", {"GENERATE_PROVIDER_PRIORITY": "gemini,openai,grok"})
+    set_current_sub("sub-a")
+    assert resolve_generate_provider_priority() == ["gemini", "openai", "grok"]
+
+
+def test_generate_provider_priority_single_user_env(monkeypatch) -> None:
+    set_current_sub(None)
+    monkeypatch.setenv("GENERATE_PROVIDER_PRIORITY", "openai,grok,gemini")
+    assert resolve_generate_provider_priority() == ["openai", "grok", "gemini"]
+
+
+def test_generate_provider_priority_concurrent_subs_isolated() -> None:
+    """Two coroutines with distinct subs see independent priorities."""
+    store_for_sub("sub-a", {"GENERATE_PROVIDER_PRIORITY": "gemini,openai,grok"})
+    store_for_sub("sub-b", {"GENERATE_PROVIDER_PRIORITY": "grok,openai,gemini"})
+
+    captured: dict[str, list[str]] = {}
+
+    async def request_for(sub: str) -> None:
+        token = _current_sub.set(sub)
+        try:
+            await asyncio.sleep(0)
+            captured[sub] = resolve_generate_provider_priority()
+        finally:
+            _current_sub.reset(token)
+
+    async def driver() -> None:
+        await asyncio.gather(request_for("sub-a"), request_for("sub-b"))
+
+    asyncio.run(driver())
+    assert captured["sub-a"] == ["gemini", "openai", "grok"]
+    assert captured["sub-b"] == ["grok", "openai", "gemini"]


### PR DESCRIPTION
## Summary

Fixes three user-reported gaps in imagine-mcp's generate / relay / credential paths. All per-sub values flow **request-scoped** (never written to `os.environ`), preserving multi-user credential isolation.

### 1. Sub-aware `UNDERSTAND_MODELS` chain (multi-user bug)
`resolve_understand_chain()` read only `os.getenv("UNDERSTAND_MODELS")`. In multi-user HTTP mode the relay-submitted chain is stored **per-sub** (`credential_state.store_for_sub`) and never reached the resolver, so a remote user's chain was silently ignored.

- New `credential_state.config_value_for_current_request(key)` accessor: returns the per-sub config value when `get_current_sub()` is set, else `os.environ.get(key)`. Mirrors `credentials_for_current_request` and **never merges `os.environ`** when a sub is active.
- `resolve_understand_chain()` now resolves through it.

### 2. `GENERATE_MODELS` model selection (the "only understand, can't pick image/video gen model" + "hardcoded" gap)
Generation provider came from a hardcoded `_DEFAULT_PROVIDER_PRIORITY` and the `model_id` was a fixed per-`(provider, tier)` catalog lookup, so callers could not pick a generation model.

- New sub-aware `resolve_generate_chain()`: when set, the first entry's `provider/` prefix selects the native provider and its model segment **overrides** the catalog `model_id` (threaded into `generate_image` / `generate_video` via a new optional `model_id` param on all three providers). Generation is still never routed through litellm.
- New sub-aware `resolve_generate_provider_priority()` (+ optional `GENERATE_PROVIDER_PRIORITY`) reorders the auto-fallback when no explicit provider / chain is given; defaults to the existing native order (XAI, OpenAI, Gemini).
- Added a `GENERATE_MODELS` model-chain field + `suggestedModels` to `relay_schema.py`; relaxed `tests/test_relay_schema.py` to assert the chain tasks are now `{understand, generate}`.

### 3. `apply_config` staleness (single-user relay re-submit ignored)
`apply_config` used `if value and key not in os.environ`, so a single-user relay re-submit of a **rotated** key was silently dropped. Now overwrites when the submitted value differs (single-user only; multi-user scopes per-sub and never touches `os.environ`).

## Multi-user isolation
Per-sub values are read request-scoped via the per-sub accessor and passed explicitly down the call (or read under the per-request sub contextvar). A second sub does **not** see the first sub's chain/priority. Single-user (`sub` is `None`) keeps the existing `os.environ` / `apply_config` behavior.

## Tests
TDD (failing test first). New: `tests/test_subaware_chains.py` (sub-aware understand/generate chains + provider priority, incl. cross-sub no-bleed, concurrent-sub isolation, no-`os.environ`-write), `tests/test_generate_selection.py` (chain overrides catalog model_id, provider-from-prefix, video override, explicit-provider-ignores-chain, priority reorder). Updated existing mocks for the new `model_id` provider param, the relay schema task set, and `apply_config` overwrite semantics.

- Full suite: **256 passed**, 3 deselected
- `ruff check` + `ruff format --check`: clean
- `ty check`: clean

## Note
Do **not** merge — lead reviews multi-user-isolation diffs before merge.
