### PR TITLE
🛡️ Sentinel: [HIGH] Fix lack of validation for MCP_PORT and MCP_HOST

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -11,3 +11,8 @@
 **Vulnerability:** Use of `os.path.splitext()` for URL extensions is platform-dependent and susceptible to bypasses if query parameters or fragments are not perfectly stripped.
 **Learning:** `os.path.splitext()` follows the host OS's path rules (e.g., handling backslashes on Windows), which may not align with URL path semantics. Also, manual string splitting for URL components is error-prone compared to standard `urlparse`.
 **Prevention:** Use `urllib.parse.urlparse` to extract the path from a URL, and use `posixpath.splitext()` to ensure consistent extension extraction regardless of the server's operating system.
+
+## 2026-06-30 - [HIGH] Inadequate validation of MCP_PORT and MCP_HOST environment variables
+**Vulnerability:** The MCP_PORT and MCP_HOST environment variables lacked strict type and bounds validation. MCP_PORT could be set to negative or out-of-bounds integers, and MCP_HOST could be set to arbitrary strings or malformed IP addresses without being caught early, potentially leading to connection failures or bypasses in multi-user remote mode.
+**Learning:** Relying purely on int() or downstream socket errors is insufficient for critical network configuration variables.
+**Prevention:** Explicitly validate ports to be within the 0-65535 range and catch ValueError during integer conversion. Use ipaddress to strictly parse IP addresses and a robust regex to validate hostnames, blocking malformed inputs immediately at startup.

--- a/src/imagine_mcp/server.py
+++ b/src/imagine_mcp/server.py
@@ -3,7 +3,9 @@
 from __future__ import annotations
 
 import asyncio
+import ipaddress
 import os
+import re
 from functools import cache
 from importlib.resources import files
 from pathlib import Path
@@ -330,9 +332,39 @@ async def run_http(port: int = 0) -> None:
                 "MCP_DCR_SERVER_SECRET missing. Multi-user remote mode "
                 "requires the DCR secret."
             )
-        port = int(os.environ.get("MCP_PORT", "8080"))
+        port_str = os.environ.get("MCP_PORT", "8080")
+        try:
+            port = int(port_str)
+            if not (0 <= port <= 65535):
+                raise ValueError("Port out of range")
+        except ValueError:
+            raise SystemExit(
+                f"imagine-mcp refuses to start: Invalid MCP_PORT {port_str!r}. "
+                "Must be an integer 0-65535."
+            ) from None
+
         mode_label = "http remote relay (multi-user)"
         host = os.environ.get("MCP_HOST", "127.0.0.1")
+
+        is_valid_ip = False
+        try:
+            ipaddress.ip_address(host)
+            is_valid_ip = True
+        except ValueError:
+            pass
+
+        if not is_valid_ip:
+            if re.match(r"^[0-9\.]+$", host) or ":" in host:
+                raise SystemExit(
+                    f"imagine-mcp refuses to start: Invalid MCP_HOST IP address {host!r}."
+                )
+            if not re.match(
+                r"^[a-zA-Z0-9]([a-zA-Z0-9\-]{0,61}[a-zA-Z0-9])?(\.[a-zA-Z0-9]([a-zA-Z0-9\-]{0,61}[a-zA-Z0-9])?)*$",
+                host,
+            ):
+                raise SystemExit(
+                    f"imagine-mcp refuses to start: Invalid MCP_HOST hostname {host!r}."
+                )
     else:
         host = "127.0.0.1"
         mode_label = "http local relay"

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -375,6 +375,44 @@ async def test_run_http_remote_relay_missing_secret(monkeypatch) -> None:
         await run_http()
 
 
+@pytest.mark.asyncio
+async def test_run_http_invalid_mcp_port(monkeypatch) -> None:
+    from imagine_mcp.server import run_http
+
+    monkeypatch.setenv("PUBLIC_URL", "https://ex.com")
+    monkeypatch.setenv("MCP_DCR_SERVER_SECRET", "secret")
+
+    monkeypatch.setenv("MCP_PORT", "abc")
+    with pytest.raises(SystemExit, match="Invalid MCP_PORT 'abc'"):
+        await run_http()
+
+    monkeypatch.setenv("MCP_PORT", "-1")
+    with pytest.raises(SystemExit, match="Invalid MCP_PORT '-1'"):
+        await run_http()
+
+    monkeypatch.setenv("MCP_PORT", "65536")
+    with pytest.raises(SystemExit, match="Invalid MCP_PORT '65536'"):
+        await run_http()
+
+
+@pytest.mark.asyncio
+async def test_run_http_invalid_mcp_host(monkeypatch) -> None:
+    from imagine_mcp.server import run_http
+
+    monkeypatch.setenv("PUBLIC_URL", "https://ex.com")
+    monkeypatch.setenv("MCP_DCR_SERVER_SECRET", "secret")
+
+    monkeypatch.setenv("MCP_HOST", "999.999.999.999")
+    with pytest.raises(
+        SystemExit, match=r"Invalid MCP_HOST IP address '999\.999\.999\.999'"
+    ):
+        await run_http()
+
+    monkeypatch.setenv("MCP_HOST", "!invalid_host!")
+    with pytest.raises(SystemExit, match=r"Invalid MCP_HOST hostname '!invalid_host!'"):
+        await run_http()
+
+
 def test_main_calls_run_http() -> None:
     from imagine_mcp.server import main
 

--- a/uv.lock
+++ b/uv.lock
@@ -709,7 +709,7 @@ wheels = [
 
 [[package]]
 name = "imagine-mcp"
-version = "1.7.0b12"
+version = "1.7.0b14"
 source = { editable = "." }
 dependencies = [
     { name = "diskcache" },


### PR DESCRIPTION
🚨 **Severity:** HIGH
💡 **Vulnerability:** `MCP_PORT` and `MCP_HOST` lacked explicit bounds and type validation, potentially leading to startup connection failures or bypasses when starting in multi-user remote mode via `PUBLIC_URL`.
🎯 **Impact:** Malicious or malformed values passed through configuration variables could lead to unexpected exceptions in downstream network binding processes, potentially facilitating bypass attacks or misconfigurations.
🔧 **Fix:** Added strict integer parsing and bounds checking (0-65535) for `MCP_PORT` with `ValueError` catching. Added explicit `ipaddress` validation and regex fallback for `MCP_HOST` to catch malformed IP-like strings early.
✅ **Verification:** Unit tests added in `tests/test_server.py` to assert `SystemExit` occurs on malformed input. Verified by running the test suite (`uv run pytest`).

---
*PR created automatically by Jules for task [4583468607587257336](https://jules.google.com/task/4583468607587257336) started by @n24q02m*