### PR TITLE
fix: 🛡️ Sentinel: [MEDIUM] fix extension bypass vulnerability

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2025-06-23 - Robust Extension Extraction
+**Vulnerability:** Use of unsafe os.path.splitext() which could be vulnerable to bypass or unexpected results with malicious inputs.
+**Learning:** Standard library functions like os.path.splitext() are useful but may not enforce strict enough constraints for security-sensitive operations. Validating the output against a strict allowlist (e.g., alphanumeric, length-limited) is essential.
+**Prevention:** Always validate file extensions against a strict regex or character set (isalnum) and enforce reasonable length limits.

--- a/src/imagine_mcp/media.py
+++ b/src/imagine_mcp/media.py
@@ -377,7 +377,12 @@ def _extract_extension(url: str) -> str:
     """Return lowercase file extension including dot, or '' if none."""
     path = url.split("?", 1)[0].split("#", 1)[0]
     _, ext = os.path.splitext(path)
-    return ext.lower()
+    ext = ext.lower()
+    # Security: Ensure extension is strictly alphanumeric and length-limited
+    # (1-10 chars after the dot).
+    if not ext.startswith(".") or not ext[1:].isalnum() or not (2 <= len(ext) <= 11):
+        return ""
+    return ext
 
 
 def _write_response(resp: httpx.Response, dest: Path) -> None:

--- a/tests/test_security_media.py
+++ b/tests/test_security_media.py
@@ -1,0 +1,39 @@
+from __future__ import annotations
+
+from imagine_mcp.media import _extract_extension
+
+
+def test_extract_extension_security() -> None:
+    # Valid extensions
+    assert _extract_extension("https://example.com/foo.png") == ".png"
+    assert _extract_extension("https://example.com/foo.jpg") == ".jpg"
+    assert _extract_extension("https://example.com/foo.jpeg") == ".jpeg"
+    assert _extract_extension("https://example.com/foo.MP4") == ".mp4"
+
+    # Valid extensions with query/fragment
+    assert _extract_extension("https://example.com/foo.png?q=1") == ".png"
+    assert _extract_extension("https://example.com/foo.png#hash") == ".png"
+
+    # Overly long extensions (> 10 chars after dot)
+    assert _extract_extension("https://example.com/foo.verylongextension") == ""
+    assert _extract_extension("https://example.com/foo.abcdefghijk") == ""  # 11 chars
+    assert (
+        _extract_extension("https://example.com/foo.abcdefghij") == ".abcdefghij"
+    )  # 10 chars
+
+    # Non-alphanumeric extensions
+    assert (
+        _extract_extension("https://example.com/foo.png.php") == ".php"
+    )  # This is fine, it gets the last one
+    assert _extract_extension("https://example.com/foo.p_n") == ""
+    assert _extract_extension("https://example.com/foo.p-n") == ""
+
+    # No extension or empty extension
+    assert _extract_extension("https://example.com/foo") == ""
+    assert _extract_extension("https://example.com/foo.") == ""
+
+    # Edge cases
+    assert _extract_extension("https://example.com/.ssh/config") == ""
+    assert (
+        _extract_extension("https://example.com/foo.123") == ".123"
+    )  # Alphanumeric includes numbers


### PR DESCRIPTION
🛡️ Sentinel: [MEDIUM] Fix extension bypass vulnerability

**Vulnerability:** Use of unsafe os.path.splitext() which could be vulnerable to bypass.
**Impact:** Maliciously crafted URLs could bypass media type detection or cause unexpected behavior by using non-alphanumeric characters, null bytes, or excessively long extensions.
**Fix:** Hardened the `_extract_extension` function in `src/imagine_mcp/media.py` to strictly enforce that extracted extensions (excluding the leading dot) are alphanumeric and between 1 and 10 characters in length.
**Verification:** 
- Created `tests/test_security_media.py` verifying valid/invalid extensions, length limits, and character validation.
- Verified that existing tests in `tests/test_media.py` pass.
- Verified that the full test suite passes.
- Verified linting and formatting.

---
*PR created automatically by Jules for task [11790530017159636277](https://jules.google.com/task/11790530017159636277) started by @n24q02m*