### PR TITLE
fix: resolve unbounded read size in download streams

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2025-06-23 - [HIGH] Unbounded download streams leading to DoS
+**Vulnerability:** Downloader allowed writing chunks to disk even if the total size exceeded the 50MB limit, by only checking the limit *after* writing the chunk. Additionally, it didn't check Content-Length headers early.
+**Learning:** Checking limits *after* an operation (like writing to disk) allows for a one-chunk "overread" and doesn't prevent resource consumption if the header already signals an oversized payload.
+**Prevention:** Always perform a pre-flight check on Content-Length headers if available, and validate that bytes_read + len(chunk) does not exceed the limit before processing/writing the chunk.

--- a/src/imagine_mcp/media.py
+++ b/src/imagine_mcp/media.py
@@ -36,6 +36,7 @@ _VIDEO_MIME_PREFIX = "video/"
 # Most image hosts serve JPEG, so it is the safest fallback when neither the
 # Content-Type header nor the magic bytes identify the format.
 _IMAGE_FALLBACK_MIME = "image/jpeg"
+_MAX_DOWNLOAD_SIZE = 50 * 1024 * 1024  # 50MB limit to prevent DoS
 
 
 def sniff_image_mime(data: bytes) -> str | None:
@@ -381,31 +382,49 @@ def _extract_extension(url: str) -> str:
 
 
 def _write_response(resp: httpx.Response, dest: Path) -> None:
-    max_size = 50 * 1024 * 1024  # 50MB limit to prevent DoS
+    content_length_str = resp.headers.get("Content-Length")
+    if content_length_str:
+        try:
+            if int(content_length_str) > _MAX_DOWNLOAD_SIZE:
+                raise httpx.HTTPError(
+                    f"Download failed: Content-Length {content_length_str} exceeds limit of {_MAX_DOWNLOAD_SIZE} bytes"
+                )
+        except ValueError:
+            pass
+
     bytes_read = 0
     with dest.open("wb") as f:
         for chunk in resp.iter_bytes(chunk_size=65536):
-            bytes_read += len(chunk)
-            if bytes_read > max_size:
+            if bytes_read + len(chunk) > _MAX_DOWNLOAD_SIZE:
                 raise httpx.HTTPError(
-                    f"Download failed: Exceeded maximum size of {max_size} bytes"
+                    f"Download failed: Exceeded maximum size of {_MAX_DOWNLOAD_SIZE} bytes"
                 )
             f.write(chunk)
+            bytes_read += len(chunk)
 
 
 async def _write_response_async(resp: httpx.Response, dest: Path) -> None:
-    max_size = 50 * 1024 * 1024  # 50MB limit to prevent DoS
+    content_length_str = resp.headers.get("Content-Length")
+    if content_length_str:
+        try:
+            if int(content_length_str) > _MAX_DOWNLOAD_SIZE:
+                raise httpx.HTTPError(
+                    f"Download failed: Content-Length {content_length_str} exceeds limit of {_MAX_DOWNLOAD_SIZE} bytes"
+                )
+        except ValueError:
+            pass
+
     bytes_read = 0
     # ⚡ Bolt: Replace high-overhead asyncio.to_thread with anyio.open_file
     # Expected impact: Dramatically reduces context-switching overhead on file chunk writes
     async with await anyio.open_file(dest, "wb") as f:
         async for chunk in resp.aiter_bytes(chunk_size=65536):
-            bytes_read += len(chunk)
-            if bytes_read > max_size:
+            if bytes_read + len(chunk) > _MAX_DOWNLOAD_SIZE:
                 raise httpx.HTTPError(
-                    f"Download failed: Exceeded maximum size of {max_size} bytes"
+                    f"Download failed: Exceeded maximum size of {_MAX_DOWNLOAD_SIZE} bytes"
                 )
             await f.write(chunk)
+            bytes_read += len(chunk)
 
 
 def download_to_path(url: str, dest: Path) -> Path:

--- a/tests/test_media.py
+++ b/tests/test_media.py
@@ -1,24 +1,24 @@
 from __future__ import annotations
 
 import concurrent.futures
-import pytest
 import socket
-from unittest.mock import MagicMock, AsyncMock
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock
 
+import httpx
+import pytest
 
 from imagine_mcp.errors import InvalidURLError, MediaDetectError
-import httpx
-from pathlib import Path
 from imagine_mcp.media import (
+    _MAX_DOWNLOAD_SIZE,
     SSRFSafeTransport,
     _extract_extension,
     detect_media_type,
     download_to_path,
+    download_to_path_async,
     resolve_image_mime,
     sniff_image_mime,
     validate_url_and_get_ip,
-    download_to_path_async,
-    _MAX_DOWNLOAD_SIZE,
 )
 
 _PNG = b"\x89PNG\r\n\x1a\n" + b"\x00" * 16
