### PR TITLE
🛡️ Sentinel: [MEDIUM] Fix MCP_PORT and MCP_HOST validation vulnerabilities

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,8 @@
 **Vulnerability:** Downloader allowed writing chunks to disk even if the total size exceeded the 50MB limit, by only checking the limit *after* writing the chunk. Additionally, it didn't check Content-Length headers early.
 **Learning:** Checking limits *after* an operation (like writing to disk) allows for a one-chunk "overread" and doesn't prevent resource consumption if the header already signals an oversized payload.
 **Prevention:** Always perform a pre-flight check on Content-Length headers if available, and validate that bytes_read + len(chunk) does not exceed the limit before processing/writing the chunk.
+
+## 2024-06-29 - Validate MCP_PORT and MCP_HOST environment variables on startup
+**Vulnerability:** The application was not validating the MCP_PORT and MCP_HOST environment variables properly. MCP_PORT could have been invalid (e.g. out of range, or a non-integer) and MCP_HOST could have been malformed (e.g. "999.999.999.999" IP bypass).
+**Learning:** We need to explicitly validate the type and bounds of port configuration values and make sure hosts match IP or hostname definitions to avoid network issues or bypasses later in the connection lifecycle.
+**Prevention:** Perform explicit bounds checking (0-65535) and hostname/IP address validation via ipaddress and regex before launching the HTTP service in remote multi-user mode.

--- a/src/imagine_mcp/server.py
+++ b/src/imagine_mcp/server.py
@@ -3,7 +3,9 @@
 from __future__ import annotations
 
 import asyncio
+import ipaddress
 import os
+import re
 from functools import cache
 from importlib.resources import files
 from pathlib import Path
@@ -330,9 +332,38 @@ async def run_http(port: int = 0) -> None:
                 "MCP_DCR_SERVER_SECRET missing. Multi-user remote mode "
                 "requires the DCR secret."
             )
-        port = int(os.environ.get("MCP_PORT", "8080"))
-        mode_label = "http remote relay (multi-user)"
+
+        try:
+            port = int(os.environ.get("MCP_PORT", "8080"))
+            if not (0 <= port <= 65535):
+                raise ValueError
+        except ValueError:
+            raise SystemExit(
+                "imagine-mcp refuses to start: MCP_PORT must be an integer between 0 and 65535."
+            ) from None
+
         host = os.environ.get("MCP_HOST", "127.0.0.1")
+        try:
+            ipaddress.ip_address(host)
+        except ValueError:
+            if re.match(r"^[0-9\.]+$", host):
+                raise SystemExit(
+                    f"imagine-mcp refuses to start: Invalid MCP_HOST {host!r}."
+                ) from None
+
+            check_host = host[:-1] if host.endswith(".") else host
+            if len(check_host) > 255:
+                raise SystemExit(
+                    f"imagine-mcp refuses to start: Invalid MCP_HOST {host!r}."
+                ) from None
+
+            allowed = re.compile(r"(?!-)[A-Z\d-]{1,63}(?<!-)$", re.IGNORECASE)
+            if not all(allowed.match(x) for x in check_host.split(".")):
+                raise SystemExit(
+                    f"imagine-mcp refuses to start: Invalid MCP_HOST {host!r}."
+                ) from None
+
+        mode_label = "http remote relay (multi-user)"
     else:
         host = "127.0.0.1"
         mode_label = "http local relay"

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -387,3 +387,54 @@ def test_main_calls_run_http() -> None:
             main()
             mock_run.assert_called_once()
         coro.close()
+
+
+@pytest.mark.asyncio
+async def test_run_http_remote_relay_invalid_port(monkeypatch) -> None:
+    from imagine_mcp.server import run_http
+
+    monkeypatch.setenv("PUBLIC_URL", "https://ex.com")
+    monkeypatch.setenv("MCP_DCR_SERVER_SECRET", "secret")
+
+    # Not an integer
+    monkeypatch.setenv("MCP_PORT", "abc")
+    with pytest.raises(
+        SystemExit, match="MCP_PORT must be an integer between 0 and 65535"
+    ):
+        await run_http()
+
+    # Out of bounds
+    monkeypatch.setenv("MCP_PORT", "70000")
+    with pytest.raises(
+        SystemExit, match="MCP_PORT must be an integer between 0 and 65535"
+    ):
+        await run_http()
+
+    monkeypatch.setenv("MCP_PORT", "-1")
+    with pytest.raises(
+        SystemExit, match="MCP_PORT must be an integer between 0 and 65535"
+    ):
+        await run_http()
+
+
+@pytest.mark.asyncio
+async def test_run_http_remote_relay_invalid_host(monkeypatch) -> None:
+    from imagine_mcp.server import run_http
+
+    monkeypatch.setenv("PUBLIC_URL", "https://ex.com")
+    monkeypatch.setenv("MCP_DCR_SERVER_SECRET", "secret")
+
+    # Malformed IP (digits and dots, but not valid IP)
+    monkeypatch.setenv("MCP_HOST", "999.999.999.999")
+    with pytest.raises(SystemExit, match="Invalid MCP_HOST"):
+        await run_http()
+
+    # Invalid hostname (starts with dash)
+    monkeypatch.setenv("MCP_HOST", "-invalid.com")
+    with pytest.raises(SystemExit, match="Invalid MCP_HOST"):
+        await run_http()
+
+    # Too long hostname
+    monkeypatch.setenv("MCP_HOST", "a" * 260 + ".com")
+    with pytest.raises(SystemExit, match="Invalid MCP_HOST"):
+        await run_http()

--- a/uv.lock
+++ b/uv.lock
@@ -709,7 +709,7 @@ wheels = [
 
 [[package]]
 name = "imagine-mcp"
-version = "1.7.0b12"
+version = "1.7.0b13"
 source = { editable = "." }
 dependencies = [
     { name = "diskcache" },


### PR DESCRIPTION
🚨 Severity: MEDIUM
💡 Vulnerability: The application previously passed `MCP_PORT` and `MCP_HOST` environment variables directly to the HTTP server initialization without stringent explicit bounds or format verification. This allowed for potentially out-of-bounds port integers, non-integer port values, or malformed IP bypass strings (e.g. `999.999.999.999`) to cause unhandled startup errors or anomalous network behavior in the remote multi-user relay configuration.
🎯 Impact: An invalid port configuration could crash the server process on startup via stack trace exposure, and a specially crafted malformed IP address could bypass standard IP validation checks, leading to unreliable network binding behavior.
🔧 Fix: Implemented strict validation during server initialization for `MCP_PORT` (must be an integer 0-65535) and `MCP_HOST` (must resolve as a valid `ipaddress.ip_address` or pass a strict regex validating correct hostname structure without permitting malformed digit-and-dot strings). All failures now raise a clean `SystemExit`.
✅ Verification: Tested against positive cases (valid hosts, localhost, IPs) and negative cases (malformed IPs, out-of-bounds ports, non-integer strings) natively and via pytest suite. Both standard formatting (`ruff check` and `format`) and standard tests (`pytest tests/test_server.py`) pass.

---
*PR created automatically by Jules for task [8372338061667743508](https://jules.google.com/task/8372338061667743508) started by @n24q02m*