### PR TITLE
test: achieve 100% coverage for dispatcher validation

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -36,3 +36,11 @@
 ## 2024-05-18 - [TEST] Mocking threaded DNS resolution in dispatcher
 **Learning:** The `_validate_url` function in `src/imagine_mcp/dispatcher.py` wraps the blocking `validate_url_and_get_ip` call using `asyncio.to_thread`. To test this without triggering real DNS resolution or hitting sandbox network limits, `monkeypatch` can be used to swap the internal `validate_url_and_get_ip` reference with a synchronous mock. This ensures the test remains fast and deterministic while still verifying that the dispatcher correctly awaits the threaded work and propagates exceptions.
 **Action:** Use `monkeypatch.setattr` to mock blocking functions wrapped in `asyncio.to_thread` when writing unit tests for async dispatchers.
+
+## 2024-06-14 - [TEST] Achieve 100% coverage for dispatcher validation logic
+**Learning:** achieved 100% test coverage for  by targeting previously untested edge cases in  error propagation and configuration-driven provider selection. Mocking internal async utilities like  and  (which wraps threaded blocking I/O) allows for robust unit testing of high-level dispatch logic without actual network dependencies.
+**Action:** When extending test coverage for dispatchers, use a dedicated extension test file to isolate new edge cases and mock all internal network-bound helpers to ensure test suite stability and speed.
+
+## 2024-06-14 - [TEST] Achieve 100% coverage for dispatcher validation logic
+**Learning:** Achieved 100% test coverage for `src/imagine_mcp/dispatcher.py` by targeting previously untested edge cases in `asyncio.gather` error propagation and configuration-driven provider selection. Mocking internal async utilities like `detect_media_type_async` and `_validate_url` (which wraps threaded blocking I/O) allows for robust unit testing of high-level dispatch logic without actual network dependencies.
+**Action:** When extending test coverage for dispatchers, use a dedicated extension test file to isolate new edge cases and mock all internal network-bound helpers to ensure test suite stability and speed.

