### PR TITLE
fix: resolve unbounded read size in download streams

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,8 @@
 **Vulnerability:** Downloader allowed writing chunks to disk even if the total size exceeded the 50MB limit, by only checking the limit *after* writing the chunk. Additionally, it didn't check Content-Length headers early.
 **Learning:** Checking limits *after* an operation (like writing to disk) allows for a one-chunk "overread" and doesn't prevent resource consumption if the header already signals an oversized payload.
 **Prevention:** Always perform a pre-flight check on Content-Length headers if available, and validate that bytes_read + len(chunk) does not exceed the limit before processing/writing the chunk.
+
+## 2025-06-25 - [HIGH] Unbounded read size in leaderboard fetcher
+**Vulnerability:** The leaderboard fetch script used `iter_text()` and accumulated chunks without a pre-flight `Content-Length` check, and only checked the size *after* incrementing a counter, potentially allowing memory exhaustion DoS.
+**Learning:** Even internal-use scripts that fetch data from external sources must follow strict download safety patterns (pre-flight checks and check-before-append).
+**Prevention:** Use `iter_bytes()` for precise byte counting, perform pre-flight `Content-Length` checks, and always validate the predicted total size (`bytes_read + len(chunk)`) against the limit *before* adding data to in-memory buffers.

--- a/scripts/fetch_leaderboards.py
+++ b/scripts/fetch_leaderboards.py
@@ -260,17 +260,27 @@ def fetch_all(client: httpx.Client) -> dict[str, list[LBRow]]:
     max_size = 5 * 1024 * 1024  # 5MB limit
     for url in LB_URLS:
         try:
-            html_chunks = []
             bytes_read = 0
             with client.stream("GET", url, timeout=30.0, follow_redirects=True) as r:
                 r.raise_for_status()
-                for chunk in r.iter_text():
-                    bytes_read += len(chunk.encode("utf-8"))
-                    if bytes_read > max_size:
-                        raise ValueError(f"Response exceeded 5MB limit: {url}")
-                    html_chunks.append(chunk)
+                content_length = r.headers.get("Content-Length")
+                if (
+                    content_length
+                    and content_length.isdigit()
+                    and int(content_length) > max_size
+                ):
+                    raise ValueError(
+                        f"Content-Length {content_length} exceeds limit: {url}"
+                    )
 
-            html = "".join(html_chunks)
+                html_bytes_chunks = []
+                for chunk in r.iter_bytes():
+                    if bytes_read + len(chunk) > max_size:
+                        raise ValueError(f"Response exceeded 5MB limit: {url}")
+                    html_bytes_chunks.append(chunk)
+                    bytes_read += len(chunk)
+
+            html = b"".join(html_bytes_chunks).decode("utf-8")
             out[url] = parse_leaderboard(url, html)
             log.info("fetched %s: %d rows after filter", url, len(out[url]))
         except Exception as exc:

--- a/src/imagine_mcp/media.py
+++ b/src/imagine_mcp/media.py
@@ -388,7 +388,10 @@ def _write_response(resp: httpx.Response, dest: Path) -> None:
     content_length_str = resp.headers.get("Content-Length")
     if content_length_str:
         try:
-            if int(content_length_str) > _MAX_DOWNLOAD_SIZE:
+            if (
+                content_length_str.isdigit()
+                and int(content_length_str) > _MAX_DOWNLOAD_SIZE
+            ):
                 raise httpx.HTTPError(
                     f"Download failed: Content-Length {content_length_str} exceeds limit of {_MAX_DOWNLOAD_SIZE} bytes"
                 )
@@ -410,7 +413,10 @@ async def _write_response_async(resp: httpx.Response, dest: Path) -> None:
     content_length_str = resp.headers.get("Content-Length")
     if content_length_str:
         try:
-            if int(content_length_str) > _MAX_DOWNLOAD_SIZE:
+            if (
+                content_length_str.isdigit()
+                and int(content_length_str) > _MAX_DOWNLOAD_SIZE
+            ):
                 raise httpx.HTTPError(
                     f"Download failed: Content-Length {content_length_str} exceeds limit of {_MAX_DOWNLOAD_SIZE} bytes"
                 )


### PR DESCRIPTION
This PR addresses a potential Denial of Service (DoS) vulnerability caused by unbounded read sizes in download streams.

Key changes:
- In `scripts/fetch_leaderboards.py`:
  - Added a pre-flight `Content-Length` check.
  - Switched from `iter_text()` to `iter_bytes()` for accurate byte counting.
  - Updated the streaming loop to validate `bytes_read + len(chunk)` against the limit *before* appending to the in-memory buffer.
- In `src/imagine_mcp/media.py`:
  - Refined the `Content-Length` check with an explicit `.isdigit()` validation.
  - Verified that streaming checks are performed before disk I/O.
- Updated `.jules/sentinel.md` with new security learnings.

Verified by running 286 project tests (all passed) and manual code review.

---
*PR created automatically by Jules for task [7363437429564642810](https://jules.google.com/task/7363437429564642810) started by @n24q02m*