### PR TITLE
[SECURITY] Use of unsafe os.path.splitext() which could be vulnerable to bypass

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -7,3 +7,7 @@
 **Vulnerability:** The leaderboard fetch script used `iter_text()` and accumulated chunks without a pre-flight `Content-Length` check, and only checked the size *after* incrementing a counter, potentially allowing memory exhaustion DoS.
 **Learning:** Even internal-use scripts that fetch data from external sources must follow strict download safety patterns (pre-flight checks and check-before-append).
 **Prevention:** Use `iter_bytes()` for precise byte counting, perform pre-flight `Content-Length` checks, and always validate the predicted total size (`bytes_read + len(chunk)`) against the limit *before* adding data to in-memory buffers.
+## 2026-06-29 - [LOW] Unsafe os.path.splitext() in URL handling
+**Vulnerability:** Use of `os.path.splitext()` for URL extensions is platform-dependent and susceptible to bypasses if query parameters or fragments are not perfectly stripped.
+**Learning:** `os.path.splitext()` follows the host OS's path rules (e.g., handling backslashes on Windows), which may not align with URL path semantics. Also, manual string splitting for URL components is error-prone compared to standard `urlparse`.
+**Prevention:** Use `urllib.parse.urlparse` to extract the path from a URL, and use `posixpath.splitext()` to ensure consistent extension extraction regardless of the server's operating system.

--- a/src/imagine_mcp/media.py
+++ b/src/imagine_mcp/media.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import asyncio
 import concurrent.futures
 import ipaddress
-import os
+import posixpath
 import socket
 import threading
 import typing
@@ -376,11 +376,18 @@ async def detect_media_type_async(url: str) -> MediaType:
 
 def _extract_extension(url: str) -> str:
     """Return lowercase file extension including dot, or '' if none."""
-    path = url.split("?", 1)[0].split("#", 1)[0]
-    _, ext = os.path.splitext(path)
-    ext = ext.lower()
-    if ext.startswith(".") and 1 <= len(ext) - 1 <= 10 and ext[1:].isalnum():
-        return ext
+    try:
+        parsed = urlparse(url)
+        path = parsed.path
+        if not path:
+            return ""
+        # Use posixpath for URL paths to ensure consistent behavior across platforms
+        _, ext = posixpath.splitext(path)
+        ext = ext.lower()
+        if ext.startswith(".") and 1 <= len(ext) - 1 <= 10 and ext[1:].isalnum():
+            return ext
+    except Exception:
+        pass
     return ""
 
 

--- a/tests/test_media.py
+++ b/tests/test_media.py
@@ -58,6 +58,23 @@ def test_resolve_image_mime_unknown_falls_back_to_jpeg() -> None:
     assert resolve_image_mime("text/html", b"\x00\x01\x02\x03") == "image/jpeg"
 
 
+def test_extract_extension_robustness() -> None:
+    from imagine_mcp.media import _extract_extension
+
+    assert _extract_extension("https://example.com/foo.png") == ".png"
+    assert _extract_extension("https://example.com/bar.jpg?w=100") == ".jpg"
+    assert _extract_extension("https://example.com/x.webp#anchor") == ".webp"
+    assert _extract_extension("http://example.png") == ""
+    assert _extract_extension("https://my.image.png/path/file.gif") == ".gif"
+    assert _extract_extension("https://example.com/file.PNG") == ".png"
+    assert _extract_extension("https://example.com/file.verylongextension") == ""
+    assert _extract_extension("https://example.com/file.123") == ".123"
+    assert _extract_extension("https://example.com/file.png.exe") == ".exe"
+    assert _extract_extension("https://example.com/path.with.dots/file.jpg") == ".jpg"
+    assert _extract_extension("https://example.com/") == ""
+    assert _extract_extension("https://example.com") == ""
+
+
 def test_detect_by_extension_image() -> None:
     assert detect_media_type("https://example.com/foo.png") == "image"
     assert detect_media_type("https://example.com/bar.jpg?w=100") == "image"


### PR DESCRIPTION
I have updated the `_extract_extension` function in `src/imagine_mcp/media.py` to be more robust and secure.
- Replaced manual string splitting for query and fragment removal with `urllib.parse.urlparse`.
- Replaced `os.path.splitext` with `posixpath.splitext` to ensure consistent behavior across platforms (since URLs use forward slashes regardless of the host OS).
- Maintained strict alphanumeric and length validation for the extracted extension.
- Added comprehensive robustness tests in `tests/test_media.py`.
- Updated `.jules/sentinel.md` with the security learning.

---
*PR created automatically by Jules for task [12718036557379716178](https://jules.google.com/task/12718036557379716178) started by @n24q02m*