--- a/tests/test_dispatcher_validation_ext.py
+++ b/tests/test_dispatcher_validation_ext.py
@@ -1,0 +1,324 @@
+from __future__ import annotations
+
+from unittest.mock import AsyncMock
+
+import pytest
+
+from imagine_mcp.dispatcher import (
+    _passthrough_api_key,
+    dispatch_generate,
+    dispatch_understand,
+    resolve_generate_provider_priority,
+)
+from imagine_mcp.errors import (
+    CredentialMissingError,
+    InvalidMediaTypeError,
+    InvalidURLError,
+)
+
+
+@pytest.fixture
+def clean_provider_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Ensure no provider API key is leaking from the host environment."""
+    for var in ("XAI_API_KEY", "OPENAI_API_KEY", "GEMINI_API_KEY"):
+        monkeypatch.delenv(var, raising=False)
+
+
+@pytest.mark.asyncio
+async def test_dispatch_understand_empty_media_urls() -> None:
+    with pytest.raises(InvalidMediaTypeError, match="media_urls is empty"):
+        await dispatch_understand(
+            media_urls=[],
+            prompt="describe",
+            provider="gemini",
+            tier="poor",
+        )
+
+
+@pytest.mark.asyncio
+async def test_dispatch_understand_validate_url_failure(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def mock_validate(url: str, param: str) -> None:
+        raise InvalidURLError("mocked failure")
+
+    monkeypatch.setattr("imagine_mcp.dispatcher.validate_url_and_get_ip", mock_validate)
+
+    with pytest.raises(InvalidURLError, match="mocked failure"):
+        await dispatch_understand(
+            media_urls=["https://example.com/cat.png"],
+            prompt="describe",
+            provider="gemini",
+            tier="poor",
+        )
+
+
+@pytest.mark.asyncio
+async def test_passthrough_understand_empty_media_urls() -> None:
+    # Trigger passthrough by providing a model
+    with pytest.raises(InvalidMediaTypeError, match="media_urls is empty"):
+        await dispatch_understand(
+            media_urls=[],
+            prompt="describe",
+            provider=None,
+            tier="poor",
+            model="openai/gpt-4o",
+        )
+
+
+@pytest.mark.asyncio
+async def test_dispatch_understand_detect_media_type_failure(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        "imagine_mcp.dispatcher.detect_media_type_async",
+        AsyncMock(side_effect=Exception("detect failure")),
+    )
+    # Stub URL validation so it doesn't fail first
+    monkeypatch.setattr(
+        "imagine_mcp.dispatcher._validate_url", AsyncMock(return_value=None)
+    )
+
+    with pytest.raises(Exception, match="detect failure"):
+        await dispatch_understand(
+            media_urls=["https://example.com/cat.png"],
+            prompt="describe",
+            provider="gemini",
+            tier="poor",
+        )
+
+
+@pytest.mark.asyncio
+async def test_dispatch_understand_gemini_multimodal(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    mock_multimodal = AsyncMock(return_value={"text": "multimodal ok"})
+    import imagine_mcp.providers.gemini as gemini_mod
+
+    monkeypatch.setattr(gemini_mod, "understand_multimodal", mock_multimodal)
+    monkeypatch.setattr(
+        "imagine_mcp.dispatcher.detect_media_type_async",
+        AsyncMock(return_value="image"),
+    )
+    monkeypatch.setattr(
+        "imagine_mcp.dispatcher._validate_url", AsyncMock(return_value=None)
+    )
+
+    result = await dispatch_understand(
+        media_urls=["https://example.com/1.png", "https://example.com/2.png"],
+        prompt="describe",
+        provider="gemini",
+        tier="poor",
+    )
+    assert result == {"text": "multimodal ok"}
+    assert mock_multimodal.called
+
+
+@pytest.mark.asyncio
+async def test_dispatch_understand_video(monkeypatch: pytest.MonkeyPatch) -> None:
+    mock_video = AsyncMock(return_value={"text": "video ok"})
+    import imagine_mcp.providers.gemini as gemini_mod
+
+    monkeypatch.setattr(gemini_mod, "understand_video", mock_video)
+    monkeypatch.setattr(
+        "imagine_mcp.dispatcher.detect_media_type_async",
+        AsyncMock(return_value="video"),
+    )
+    monkeypatch.setattr(
+        "imagine_mcp.dispatcher._validate_url", AsyncMock(return_value=None)
+    )
+
+    result = await dispatch_understand(
+        media_urls=["https://example.com/video.mp4"],
+        prompt="describe",
+        provider="gemini",
+        tier="poor",
+    )
+    assert result == {"text": "video ok"}
+    assert mock_video.called
+
+
+@pytest.mark.asyncio
+async def test_dispatch_generate_video(monkeypatch: pytest.MonkeyPatch) -> None:
+    mock_gen_video = AsyncMock(return_value={"video": "ok"})
+    import imagine_mcp.providers.gemini as gemini_mod
+
+    monkeypatch.setattr(gemini_mod, "generate_video", mock_gen_video)
+    monkeypatch.setattr(
+        "imagine_mcp.dispatcher._validate_url", AsyncMock(return_value=None)
+    )
+
+    result = await dispatch_generate(
+        media_type="video",
+        prompt="a video",
+        provider="gemini",
+        tier="poor",
+    )
+    assert result == {"video": "ok"}
+    assert mock_gen_video.called
+
+
+@pytest.mark.asyncio
+async def test_default_provider_credential_missing(
+    clean_provider_env: None, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # Ensure no credentials are set in PerPluginStore either
+    monkeypatch.setattr(
+        "imagine_mcp.credential_state.credentials_for_current_request",
+        lambda: {},
+    )
+
+    with pytest.raises(CredentialMissingError, match="No provider API key configured"):
+        await dispatch_understand(
+            media_urls=["https://example.com/cat.png"],
+            prompt="describe",
+            provider=None,
+            tier="poor",
+        )
+
+
+@pytest.mark.asyncio
+async def test_dispatch_generate_validate_url_failure(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def mock_validate(url: str, param: str) -> None:
+        raise InvalidURLError("mocked failure")
+
+    monkeypatch.setattr("imagine_mcp.dispatcher.validate_url_and_get_ip", mock_validate)
+
+    with pytest.raises(InvalidURLError, match="mocked failure"):
+        await dispatch_generate(
+            media_type="image",
+            prompt="a cat",
+            provider="gemini",
+            tier="poor",
+            reference_image_url="https://example.com/ref.png",
+        )
+
+
+def test_resolve_generate_provider_priority_custom(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        "imagine_mcp.credential_state.config_value_for_current_request",
+        lambda x: "openai,gemini" if x == "GENERATE_PROVIDER_PRIORITY" else None,
+    )
+    assert resolve_generate_provider_priority() == ["openai", "gemini"]
+
+
+@pytest.mark.asyncio
+async def test_passthrough_understand_validate_url_failure(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def mock_validate(url: str, param: str) -> None:
+        raise InvalidURLError("mocked failure")
+
+    monkeypatch.setattr("imagine_mcp.dispatcher.validate_url_and_get_ip", mock_validate)
+    monkeypatch.setenv("OPENAI_API_KEY", "test")
+
+    with pytest.raises(InvalidURLError, match="mocked failure"):
+        await dispatch_understand(
+            media_urls=["https://example.com/cat.png"],
+            prompt="describe",
+            provider=None,
+            tier="poor",
+            model="openai/gpt-4o",
+        )
+
+
+@pytest.mark.asyncio
+async def test_dispatch_generate_resolve_chain_provider(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("GENERATE_MODELS", "openai/dall-e-3")
+    monkeypatch.setenv("OPENAI_API_KEY", "test")
+
+    mock_gen_image = AsyncMock(return_value={"image": "ok"})
+    import imagine_mcp.providers.openai as openai_mod
+
+    monkeypatch.setattr(openai_mod, "generate_image", mock_gen_image)
+
+    result = await dispatch_generate(
+        media_type="image",
+        prompt="a cat",
+        provider=None,
+        tier="poor",
+    )
+    assert result == {"image": "ok"}
+    assert mock_gen_image.called
+
+
+def test_passthrough_api_key_none() -> None:
+    assert _passthrough_api_key("unknown/model") is None
+
+
+@pytest.mark.asyncio
+async def test_passthrough_understand_gather_exception(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # Coverage for line 272
+    monkeypatch.setenv("OPENAI_API_KEY", "test")
+    monkeypatch.setattr(
+        "imagine_mcp.dispatcher._validate_url",
+        AsyncMock(side_effect=Exception("gather error")),
+    )
+
+    with pytest.raises(Exception, match="gather error"):
+        await dispatch_understand(
+            media_urls=["https://example.com/cat.png"],
+            prompt="describe",
+            provider=None,
+            tier="poor",
+            model="openai/gpt-4o",
+        )
+
+
+@pytest.mark.asyncio
+async def test_default_generate_provider_credential_missing(
+    clean_provider_env: None, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # Coverage for line 139-140 via dispatch_generate
+    monkeypatch.setattr(
+        "imagine_mcp.credential_state.credentials_for_current_request",
+        lambda: {},
+    )
+
+    with pytest.raises(CredentialMissingError, match="No provider API key configured"):
+        await dispatch_generate(
+            media_type="image",
+            prompt="a cat",
+            provider=None,
+            tier="poor",
+        )
+
+
+@pytest.mark.asyncio
+async def test_passthrough_understand_download_failure(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # Coverage for line 272
+    monkeypatch.setenv("OPENAI_API_KEY", "test")
+    # Bypass validation
+    monkeypatch.setattr(
+        "imagine_mcp.dispatcher._validate_url", AsyncMock(return_value=None)
+    )
+    # Mock capability check and completion
+    from mcp_core import llm
+
+    monkeypatch.setattr(llm, "check_capability", lambda *a, **k: None)
+
+    # Mock SSRF client to fail
+    mock_client = AsyncMock()
+    mock_client.get.side_effect = Exception("download fail")
+    import imagine_mcp.media as media_mod
+
+    monkeypatch.setattr(media_mod, "get_ssrf_safe_async_client", lambda: mock_client)
+
+    with pytest.raises(Exception, match="download fail"):
+        await dispatch_understand(
+            media_urls=["https://example.com/cat.png"],
+            prompt="describe",
+            provider=None,
+            tier="poor",
+            model="openai/gpt-4o",
+        )


### PR DESCRIPTION
Achieved 100% test coverage for src/imagine_mcp/dispatcher.py by implementing a new extension test suite (tests/test_dispatcher_validation_ext.py). The new tests specifically target:
- SSRF validation failures (_validate_url) across all dispatch entry points.
- Empty media input validation.
- Gemini-specific multimodal and video routing paths.
- Thread-aware DNS resolution mocking.
- Configuration-driven provider priority resolution.
- Error propagation from concurrent asyncio.gather tasks.

Verification:
- uv run pytest --cov=imagine_mcp.dispatcher tests/test_dispatcher.py tests/test_dispatcher_validation_ext.py shows 100% coverage and all tests passing.
- uv run ruff check . passes.

---
*PR created automatically by Jules for task [15049817869998741828](https://jules.google.com/task/15049817869998741828) started by @n24q02m*