### PR TITLE
feat: deploy CF Worker+Container on release from cd.yml

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -266,3 +266,47 @@ jobs:
             -f event_type=plugin-sync \
             -f 'client_payload[repo]=imagine-mcp' \
             -f 'client_payload[tag]=${{ needs.release.outputs.tag }}'
+
+  # =================== Deploy Cloudflare ===================
+  deploy-cf:
+    name: Deploy Cloudflare Worker+Container
+    # Builds the http-slim image on a GitHub Linux runner and deploys it to
+    # Cloudflare so any release == CF live on that version — a beta dispatch redeploys
+    # the beta, a stable dispatch is maintainer-gated (replaces the
+    # manual local deploy_cf.py step + its Windows Docker OOM). Only needs the
+    # `release` job (deploy_cf.py builds its OWN image, so merge-docker is not a
+    # dependency). Dispatch-only workflow (no fork PRs) => secrets are safe.
+    # NOTE: in CI the template renders the image at the NEW tag, so deploy_cf.py's
+    # auto-rollback (prev_ref != new) is inert here; a failed canary still fails
+    # this job (exit 1, no silent bad deploy). Live-image prev_ref for true CI
+    # rollback is a tracked follow-up.
+    needs: [release]
+    if: needs.release.outputs.released == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2
+        with:
+          egress-policy: audit
+      - name: Checkout the released tag
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        with:
+          ref: ${{ needs.release.outputs.tag }}
+      - name: Setup Bun (bunx wrangler)
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
+      - name: Install worker deps (wrangler bundles worker.ts, needs @cloudflare/containers)
+        run: bun install --frozen-lockfile
+      - name: Setup Python
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6
+        with:
+          python-version: "3.13"
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4
+      - name: Deploy to Cloudflare (build http-slim + push + deploy + canary)
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CF_DEPLOY_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          CF_KV_ID: ${{ secrets.CF_KV_ID }}
+          PUBLIC_URL: ${{ secrets.PUBLIC_URL }}
+          IMAGE_TAG: ${{ needs.release.outputs.version }}
+        run: python scripts/deploy_cf.py --from-template --tag "${IMAGE_TAG}"

--- a/scripts/deploy_cf.py
+++ b/scripts/deploy_cf.py
@@ -48,6 +48,7 @@ from __future__ import annotations
 import argparse
 import contextlib
 import json
+import os
 import re
 import subprocess
 import sys
@@ -64,6 +65,28 @@ for _stream in (sys.stdout, sys.stderr):
         _stream.reconfigure(encoding="utf-8", errors="replace")
 
 DEPLOY_CONFIG = "wrangler.deploy.jsonc"
+TEMPLATE_CONFIG = "wrangler.deploy.template.jsonc"
+
+
+def render_template(path: str) -> str:
+    """Substitute ``${VAR}`` tokens in the committed deploy template from the
+    environment.
+
+    CI runs ``deploy_cf.py --from-template`` to reconstruct the gitignored
+    ``wrangler.deploy.jsonc`` from the committed placeholder template plus the
+    real IDs, which arrive as env vars (GitHub Actions secrets synced from
+    skret). Fails loudly if a referenced var is missing so a half-substituted
+    config never reaches ``wrangler deploy``.
+    """
+    text = Path(path).read_text(encoding="utf-8")
+
+    def _sub(m: re.Match[str]) -> str:
+        val = os.environ.get(m.group(1))
+        if val is None:
+            raise SystemExit(f"template var ${{{m.group(1)}}} not set in environment")
+        return val
+
+    return re.sub(r"\$\{([A-Z0-9_]+)\}", _sub, text)
 
 
 def _strip_jsonc(text: str) -> str:
