### PR TITLE
fix: add vertex ai (express) support to the relay credential form

### DIFF
--- a/src/imagine_mcp/__main__.py
+++ b/src/imagine_mcp/__main__.py
@@ -54,7 +54,13 @@ def main() -> None:
     # No daemon, no bridge. Env-only creds; exit 1 if all 3 missing
     # (server has no functional tools without at least one provider).
     if not any(
-        os.environ.get(k) for k in ("GEMINI_API_KEY", "OPENAI_API_KEY", "XAI_API_KEY")
+        os.environ.get(k)
+        for k in (
+            "GEMINI_API_KEY",
+            "OPENAI_API_KEY",
+            "XAI_API_KEY",
+            "GOOGLE_VERTEX_EXPRESS_API_KEY",
+        )
     ):
         sys.stderr.write(_STDIO_MISSING_CRED_MSG)
         raise SystemExit(1)

--- a/src/imagine_mcp/credential_state.py
+++ b/src/imagine_mcp/credential_state.py
@@ -40,6 +40,7 @@ CLOUD_KEYS: tuple[str, ...] = (
     "XAI_API_KEY",
     "OPENAI_API_KEY",
     "GEMINI_API_KEY",
+    "GOOGLE_VERTEX_EXPRESS_API_KEY",
 )
 
 # Per-request JWT sub. Set by ``auth_scope`` middleware in HTTP multi-user

--- a/src/imagine_mcp/relay_schema.py
+++ b/src/imagine_mcp/relay_schema.py
@@ -84,6 +84,12 @@ RELAY_SCHEMA: dict[str, Any] = {
             "xai-...",
             "https://console.x.ai",
         ),
+        _key_field(
+            "GOOGLE_VERTEX_EXPRESS_API_KEY",
+            "Vertex AI (Express) API Key",
+            "AQ...",
+            "https://cloud.google.com/vertex-ai/generative-ai/docs/start/express-mode/overview",
+        ),
     ],
     "capabilityInfo": [
         {

--- a/src/imagine_mcp/relay_setup.py
+++ b/src/imagine_mcp/relay_setup.py
@@ -18,6 +18,7 @@ CREDENTIAL_KEYS: list[str] = [
     "GEMINI_API_KEY",
     "OPENAI_API_KEY",
     "XAI_API_KEY",
+    "GOOGLE_VERTEX_EXPRESS_API_KEY",
 ]
 
 # 5 minutes: user needs time to copy URL, open browser, fill up to 3 keys

--- a/src/imagine_mcp/server.py
+++ b/src/imagine_mcp/server.py
@@ -51,6 +51,7 @@ def _providers_configured() -> list[str]:
         "GEMINI_API_KEY": "gemini",
         "OPENAI_API_KEY": "openai",
         "XAI_API_KEY": "grok",
+        "GOOGLE_VERTEX_EXPRESS_API_KEY": "vertex_express",
     }
     return list(
         dict.fromkeys(
@@ -76,6 +77,7 @@ def _providers_configured_live() -> list[str]:
         "GEMINI_API_KEY": "gemini",
         "OPENAI_API_KEY": "openai",
         "XAI_API_KEY": "grok",
+        "GOOGLE_VERTEX_EXPRESS_API_KEY": "vertex_express",
     }
     return list(
         dict.fromkeys(

--- a/tests/test_relay_schema.py
+++ b/tests/test_relay_schema.py
@@ -8,7 +8,12 @@ from __future__ import annotations
 
 from imagine_mcp.relay_schema import RELAY_SCHEMA
 
-_CREDENTIAL_KEYS = {"GEMINI_API_KEY", "OPENAI_API_KEY", "XAI_API_KEY"}
+_CREDENTIAL_KEYS = {
+    "GEMINI_API_KEY",
+    "OPENAI_API_KEY",
+    "XAI_API_KEY",
+    "GOOGLE_VERTEX_EXPRESS_API_KEY",
+}
 
 
 def test_top_level_keys_present():


### PR DESCRIPTION
## Problem

In the relay credential form, choosing a Vertex Gemini model in a model chain showed no credential box. Root cause (verified in code, not guessed):

- The dropdown offered the whole litellm registry, including providers no server declares a credential field for (`vertex_ai/*`, `bedrock/*`, `azure/*`, ...). Picking one derived an unbacked `<PROVIDER>_API_KEY`, so the derive-keys widget had nothing to reveal — a silent trap.
- litellm's `vertex_ai/` still requires a Service Account / ADC (BerriAI/litellm#21036, open). This stack authenticates Vertex only via the `vertex_express` httpx adapter (Gemini chat/vision, `GOOGLE_VERTEX_EXPRESS_API_KEY`).
- Even the correct `vertex_express/` prefix had no schema field, and the hardcoded `CLOUD_KEYS` omitted the key, so a vertex-only config was neither detected as configured nor forwarded to the LLM dispatch.

## Fix

- **mcp-core**: the dropdown offers only catalog models whose provider has a credential field on the page; it remaps `vertex_ai/gemini-*` to the working `vertex_express/*` and drops other unsupported `vertex_ai/*`.
- **server**: declares the derived `GOOGLE_VERTEX_EXPRESS_API_KEY` field and adds it to `CLOUD_KEYS` / credential-state so the key actually reaches the model dispatch.

Free-text entry still accepts any model (open passthrough). Part of a coordinated 5-repo set: mcp-core + wet-mcp + mnemo-mcp + better-code-review-graph + imagine-mcp.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for an additional Vertex AI Express API key across setup and configuration screens.
  * Providers list now recognizes this credential when it is available.

* **Bug Fixes**
  * `stdio` mode no longer exits early when only the Vertex AI Express API key is set.
  * Credential detection now includes the new key in saved and environment-based configuration flows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->