### PR TITLE
perf: loop optimization via set operation for configuration keys

### DIFF
--- a/src/imagine_mcp/server.py
+++ b/src/imagine_mcp/server.py
@@ -51,16 +51,13 @@ def _providers_configured() -> list[str]:
         "OPENAI_API_KEY": "openai",
         "XAI_API_KEY": "grok",
     }
-    seen: set[str] = set()
-    out: list[str] = []
-    for key in CREDENTIAL_KEYS:
-        provider = _key_to_provider.get(key, key)
-        if provider in seen:
-            continue
-        if os.environ.get(key):
-            out.append(provider)
-            seen.add(provider)
-    return out
+    return list(
+        dict.fromkeys(
+            _key_to_provider.get(key, key)
+            for key in CREDENTIAL_KEYS
+            if os.environ.get(key)
+        )
+    )
 
 
 def _providers_configured_live() -> list[str]:
@@ -79,16 +76,13 @@ def _providers_configured_live() -> list[str]:
         "OPENAI_API_KEY": "openai",
         "XAI_API_KEY": "grok",
     }
-    seen: set[str] = set()
-    out: list[str] = []
-    for key in CREDENTIAL_KEYS:
-        provider = _key_to_provider.get(key, key)
-        if provider in seen:
-            continue
-        if os.environ.get(key) or saved.get(key):
-            out.append(provider)
-            seen.add(provider)
-    return out
+    return list(
+        dict.fromkeys(
+            _key_to_provider.get(key, key)
+            for key in CREDENTIAL_KEYS
+            if os.environ.get(key) or saved.get(key)
+        )
+    )
 
 
 def _set_runtime(key: str | None, value: str | None) -> dict[str, Any]:

--- a/uv.lock
+++ b/uv.lock
@@ -709,7 +709,7 @@ wheels = [
 
 [[package]]
 name = "imagine-mcp"
-version = "1.7.0b11"
+version = "1.7.0b12"
 source = { editable = "." }
 dependencies = [
     { name = "diskcache" },


### PR DESCRIPTION
### Description
Optimized the provider configuration detection loops in `_providers_configured` and `_providers_configured_live` in `src/imagine_mcp/server.py`.

### Why
The original implementation used a manual loop with a `seen` set to deduplicate provider names while checking for existence in `os.environ` or `PerPluginStore`. Replacing this with a list comprehension and `dict.fromkeys()` provides a more idiomatic and efficient way to achieve the same result (deduplication while strictly preserving the order defined by `CREDENTIAL_KEYS`) in a more readable manner.

### Verification
- Ran full test suite with `uv run pytest`. All 257 tests passed.
- Ran linting and formatting with `uv run ruff check .` and `uv run ruff format .`. All checks passed.

---
*PR created automatically by Jules for task [14648127302136176012](https://jules.google.com/task/14648127302136176012) started by @n24q02m*