### PR TITLE
fix: bump mcp-core to 1.18.1b1 for the vertex relay dropdown fix

### DIFF
--- a/uv.lock
+++ b/uv.lock
@@ -709,7 +709,7 @@ wheels = [
 
 [[package]]
 name = "imagine-mcp"
-version = "1.7.0b14"
+version = "1.7.0"
 source = { editable = "." }
 dependencies = [
     { name = "diskcache" },
@@ -955,7 +955,7 @@ wheels = [
 
 [[package]]
 name = "litellm"
-version = "1.90.1"
+version = "1.90.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "aiohttp" },
@@ -971,9 +971,9 @@ dependencies = [
     { name = "tiktoken" },
     { name = "tokenizers" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/36/1e/b079ec9b840bac7573c33fa06c075414616c19ac0adde06ec4cb694cbc9f/litellm-1.90.1.tar.gz", hash = "sha256:a0c79d9efa1dbc031371348540466240216c898c68687d4c2de1343ca3ac3dd0", size = 14818439, upload-time = "2026-06-30T01:43:41.558Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/88/00/4187e33818d0de19fd602214ce15a6e1cfa5bf04fb50a6e59606214a92df/litellm-1.90.2.tar.gz", hash = "sha256:b536603894ba2a0ccd14a6f1ebeb5f46cc35b19d4537e8fda7bfdfc7757f19d3", size = 14819154, upload-time = "2026-07-01T02:29:58.397Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/d0/86/86063e003e0ca31f8304a5ba808d51d91b959512b33b6cab5e0c55e936e8/litellm-1.90.1-py3-none-any.whl", hash = "sha256:d90482c7f3a7dfa3f4d88b255cb4e1e60793d7452efcc0fe461a719df52c283e", size = 16611651, upload-time = "2026-06-30T01:43:38.154Z" },
+    { url = "https://files.pythonhosted.org/packages/24/30/3afa7b212ce1f9bb8b6fa5f58c631f437c1d7b3a025e4e4ed6b01b3d28ad/litellm-1.90.2-py3-none-any.whl", hash = "sha256:6fb46f485150cc861be62a62d670f94d33adbd26991091befeb51bcdfdad34f6", size = 16612720, upload-time = "2026-07-01T02:29:55.215Z" },
 ]
 
 [[package]]
@@ -1127,7 +1127,7 @@ wheels = [
 
 [[package]]
 name = "n24q02m-mcp-core"
-version = "1.18.0b22"
+version = "1.18.1b1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "authlib" },
@@ -1142,9 +1142,9 @@ dependencies = [
     { name = "starlette" },
     { name = "tomli-w" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/09/1a/944eea486975a459e9ff106da3f82718e0d295b759e513d1d2f7356870ad/n24q02m_mcp_core-1.18.0b22.tar.gz", hash = "sha256:890a42e8c4df4fad2ca8fe6e85c4cfa779be563d38f2242ac1144d683f18a487", size = 305001, upload-time = "2026-06-30T08:12:05.443Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/36/2f/1d7d959c288767da22b2ede972b3f469726f7956a3007e0dededfa8517b3/n24q02m_mcp_core-1.18.1b1.tar.gz", hash = "sha256:e508d95350c2c0f6ad1538b8e9038629d4652132d4a365d1b2f5275b534a3ec3", size = 305285, upload-time = "2026-07-01T16:16:36.081Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/12/8f/43e3b16d9c769036e9ad430ec78ccb38f7e928de864a5aa5555c65a31e04/n24q02m_mcp_core-1.18.0b22-py3-none-any.whl", hash = "sha256:938604fcc3dbad6c32f6e998a6d4e95a209f34916bb8a2ac4a679d9185bbd643", size = 169045, upload-time = "2026-06-30T08:12:04.327Z" },
+    { url = "https://files.pythonhosted.org/packages/60/17/cfbb9120e17c5bea3e47d709789ed3c179970010d847351a123fb2229fa3/n24q02m_mcp_core-1.18.1b1-py3-none-any.whl", hash = "sha256:b173071fbbbe7aec7665676e58ff9faf68b4dfb257083f4b7f976bc5363cb01f", size = 169902, upload-time = "2026-07-01T16:16:34.97Z" },
 ]
 
 [package.optional-dependencies]


### PR DESCRIPTION
Bumps the pinned n24q02m-mcp-core to 1.18.1b1 (uv.lock) so the built image includes the relay dropdown fix (offer vertex_express models + filter to credential-backed providers). The server's own vertex schema + credential-state fix already landed on main; this pulls in the shared mcp-core piece.