### PR TITLE
test: untested openai generate_image logic

### DIFF
--- a/tests/test_providers_openai.py
+++ b/tests/test_providers_openai.py
@@ -1,10 +1,11 @@
 from __future__ import annotations
 
+import base64
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
-from imagine_mcp.errors import ProviderUnsupportedError
+from imagine_mcp.errors import ProviderAPIError, ProviderUnsupportedError
 from imagine_mcp.providers import openai as provider
 
 
@@ -64,3 +65,87 @@ async def test_understand_image_mocked(
     assert result["provider"] == "openai"
     assert captured["model"] == "openai/gpt-5.4-mini"
     assert captured["api_key"] == "sk-test"
+
+
+@pytest.mark.asyncio
+async def test_generate_image_basic_mocked(monkeypatch: pytest.MonkeyPatch) -> None:
+    mock_resp = MagicMock()
+    mock_item = MagicMock()
+    mock_item.b64_json = base64.b64encode(b"generated-image").decode()
+    mock_resp.data = [mock_item]
+
+    mock_client_inst = MagicMock()
+    mock_client_inst.images.generate = AsyncMock(return_value=mock_resp)
+
+    monkeypatch.setattr(provider, "_client", lambda: mock_client_inst)
+
+    async def fake_emit_media(data, suffix, key, output_mode):
+        assert data == b"generated-image"
+        return {"image_base64": "fake-b64", "image_path": "fake/path.png"}
+
+    monkeypatch.setattr("imagine_mcp.media.emit_media", fake_emit_media)
+
+    result = await provider.generate_image(
+        prompt="a sunset", tier="poor", aspect_ratio="16:9"
+    )
+
+    assert result["image_path"] == "fake/path.png"
+    assert result["model"] == "gpt-image-1-mini"
+    assert result["provider"] == "openai"
+    assert result["tier"] == "poor"
+    mock_client_inst.images.generate.assert_called_once_with(
+        model="gpt-image-1-mini", prompt="a sunset", size="1792x1024", n=1
+    )
+
+
+@pytest.mark.asyncio
+async def test_generate_image_edit_mocked(
+    mock_media_fetch: None, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    mock_resp = MagicMock()
+    mock_item = MagicMock()
+    mock_item.b64_json = base64.b64encode(b"edited-image").decode()
+    mock_resp.data = [mock_item]
+
+    mock_client_inst = MagicMock()
+    mock_client_inst.images.edit = AsyncMock(return_value=mock_resp)
+
+    monkeypatch.setattr(provider, "_client", lambda: mock_client_inst)
+
+    async def fake_emit_media(data, suffix, key, output_mode):
+        assert data == b"edited-image"
+        return {"image_path": "fake/edited.png"}
+
+    monkeypatch.setattr("imagine_mcp.media.emit_media", fake_emit_media)
+
+    result = await provider.generate_image(
+        prompt="add a cat",
+        tier="rich",
+        reference_image_url="https://example.com/ref.png",
+        aspect_ratio="1:1",
+    )
+
+    assert result["image_path"] == "fake/edited.png"
+    assert result["model"] == "gpt-image-1.5"
+    mock_client_inst.images.edit.assert_called_once_with(
+        model="gpt-image-1.5",
+        image=b"fake-image-bytes",
+        prompt="add a cat",
+        size="1024x1024",
+    )
+
+
+@pytest.mark.asyncio
+async def test_generate_image_no_data_raises(monkeypatch: pytest.MonkeyPatch) -> None:
+    mock_resp = MagicMock()
+    mock_item = MagicMock()
+    mock_item.b64_json = None
+    mock_resp.data = [mock_item]
+
+    mock_client_inst = MagicMock()
+    mock_client_inst.images.generate = AsyncMock(return_value=mock_resp)
+
+    monkeypatch.setattr(provider, "_client", lambda: mock_client_inst)
+
+    with pytest.raises(ProviderAPIError, match="OpenAI returned no image"):
+        await provider.generate_image(prompt="nothing", tier="poor")


### PR DESCRIPTION
Implemented comprehensive unit tests for the OpenAI provider's generate_image function. Covered standard image generation, image editing with reference URLs, and error handling for empty responses. Utilized mocks for the OpenAI client and SSRF-safe media fetchers to ensure reliable execution.

---
*PR created automatically by Jules for task [14897006987635731131](https://jules.google.com/task/14897006987635731131) started by @n24q02m*