### PR TITLE
perf: optimize provider configuration deduplication

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -32,3 +32,7 @@
 ## 2026-06-13 - Request-Scoped ContextVar Caching for Sub-Aware Configurations
 **Learning:** `config_value_for_current_request` in `src/imagine_mcp/credential_state.py` retrieved configurations directly via `read_for_sub(sub)` for every lookup (like `UNDERSTAND_MODELS` and `GENERATE_MODELS` chained across requests). Since `read_for_sub` invokes `PerPluginStore.load()` internally, this introduced redundant disk I/O, JSON parsing, and AES-GCM decryption for *each* configuration variable requested during a single tool call. Even though credentials were being cached via the `_request_creds` `ContextVar`, the configuration lookups were incorrectly bypassing that cache.
 **Action:** Always route configuration variable lookups through the same request-scoped cache used for credentials when operating under the same tenant isolation boundaries, avoiding repetitive and expensive I/O operations per key.
+
+## 2026-06-26 - Optimize sequence deduplication
+**Learning:** Manual loops that use a `seen` set and list `append` to deduplicate an ordered sequence introduce unnecessary Python-level iteration overhead. Python dictionaries preserve insertion order, making `list(dict.fromkeys(...))` a much faster native mechanism for producing an ordered, deduplicated list.
+**Action:** Replace `seen` set loops with `list(dict.fromkeys(generator_expression))` to speed up sequence deduplication while strictly preserving element order.

--- a/src/imagine_mcp/server.py
+++ b/src/imagine_mcp/server.py
@@ -51,16 +51,15 @@ def _providers_configured() -> list[str]:
         "OPENAI_API_KEY": "openai",
         "XAI_API_KEY": "grok",
     }
-    seen: set[str] = set()
-    out: list[str] = []
-    for key in CREDENTIAL_KEYS:
-        provider = _key_to_provider.get(key, key)
-        if provider in seen:
-            continue
-        if os.environ.get(key):
-            out.append(provider)
-            seen.add(provider)
-    return out
+    # ⚡ Bolt: Deduplicate via dict keys natively to avoid Python loop overhead
+    # Expected impact: Faster list generation while strictly preserving order
+    return list(
+        dict.fromkeys(
+            _key_to_provider.get(key, key)
+            for key in CREDENTIAL_KEYS
+            if os.environ.get(key)
+        )
+    )
 
 
 def _providers_configured_live() -> list[str]:
@@ -79,16 +78,15 @@ def _providers_configured_live() -> list[str]:
         "OPENAI_API_KEY": "openai",
         "XAI_API_KEY": "grok",
     }
-    seen: set[str] = set()
-    out: list[str] = []
-    for key in CREDENTIAL_KEYS:
-        provider = _key_to_provider.get(key, key)
-        if provider in seen:
-            continue
-        if os.environ.get(key) or saved.get(key):
-            out.append(provider)
-            seen.add(provider)
-    return out
+    # ⚡ Bolt: Deduplicate via dict keys natively to avoid Python loop overhead
+    # Expected impact: Faster list generation while strictly preserving order
+    return list(
+        dict.fromkeys(
+            _key_to_provider.get(key, key)
+            for key in CREDENTIAL_KEYS
+            if os.environ.get(key) or saved.get(key)
+        )
+    )
 
 
 def _set_runtime(key: str | None, value: str | None) -> dict[str, Any]:


### PR DESCRIPTION
💡 **What:** Refactored `_providers_configured` and `_providers_configured_live` in `src/imagine_mcp/server.py` to use `list(dict.fromkeys(...))` instead of manual `seen` set loops.
🎯 **Why:** To eliminate the overhead of Python-level list appends and set lookups inside tight credential mapping logic, leaning on fast, native C implementation of dictionaries which preserve insertion order.
📊 **Impact:** Speeds up sequence deduplication during server configuration queries and capability checks, resulting in slightly faster execution with zero changes to system behavior.
🔬 **Measurement:** Code logic continues to pass unit tests verbatim while strictly preserving provider order natively. Verified by running the entire test suite `uv run pytest` and linters.

---
*PR created automatically by Jules for task [15504313515740017717](https://jules.google.com/task/15504313515740017717) started by @n24q02m*