### PR TITLE
perf: ⚡ Bolt: Cache request-scoped config values to eliminate redundant file I/O

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -28,3 +28,7 @@
 ## 2024-06-25 - [Optimize File Download Chunking]
 **Learning:** Native `anyio.open_file` is much faster for writing small chunks inside an async iteration compared to `await asyncio.to_thread(f.write, chunk)`. Using `to_thread` repeatedly within a loop introducing significant context-switching overhead.
 **Action:** Always prefer native asynchronous file I/O operations (like `anyio`) for fine-grained chunked streaming in high-frequency loops instead of delegating individual chunk writes to thread pools.
+
+## 2026-06-13 - Request-Scoped ContextVar Caching for Sub-Aware Configurations
+**Learning:** `config_value_for_current_request` in `src/imagine_mcp/credential_state.py` retrieved configurations directly via `read_for_sub(sub)` for every lookup (like `UNDERSTAND_MODELS` and `GENERATE_MODELS` chained across requests). Since `read_for_sub` invokes `PerPluginStore.load()` internally, this introduced redundant disk I/O, JSON parsing, and AES-GCM decryption for *each* configuration variable requested during a single tool call. Even though credentials were being cached via the `_request_creds` `ContextVar`, the configuration lookups were incorrectly bypassing that cache.
+**Action:** Always route configuration variable lookups through the same request-scoped cache used for credentials when operating under the same tenant isolation boundaries, avoiding repetitive and expensive I/O operations per key.

--- a/src/imagine_mcp/credential_state.py
+++ b/src/imagine_mcp/credential_state.py
@@ -157,7 +157,16 @@ def config_value_for_current_request(key: str) -> str | None:
     sub = _current_sub.get()
     if sub is None:
         return os.environ.get(key)
-    return read_for_sub(sub).get(key)
+
+    # ⚡ Bolt: Leverage existing request-scoped cache to prevent redundant
+    # file I/O (PerPluginStore.load) and decryption per key lookup.
+    cached = _request_creds.get()
+    if cached is not None:
+        return cached.get(key)
+
+    config = read_for_sub(sub)
+    _request_creds.set(config)
+    return config.get(key)
 
 
 # ---------------------------------------------------------------------------

--- a/uv.lock
+++ b/uv.lock
@@ -709,7 +709,7 @@ wheels = [
 
 [[package]]
 name = "imagine-mcp"
-version = "1.7.0b8"
+version = "1.7.0b9"
 source = { editable = "." }
 dependencies = [
     { name = "diskcache" },


### PR DESCRIPTION
💡 **What**:
Updated `config_value_for_current_request` in `src/imagine_mcp/credential_state.py` to first check the `_request_creds` ContextVar for a cached configuration state before calling `read_for_sub(sub)`. If not cached, it fetches the config and caches it for subsequent lookups in the same request context.

🎯 **Why**:
`read_for_sub` invokes `PerPluginStore.load()`, which performs disk I/O, JSON parsing, and AES-GCM decryption. Because configuration keys like `UNDERSTAND_MODELS` and `GENERATE_MODELS` are evaluated on every `dispatch_understand` and `dispatch_generate` call, the previous implementation was doing redundant, expensive disk reads per-key, severely hampering request latency for chained model fallbacks.

📊 **Impact**:
Reduces file I/O and decryption overhead from O(K) (where K is the number of config key lookups per request) to O(1) per request when a `sub` is provided. Substantially improves latency for `understand` and `generate` operations in multi-user mode.

🔬 **Measurement**:
Verified that the optimization relies entirely on existing memory-isolated ContextVars and does not regress existing credential tests. All tests run cleanly (`uv run pytest`) and `read_for_sub` overhead is functionally bypassed on secondary lookups within the same HTTP request scope.

---
*PR created automatically by Jules for task [10158991336896454815](https://jules.google.com/task/10158991336896454815) started by @n24q02m*