@@ -315,6 +338,11 @@ def main(argv: list[str] | None = None) -> int:
     )
     p.add_argument("--dry-run", action="store_true", help="print the plan, run nothing")
     p.add_argument(
+        "--from-template",
+        action="store_true",
+        help="reconstruct wrangler.deploy.jsonc from the committed template + env (CI)",
+    )
+    p.add_argument(
         "--no-canary",
         action="store_true",
         help="skip the post-deploy canary gate (and its auto-rollback)",
@@ -322,6 +350,11 @@ def main(argv: list[str] | None = None) -> int:
     args = p.parse_args(argv)
 
     repo = Path(__file__).resolve().parent.parent
+    if args.from_template:
+        (repo / DEPLOY_CONFIG).write_text(
+            render_template(str(repo / TEMPLATE_CONFIG)), encoding="utf-8"
+        )
+        print(f"Rendered {DEPLOY_CONFIG} from {TEMPLATE_CONFIG} (CI mode).")
     cfg = _load_deploy_config(repo)
     worker = cfg["name"]
     base, _account, name = _image_parts(cfg)
@@ -334,7 +367,17 @@ def main(argv: list[str] | None = None) -> int:
     if not args.skip_build:
         print("[1/4] docker build --target http")
         _run(
-            ["docker", "build", "--target", "http", "-t", local, "."],
+            [
+                "docker",
+                "build",
+                "--target",
+                "http",
+                "--build-arg",
+                "SLIM=1",
+                "-t",
+                local,
+                ".",
+            ],
             dry=args.dry_run,
             cwd=repo,
         )

--- a/tests/test_deploy_cf_template.py
+++ b/tests/test_deploy_cf_template.py
@@ -1,0 +1,71 @@
+"""Tests for the CI CF-deploy template rendering in ``scripts/deploy_cf.py``.
+
+``deploy_cf.py --from-template`` reconstructs the gitignored
+``wrangler.deploy.jsonc`` from the committed placeholder template + env (CI
+provides the real IDs as GitHub Actions secrets). These tests exercise the pure
+``render_template`` substitution without touching docker/wrangler.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import pathlib
+
+import pytest
+
+_SCRIPT = pathlib.Path(__file__).resolve().parent.parent / "scripts" / "deploy_cf.py"
+_spec = importlib.util.spec_from_file_location("deploy_cf", _SCRIPT)
+assert _spec is not None and _spec.loader is not None
+deploy_cf = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(deploy_cf)
+
+
+def test_render_template_substitutes_env(tmp_path, monkeypatch):
+    tpl = tmp_path / "wrangler.deploy.template.jsonc"
+    tpl.write_text(
+        '{"image":"registry.cloudflare.com/${CLOUDFLARE_ACCOUNT_ID}/imagine-mcp:${IMAGE_TAG}",'
+        '"vars":{"PUBLIC_URL":"${PUBLIC_URL}"}}',
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("CLOUDFLARE_ACCOUNT_ID", "acct123")
+    monkeypatch.setenv("IMAGE_TAG", "v9.9.9")
+    # A non-URL sentinel: this unit test exercises substitution mechanics, and a
+    # real URL literal would trip CodeQL's url-substring-sanitization heuristic.
+    # Parse + equality-assert the rendered JSON (not substring) so the test is
+    # precise and CodeQL sees no url-in-string validation pattern.
+    monkeypatch.setenv("PUBLIC_URL", "PUBLIC-URL-SENTINEL")
+    cfg = json.loads(deploy_cf.render_template(str(tpl)))
+    assert cfg["image"] == "registry.cloudflare.com/acct123/imagine-mcp:v9.9.9"
+    assert cfg["vars"]["PUBLIC_URL"] == "PUBLIC-URL-SENTINEL"
+
+
+def test_render_template_missing_var_fails_loudly(tmp_path, monkeypatch):
+    tpl = tmp_path / "t.jsonc"
+    tpl.write_text('{"x":"${DEFINITELY_MISSING_VAR}"}', encoding="utf-8")
+    monkeypatch.delenv("DEFINITELY_MISSING_VAR", raising=False)
+    with pytest.raises(SystemExit):
+        deploy_cf.render_template(str(tpl))
+
+
+def test_committed_template_renders_to_valid_json(monkeypatch):
+    """The real committed template must render cleanly when all documented CI
+    env vars are set, and parse as valid JSON (catches a ${VAR} typo or a stray
+    placeholder the tiny unit example would miss)."""
+    for k, v in {
+        "CLOUDFLARE_ACCOUNT_ID": "acct",
+        "IMAGE_TAG": "v1",
+        "CF_KV_ID": "kvid",
+        "PUBLIC_URL": "https://imagine.n24q02m.com",
+    }.items():
+        monkeypatch.setenv(k, v)
+    tpl = _SCRIPT.parent.parent / "wrangler.deploy.template.jsonc"
+    out = deploy_cf.render_template(str(tpl))
+    assert "${" not in out  # no leftover placeholder
+    cfg = json.loads(deploy_cf._strip_jsonc(out))
+    assert cfg["name"] == "imagine-mcp-worker"
+    assert (
+        cfg["containers"][0]["image"] == "registry.cloudflare.com/acct/imagine-mcp:v1"
+    )
+    assert cfg["kv_namespaces"][0]["id"] == "kvid"
+    assert cfg["vars"]["PUBLIC_URL"] == "https://imagine.n24q02m.com"

--- a/wrangler.deploy.template.jsonc
+++ b/wrangler.deploy.template.jsonc
@@ -1,0 +1,36 @@
+// wrangler.deploy.template.jsonc - COMMITTED placeholder template for CI CF deploy.
+// scripts/deploy_cf.py --from-template renders this into the gitignored
+// wrangler.deploy.jsonc by substituting the placeholder tokens below from the
+// environment (CI provides them from GitHub Actions secrets synced from skret).
+// Real account/KV IDs never live in git; they are placeholder tokens here.
+// KV-only (no D1/Vectorize) per the imagine CF mode table. NO routes block
+// (imagine.n24q02m.com already attached; the deploy token can't reconcile
+// routes). workers_dev:false keeps the worker off *.workers.dev.
+{
+  "name": "imagine-mcp-worker",
+  "main": "src/worker.ts",
+  "compatibility_date": "2026-06-14",
+  "workers_dev": false,
+  "containers": [
+    {
+      "name": "imagine-mcp-worker",
+      "class_name": "ImagineContainer",
+      "image": "registry.cloudflare.com/${CLOUDFLARE_ACCOUNT_ID}/imagine-mcp:${IMAGE_TAG}",
+      "instance_type": "basic",
+      "max_instances": 1
+    }
+  ],
+  "durable_objects": {
+    "bindings": [{ "name": "IMAGINE", "class_name": "ImagineContainer" }]
+  },
+  "migrations": [{ "tag": "v1", "new_sqlite_classes": ["ImagineContainer"] }],
+  "kv_namespaces": [{ "binding": "KV", "id": "${CF_KV_ID}" }],
+  "vars": {
+    "PUBLIC_URL": "${PUBLIC_URL}",
+    "MCP_STORAGE_BACKEND": "cf-kv",
+    "MCP_KV_BASE_URL": "http://kv.internal",
+    "IMAGINE_OUTPUT_MODE": "base64",
+    "MCP_TRANSPORT": "http"
+  },
+  "observability": { "enabled": true }
+}


### PR DESCRIPTION
Mirrors the wet-mcp deploy-cf-in-cd pilot: dispatch-only deploy-cf job builds http-slim on a GitHub runner + bun install + deploy_cf.py --from-template. Part of the 6-CF-server rollout.