@@ -346,9 +346,9 @@ class TestSSRFProtection:
         assert called["validated"] is False
 
 
-
-
-def test_download_to_path_content_length_limit(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+def test_download_to_path_content_length_limit(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
     dest = tmp_path / "test.png"
 
     mock_response = MagicMock()
@@ -366,8 +366,11 @@ def test_download_to_path_content_length_limit(monkeypatch: pytest.MonkeyPatch, 
     with pytest.raises(httpx.HTTPError, match="exceeds limit"):
         download_to_path("https://example.com/too-large.png", dest)
 
+
 @pytest.mark.asyncio
-async def test_download_to_path_async_content_length_limit(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+async def test_download_to_path_async_content_length_limit(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
     dest = tmp_path / "test.png"
 
     mock_response = MagicMock()
@@ -382,21 +385,28 @@ async def test_download_to_path_async_content_length_limit(monkeypatch: pytest.M
         def stream(self, method, url, **kw):
             return mock_response
 
-    monkeypatch.setattr("imagine_mcp.media.get_ssrf_safe_async_client", lambda: MockClient())
+    monkeypatch.setattr(
+        "imagine_mcp.media.get_ssrf_safe_async_client", lambda: MockClient()
+    )
 
     with pytest.raises(httpx.HTTPError, match="exceeds limit"):
         await download_to_path_async("https://example.com/too-large.png", dest)
 
-def test_download_to_path_streaming_limit(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+
+def test_download_to_path_streaming_limit(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
     dest = tmp_path / "test.png"
 
     mock_response = MagicMock()
     mock_response.__enter__.return_value = mock_response
     mock_response.__exit__.return_value = None
-    mock_response.headers = {} # No content length
+    mock_response.headers = {}  # No content length
     mock_response.raise_for_status = MagicMock()
     # First chunk is okay, second chunk exceeds limit
-    mock_response.iter_bytes = MagicMock(return_value=[b"a" * (_MAX_DOWNLOAD_SIZE - 10), b"b" * 20])
+    mock_response.iter_bytes = MagicMock(
+        return_value=[b"a" * (_MAX_DOWNLOAD_SIZE - 10), b"b" * 20]
+    )
 
     class MockClient:
         def stream(self, method, url, **kw):
@@ -407,8 +417,11 @@ def test_download_to_path_streaming_limit(monkeypatch: pytest.MonkeyPatch, tmp_p
     with pytest.raises(httpx.HTTPError, match="Exceeded maximum size"):
         download_to_path("https://example.com/streaming-large.png", dest)
 
+
 @pytest.mark.asyncio
-async def test_download_to_path_async_streaming_limit(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+async def test_download_to_path_async_streaming_limit(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
     dest = tmp_path / "test.png"
 
     mock_response = MagicMock()
@@ -428,7 +441,9 @@ async def test_download_to_path_async_streaming_limit(monkeypatch: pytest.Monkey
         def stream(self, method, url, **kw):
             return mock_response
 
-    monkeypatch.setattr("imagine_mcp.media.get_ssrf_safe_async_client", lambda: MockClient())
+    monkeypatch.setattr(
+        "imagine_mcp.media.get_ssrf_safe_async_client", lambda: MockClient()
+    )
 
     with pytest.raises(httpx.HTTPError, match="Exceeded maximum size"):
         await download_to_path_async("https://example.com/streaming-large.png", dest)

--- a/tests/test_media.py
+++ b/tests/test_media.py
@@ -1,14 +1,14 @@
 from __future__ import annotations
 
 import concurrent.futures
-import socket
-from pathlib import Path
-from unittest.mock import MagicMock
-
-import httpx
 import pytest
+import socket
+from unittest.mock import MagicMock, AsyncMock
+
 
 from imagine_mcp.errors import InvalidURLError, MediaDetectError
+import httpx
+from pathlib import Path
 from imagine_mcp.media import (
     SSRFSafeTransport,
     _extract_extension,
@@ -17,6 +17,8 @@ from imagine_mcp.media import (
     resolve_image_mime,
     sniff_image_mime,
     validate_url_and_get_ip,
+    download_to_path_async,
+    _MAX_DOWNLOAD_SIZE,
 )
 
 _PNG = b"\x89PNG\r\n\x1a\n" + b"\x00" * 16
@@ -342,3 +344,91 @@ class TestSSRFProtection:
         transport = SSRFSafeTransport()
         transport.handle_request(httpx.Request("GET", "file:///etc/passwd"))
         assert called["validated"] is False
+
+
+
+
+def test_download_to_path_content_length_limit(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    dest = tmp_path / "test.png"
+
+    mock_response = MagicMock()
+    mock_response.__enter__.return_value = mock_response
+    mock_response.__exit__.return_value = None
+    mock_response.headers = {"Content-Length": str(_MAX_DOWNLOAD_SIZE + 1)}
+    mock_response.raise_for_status = MagicMock()
+
+    class MockClient:
+        def stream(self, method, url, **kw):
+            return mock_response
+
+    monkeypatch.setattr("imagine_mcp.media.get_ssrf_safe_client", lambda: MockClient())
+
+    with pytest.raises(httpx.HTTPError, match="exceeds limit"):
+        download_to_path("https://example.com/too-large.png", dest)
+
+@pytest.mark.asyncio
+async def test_download_to_path_async_content_length_limit(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    dest = tmp_path / "test.png"
+
+    mock_response = MagicMock()
+    mock_response.headers = {"Content-Length": str(_MAX_DOWNLOAD_SIZE + 1)}
+    mock_response.raise_for_status = MagicMock()
+
+    # aenter/aexit for async with
+    mock_response.__aenter__ = AsyncMock(return_value=mock_response)
+    mock_response.__aexit__ = AsyncMock(return_value=None)
+
+    class MockClient:
+        def stream(self, method, url, **kw):
+            return mock_response
+
+    monkeypatch.setattr("imagine_mcp.media.get_ssrf_safe_async_client", lambda: MockClient())
+
+    with pytest.raises(httpx.HTTPError, match="exceeds limit"):
+        await download_to_path_async("https://example.com/too-large.png", dest)
+
+def test_download_to_path_streaming_limit(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    dest = tmp_path / "test.png"
+
+    mock_response = MagicMock()
+    mock_response.__enter__.return_value = mock_response
+    mock_response.__exit__.return_value = None
+    mock_response.headers = {} # No content length
+    mock_response.raise_for_status = MagicMock()
+    # First chunk is okay, second chunk exceeds limit
+    mock_response.iter_bytes = MagicMock(return_value=[b"a" * (_MAX_DOWNLOAD_SIZE - 10), b"b" * 20])
+
+    class MockClient:
+        def stream(self, method, url, **kw):
+            return mock_response
+
+    monkeypatch.setattr("imagine_mcp.media.get_ssrf_safe_client", lambda: MockClient())
+
+    with pytest.raises(httpx.HTTPError, match="Exceeded maximum size"):
+        download_to_path("https://example.com/streaming-large.png", dest)
+
+@pytest.mark.asyncio
+async def test_download_to_path_async_streaming_limit(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    dest = tmp_path / "test.png"
+
+    mock_response = MagicMock()
+    mock_response.headers = {}
+    mock_response.raise_for_status = MagicMock()
+    mock_response.__aenter__ = AsyncMock(return_value=mock_response)
+    mock_response.__aexit__ = AsyncMock(return_value=None)
+
+    # Mock aiter_bytes
+    async def mock_aiter_bytes(chunk_size=None):
+        yield b"a" * (_MAX_DOWNLOAD_SIZE - 10)
+        yield b"b" * 20
+
+    mock_response.aiter_bytes = mock_aiter_bytes
+
+    class MockClient:
+        def stream(self, method, url, **kw):
+            return mock_response
+
+    monkeypatch.setattr("imagine_mcp.media.get_ssrf_safe_async_client", lambda: MockClient())
+
+    with pytest.raises(httpx.HTTPError, match="Exceeded maximum size"):
+        await download_to_path_async("https://example.com/streaming-large.png", dest)

--- a/uv.lock
+++ b/uv.lock
@@ -709,7 +709,7 @@ wheels = [
 
 [[package]]
 name = "imagine-mcp"
-version = "1.7.0b11"
+version = "1.7.0b12"
 source = { editable = "." }
 dependencies = [
     { name = "diskcache" },


### PR DESCRIPTION
This PR addresses a potential DoS vulnerability in \`src/imagine_mcp/media.py\`. 

**Changes:**
1. Defined \`_MAX_DOWNLOAD_SIZE = 50 * 1024 * 1024\` as a constant.
2. Updated \`_write_response\` and \`_write_response_async\` to:
   - Check the \`Content-Length\` header immediately and fail if it exceeds the limit.
   - Check if \`bytes_read + len(chunk)\` exceeds the limit *before* writing the chunk to disk, preventing a one-chunk overread and resource exhaustion.
3. Added comprehensive regression tests in \`tests/test_media.py\`.
4. Documented the fix in \`.jules/sentinel.md\`.

All 261 tests passed.

---
*PR created automatically by Jules for task [18383755627737617581](https://jules.google.com/task/18383755627737617581) started by @n24q02m*