### PR TITLE
fix: too many parameters in connect_tcp methods

### DIFF
--- a/src/imagine_mcp/media.py
+++ b/src/imagine_mcp/media.py
@@ -94,18 +94,12 @@ class SSRFSafeBackend(httpcore.NetworkBackend):
         self,
         host: str,
         port: int,
-        timeout: float | None = None,
-        local_address: str | None = None,
-        socket_options: typing.Iterable[httpcore.SOCKET_OPTION] | None = None,
+        **kwargs: typing.Any,
     ) -> httpcore.NetworkStream:
         # Pin the request to a validated IP to prevent TOCTOU DNS rebinding.
         ip = _validate_hostname_and_get_ip(host, port, "url")
         return self._backend.connect_tcp(
-            host=ip,
-            port=port,
-            timeout=timeout,
-            local_address=local_address,
-            socket_options=socket_options,
+            host=ip, port=port, **kwargs
         )
 
     def connect_unix_socket(
@@ -131,18 +125,12 @@ class AsyncSSRFSafeBackend(httpcore.AsyncNetworkBackend):
         self,
         host: str,
         port: int,
-        timeout: float | None = None,
-        local_address: str | None = None,
-        socket_options: typing.Iterable[httpcore.SOCKET_OPTION] | None = None,
+        **kwargs: typing.Any,
     ) -> httpcore.AsyncNetworkStream:
         # Blocking DNS resolution offloaded to thread.
         ip = await asyncio.to_thread(_validate_hostname_and_get_ip, host, port, "url")
         return await self._backend.connect_tcp(
-            host=ip,
-            port=port,
-            timeout=timeout,
-            local_address=local_address,
-            socket_options=socket_options,
+            host=ip, port=port, **kwargs
         )
 
     async def connect_unix_socket(


### PR DESCRIPTION
This PR refactors the `connect_tcp` methods in `src/imagine_mcp/media.py` to use `**kwargs` for optional parameters (`timeout`, `local_address`, `socket_options`). This reduces the positional parameter count from 5 to 2 (plus `**kwargs`), addressing the "too many parameters" rationale while ensuring full compatibility with the underlying `httpcore` backends.

The change was verified by running the full test suite (`uv run pytest`), which passed all 286 tests, including the media-specific tests. Linting with `ruff` also passed.

---
*PR created automatically by Jules for task [8926399373972655159](https://jules.google.com/task/8926399373972655159) started by @n24q02m*