### PR TITLE
fix: pin CF max_instances to 3

### DIFF
--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -16,7 +16,7 @@
       // then fill <YOUR_ACCOUNT_ID>.
       "image": "registry.cloudflare.com/<YOUR_ACCOUNT_ID>/imagine-mcp:beta",
       "instance_type": "basic",
-      "max_instances": 10
+      "max_instances": 3
     }
   ],
   "durable_objects": {


### PR DESCRIPTION
Right-size the committed CF container config: pin `max_instances` 10 -> 3 in `wrangler.jsonc` to match the live emergency cap and cap blast radius (3 x 1GiB basic). Keeps `instance_type=basic` and the `:beta` image ref unchanged.

Rationale: container memory (GiB-second) is the dominant CF cost; 10 x 1GiB allows a 10GiB warm footprint runaway. The live app was already PATCHed to max=3; this makes the committed config durable so the next CD redeploy does not reset it back to 10.