### PR TITLE
fix: [SECURITY] missing validation of PUBLIC_URL schema

### DIFF
--- a/src/imagine_mcp/server.py
+++ b/src/imagine_mcp/server.py
@@ -8,6 +8,7 @@ from functools import cache
 from importlib.resources import files
 from pathlib import Path
 from typing import Any, Literal
+from urllib.parse import urlparse
 
 import platformdirs
 from fastmcp import FastMCP
@@ -318,15 +319,26 @@ async def run_http(port: int = 0) -> None:
 
     public_url = os.environ.get("PUBLIC_URL")
     if public_url:
+        parsed = urlparse(public_url)
+        if parsed.scheme.lower() not in ("http", "https"):
+            raise SystemExit(
+                f"imagine-mcp refuses to start: Invalid PUBLIC_URL scheme {parsed.scheme!r}. "
+                "Only http/https are allowed."
+            )
+        if not parsed.hostname:
+            raise SystemExit(
+                "imagine-mcp refuses to start: Invalid PUBLIC_URL: missing hostname."
+            )
+
         if not os.environ.get("MCP_DCR_SERVER_SECRET"):
             raise SystemExit(
                 "imagine-mcp refuses to start: PUBLIC_URL set but "
                 "MCP_DCR_SERVER_SECRET missing. Multi-user remote mode "
                 "requires the DCR secret."
             )
-        host = os.environ.get("MCP_HOST", "127.0.0.1")
         port = int(os.environ.get("MCP_PORT", "8080"))
         mode_label = "http remote relay (multi-user)"
+        host = os.environ.get("MCP_HOST", "127.0.0.1")
     else:
         host = "127.0.0.1"
         mode_label = "http local relay"

--- a/uv.lock
+++ b/uv.lock
@@ -709,7 +709,7 @@ wheels = [
 
 [[package]]
 name = "imagine-mcp"
-version = "1.7.0b11"
+version = "1.7.0b12"
 source = { editable = "." }
 dependencies = [
     { name = "diskcache" },


### PR DESCRIPTION
This PR adds validation for the `PUBLIC_URL` environment variable in `src/imagine_mcp/server.py`.
Previously, the code checked for the presence of `PUBLIC_URL` but did not verify if it was a valid URL.
The fix ensures that:
1. The URL scheme is either `http` or `https`.
2. The URL contains a valid hostname.
If validation fails, the server raises `SystemExit` with a descriptive error message, preventing the application from starting in an insecure or misconfigured state.

---
*PR created automatically by Jules for task [5100080066881328051](https://jules.google.com/task/5100080066881328051) started by @n24q02m*