### PR TITLE
fix: bump mcp-core to 1.18.0b20 for relay catalog + drop hardcoded suggestions

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,7 +47,7 @@ dependencies = [
     "pillow>=12.2.0",
     "diskcache>=5.6.3",
     "loguru>=0.7.3",
-    "n24q02m-mcp-core[llm]>=1.18.0b19,<2",
+    "n24q02m-mcp-core[llm]>=1.18.0b20,<2",
     "platformdirs>=4.10.0",
     # Security floors: transitive deps pinned to patched releases.
     # urllib3 < 2.7.0 -> PYSEC-2026-141/142; idna < 3.15 -> CVE-2026-45409.

--- a/src/imagine_mcp/relay_schema.py
+++ b/src/imagine_mcp/relay_schema.py
@@ -11,26 +11,17 @@ from __future__ import annotations
 
 from typing import Any
 
-# Catalog understand IMAGE models, explicit ``provider/`` prefixes.
-_UNDERSTAND_SUGGESTED = [
-    "xai/grok-4.20-0309-non-reasoning",
-    "xai/grok-4.20-0309-reasoning",
-    "gemini/gemini-3.1-flash-lite-preview",
-    "gemini/gemini-3.1-pro-preview",
-    "openai/gpt-5.4-mini",
-    "openai/gpt-5.4",
-]
+# UNDERSTAND models are fully catalog-driven: the litellm chat catalog covers
+# the gemini/openai/xai vision models, so the dropdown carries no hardcoded
+# suggestions (the user searches the real provider/model space).
 
-# Catalog generate models, explicit ``provider/`` prefixes. The first entry of
+# GENERATE keeps a MINIMAL supplement: only the native grok (xAI) image/video
+# models, a verified litellm gap (absent from the generate catalog) with no
+# keyless list endpoint to fetch. Gemini/OpenAI generation models come from the
+# litellm generate catalog (image/video modes), not hardcode. The first entry of
 # a chosen GENERATE_MODELS chain selects the native provider + overrides the
 # catalog model_id; leaving it empty keeps the provider/tier catalog default.
 _GENERATE_SUGGESTED = [
-    "gemini/gemini-3.1-flash-image-preview",
-    "gemini/gemini-3-pro-image-preview",
-    "gemini/veo-3.1-lite-generate-preview",
-    "gemini/veo-3.1-generate-preview",
-    "openai/gpt-image-1-mini",
-    "openai/gpt-image-1.5",
     "grok/grok-imagine-image",
     "grok/grok-imagine-image-pro",
     "grok/grok-imagine-video",
@@ -63,7 +54,6 @@ RELAY_SCHEMA: dict[str, Any] = {
             "label": "Understand models",
             "type": "model-chain",
             "task": "understand",
-            "suggestedModels": _UNDERSTAND_SUGGESTED,
             "hasLocal": False,
             "placeholder": "add understand model…",
         },

--- a/tests/test_relay_schema.py
+++ b/tests/test_relay_schema.py
@@ -47,3 +47,14 @@ def test_capability_info_entries_well_formed():
         assert cap["label"]
         assert cap["priority"]
         assert cap["description"]
+
+
+def test_understand_catalog_driven_generate_keeps_grok_supplement():
+    # understand is fully catalog-driven (litellm chat catalog covers it); generate
+    # keeps ONLY the grok models litellm cannot list (no gemini/openai hardcode).
+    by_key = {f["key"]: f for f in RELAY_SCHEMA["fields"]}
+    assert not by_key["UNDERSTAND_MODELS"].get("suggestedModels")
+    gen = by_key["GENERATE_MODELS"].get("suggestedModels", [])
+    assert gen, "generate must keep a minimal grok supplement litellm lacks"
+    assert all("grok" in m for m in gen), f"only grok supplement expected, got {gen}"
+    assert not any(m.startswith(("gemini/", "openai/")) for m in gen)

--- a/uv.lock
+++ b/uv.lock
@@ -709,7 +709,7 @@ wheels = [
 
 [[package]]
 name = "imagine-mcp"
-version = "1.7.0b10"
+version = "1.7.0b11"
 source = { editable = "." }
 dependencies = [
     { name = "diskcache" },
@@ -752,7 +752,7 @@ requires-dist = [
     { name = "idna", specifier = ">=3.18" },
     { name = "loguru", specifier = ">=0.7.3" },
     { name = "mcp", extras = ["cli"], specifier = ">=1.28.0" },
-    { name = "n24q02m-mcp-core", extras = ["llm"], specifier = ">=1.18.0b19,<2" },
+    { name = "n24q02m-mcp-core", extras = ["llm"], specifier = ">=1.18.0b20,<2" },
     { name = "openai", specifier = ">=2.43.0" },
     { name = "pillow", specifier = ">=12.2.0" },
     { name = "platformdirs", specifier = ">=4.10.0" },
@@ -1132,7 +1132,7 @@ wheels = [
 
 [[package]]
 name = "n24q02m-mcp-core"
-version = "1.18.0b19"
+version = "1.18.0b20"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "authlib" },
@@ -1147,9 +1147,9 @@ dependencies = [
     { name = "starlette" },
     { name = "tomli-w" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/9b/0b/3d4ed59ce33bf6a8991ce47713d7fedb22bd3040079529851c7a670508e2/n24q02m_mcp_core-1.18.0b19.tar.gz", hash = "sha256:6105cc86a79dd5c6778991ee378561eea9dbd1677f8fb5af6acc7331c40f5b0d", size = 297999, upload-time = "2026-06-22T12:46:55.254Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/0c/10/ec1bdeff0df00bb00382107f79ca575c784c28067fda4229083ab3a97dc7/n24q02m_mcp_core-1.18.0b20.tar.gz", hash = "sha256:6814f5e0c9887dff3afdf2c7049ff4b598fa1c2cbca0656d95f48fb1f2226d8b", size = 301569, upload-time = "2026-06-23T02:28:51.212Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/c1/15/d39c509cfde412e94db5b5c6921b931f7833c1cc4479e668b589f7742198/n24q02m_mcp_core-1.18.0b19-py3-none-any.whl", hash = "sha256:8a31c96a80e029455e07ce7a9c08795495a166d7edce250457e2708879587a37", size = 166014, upload-time = "2026-06-22T12:46:53.867Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/db/a555b269c368c2238a82186e90f65a41a07a93b11d0c4b8516703a19a90b/n24q02m_mcp_core-1.18.0b20-py3-none-any.whl", hash = "sha256:66fae2c80c3287b1a7c5d3aa3eec0948ccd819efb1ddc9549a9ecfb003be3d84", size = 168546, upload-time = "2026-06-23T02:28:49.873Z" },
 ]
 
 [package.optional-dependencies]


### PR DESCRIPTION
Bumps n24q02m-mcp-core[llm] floor to >=1.18.0b20,<2 and regenerates uv.lock so the Docker image (uv sync --frozen) ships the catalog-driven relay model search (Jina live + bare-name normalize + keyword widget). Includes the prior relay hardcode-removal commit: understand models are now catalog-driven with a minimal grok generate supplement.

Local checks: ruff check, ruff format --check, ty check all pass. uv.lock resolves n24q02m-mcp-core to exactly 1.18.0b20.