### PR TITLE
fix: right-size CF container instance_type and sleepAfter to cut GiB-second cost

### DIFF
--- a/src/worker.ts
+++ b/src/worker.ts
@@ -145,7 +145,7 @@ function extractUserId(request: Request): string {
 // + EXPOSE 8080).
 export class ImagineContainer extends Container<Env> {
   defaultPort = 8080
-  sleepAfter = '1h'
+  sleepAfter = '5m'
   // The container reaches cloud model APIs (Gemini, OpenAI, xAI) over the public
   // internet; kv.internal stays intercepted (see outboundByHost).
   enableInternet = true

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -15,8 +15,8 @@
       //   wrangler containers push imagine-mcp:beta
       // then fill <YOUR_ACCOUNT_ID>.
       "image": "registry.cloudflare.com/<YOUR_ACCOUNT_ID>/imagine-mcp:beta",
-      "instance_type": "standard-1",
-      "max_instances": 100
+      "instance_type": "basic",
+      "max_instances": 10
     }
   ],
   "durable_objects": {


### PR DESCRIPTION
## Summary

Right-size the Cloudflare container config to cut the dominant cost driver (container memory per GiB-second, ~95% of the CF bill). Config-only change; no application logic touched.

The imagine-mcp container runs in stateless cloud mode (KV-only externalised state, no local model loaded, no in-RAM auth window), so the `standard-1` (4 GiB) instance and `1h` idle window are oversized for the actual working set.

## Changes

| File | Field | Before | After |
|------|-------|--------|-------|
| `wrangler.jsonc` | `instance_type` | `standard-1` (4 GiB) | `basic` (1 GiB) |
| `wrangler.jsonc` | `max_instances` | `100` | `10` |
| `src/worker.ts` | `ImagineContainer.sleepAfter` | `1h` | `5m` |

- 4 GiB -> 1 GiB cuts the per-instance GiB-second rate 4x for the same wall time.
- `sleepAfter` 1h -> 5m stops billing idle memory long before the previous hour-long window; safe because the container holds no in-RAM session/auth state (credentials live in KV).
- `max_instances` 100 -> 10 caps the concurrent-instance blast radius.

## Verification

- `wrangler deploy --dry-run`: passes, config schema valid (`basic` accepted as `instance_type`, worker bundles, all bindings resolve). No config/schema parse error.
- `vitest run tests/worker.test.ts`: 9/9 pass.
- `tsc --noEmit`: the 8 type errors in `tests/worker.test.ts` are pre-existing (identical on `origin/main` before this change) and live in the test mocks, not in `worker.ts` source; this change introduces zero new type errors. They are not a CI gate (CI runs only the Python lint/type/test suite).

No application logic was changed. `defaultPort`, `enableInternet`, `envVars`, and all outbound-handler wiring are untouched.
