### PR TITLE
fix: use placeholders for PUBLIC_URL and routes in wrangler.jsonc (BYO-generic)

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ mcp-name: io.github.n24q02m/imagine-mcp
 - [Comparison](#comparison)
 - [Security](#security)
 - [Build from Source](#build-from-source)
+- [Deploy to Cloudflare](#deploy-to-cloudflare)
 - [Trust Model](#trust-model)
 - [Contributing](#contributing)
 - [License](#license)
@@ -218,6 +219,52 @@ cd imagine-mcp
 mise run setup      # or: uv sync --group dev
 mise run dev        # run the server in stdio mode (add --http for the HTTP daemon)
 ```
+
+## Deploy to Cloudflare
+
+[![Deploy to Cloudflare](https://deploy.workers.cloudflare.com/button)](https://deploy.workers.cloudflare.com/?url=https://github.com/n24q02m/imagine-mcp)
+
+Run your own imagine instance serverless on Cloudflare (Worker + Container + KV). Storage
+is KV-only -- the per-user credential vault lives in KV, and generation returns base64 only
+because the container filesystem is ephemeral (`IMAGINE_OUTPUT_MODE=base64`).
+
+**Prerequisites:** a Cloudflare account on the Workers Paid plan and the `wrangler` CLI.
+
+1. `git clone https://github.com/n24q02m/imagine-mcp && cd imagine-mcp`
+2. `wrangler login`
+3. Create the KV namespace (imagine is KV-only -- no D1 or Vectorize), then paste the
+   returned id into `wrangler.jsonc` (the `<imagine-kv-namespace-id>` placeholder):
+   ```
+   wrangler kv namespace create imagine-kv
+   ```
+4. Push the container image to your Cloudflare managed registry (CF Containers cannot pull
+   from external registries directly), then set `<YOUR_ACCOUNT_ID>` in `wrangler.jsonc`:
+   ```
+   docker pull ghcr.io/n24q02m/imagine-mcp:beta
+   docker tag ghcr.io/n24q02m/imagine-mcp:beta imagine-mcp:beta
+   wrangler containers push imagine-mcp:beta   # prints registry.cloudflare.com/<ACCOUNT_ID>/imagine-mcp:beta
+   ```
+5. Point the remaining `wrangler.jsonc` placeholders at your own domain: `<YOUR_PUBLIC_URL>`
+   (the `vars.PUBLIC_URL`, e.g. `https://imagine.example.com`) and `<YOUR_WORKER_DOMAIN>`
+   (the `routes` custom-domain pattern, e.g. `imagine.example.com`).
+6. Set secrets. `CREDENTIAL_SECRET` (stable JWT signing key + per-user vault key) and
+   `MCP_DCR_SERVER_SECRET` (proof of an intentional multi-user deploy) are required;
+   `MCP_RELAY_PASSWORD` gates the browser setup form's login. Provider keys are optional
+   server defaults -- users normally paste their own through the setup form instead:
+   ```
+   wrangler secret put CREDENTIAL_SECRET
+   wrangler secret put MCP_DCR_SERVER_SECRET
+   wrangler secret put MCP_RELAY_PASSWORD
+   wrangler secret put GEMINI_API_KEY       # optional provider default
+   wrangler secret put OPENAI_API_KEY       # optional provider default
+   wrangler secret put XAI_API_KEY          # optional provider default
+   ```
+7. `wrangler deploy`, then open your Worker domain and finish setup in the browser relay form.
+
+The `http` container image already runs multi-user (`MCP_TRANSPORT=http` is baked into the
+image target). Storage maps to Cloudflare via `MCP_STORAGE_BACKEND=cf-kv` (encrypted
+credential vault) with `IMAGINE_OUTPUT_MODE=base64`, which forces base64 responses so no
+media path is written to the ephemeral container filesystem.
 
 ## Trust Model
 

--- a/README.md
+++ b/README.md
@@ -228,7 +228,7 @@ Run your own imagine instance serverless on Cloudflare (Worker + Container + KV)
 is KV-only -- the per-user credential vault lives in KV, and generation returns base64 only
 because the container filesystem is ephemeral (`IMAGINE_OUTPUT_MODE=base64`).
 
-**Prerequisites:** a Cloudflare account on the Workers Paid plan and the `wrangler` CLI.
+**Prerequisites:** a Cloudflare account on the **Workers Paid plan** -- required for Containers (the Cloudflare free tier does not include Containers) -- and the `wrangler` CLI.
 
 1. `git clone https://github.com/n24q02m/imagine-mcp && cd imagine-mcp`
 2. `wrangler login`

--- a/scripts/cf_deploy_config.mjs
+++ b/scripts/cf_deploy_config.mjs
@@ -12,7 +12,8 @@
 // against it, so the committed wrangler.jsonc stays placeholder-clean. The
 // <YOUR_WORKER_DOMAIN> routes placeholder needs no value -- the routes block is
 // stripped below (the config-only token can't reconcile zone Workers Routes).
-// Pass --dry-run to print the substituted config and exit without deploying.
+// Pass --dry-run to write the substituted config to wrangler.deploy-tmp.jsonc
+// (gitignored, for inspection) and exit without deploying.
 //
 // It is config-only: it does NOT rebuild or push the container image. It reuses
 // the image tag already pushed to the CF managed registry (default `beta`,
@@ -39,9 +40,9 @@ const root = process.cwd();
 const srcConfig = join(root, 'wrangler.jsonc');
 const tmpConfig = join(root, 'wrangler.deploy-tmp.jsonc');
 
-// --dry-run substitutes + prints the temp config without deploying (no CF token
-// needed); account/KV fall back to obvious dummies so a quick PUBLIC_URL check
-// works with only PUBLIC_URL set.
+// --dry-run substitutes + writes the temp config (for inspection) without
+// deploying (no CF token needed); account/KV fall back to obvious dummies so a
+// quick PUBLIC_URL check works with only PUBLIC_URL set.
 const dryRun = process.argv.includes('--dry-run');
 
 const accountId = process.env.CLOUDFLARE_ACCOUNT_ID || (dryRun ? 'DRYRUN_ACCOUNT' : undefined);
@@ -91,17 +92,19 @@ if (config.includes(PUBLIC_URL_PLACEHOLDER)) {
 writeFileSync(tmpConfig, config, 'utf8');
 
 if (dryRun) {
-  // Print the fully-substituted config and flag any placeholder still left, then
-  // exit without touching Cloudflare (the temp config is not deployed).
+  // Verify substitution without deploying (no CF token needed). The substituted
+  // config was written to `tmpConfig` above; leave it in place (gitignored) so a
+  // BYO adopter can inspect exactly what would deploy, and flag any placeholder
+  // still left. Do NOT echo the substituted config to stdout -- it carries
+  // env-derived values (account / KV id, PUBLIC_URL) that must not be logged in
+  // clear text.
   const leftover = [...new Set(config.match(/<[A-Za-z0-9_-]+>/g) || [])];
-  console.log('cf:deploy --dry-run - substituted config (not deploying):\n');
-  console.log(config);
-  rmSync(tmpConfig, { force: true });
   if (leftover.length) {
-    console.error(`\nFAIL: unsubstituted placeholder(s) remain: ${leftover.join(', ')}`);
+    rmSync(tmpConfig, { force: true });
+    console.error(`FAIL: unsubstituted placeholder(s) remain: ${leftover.join(', ')}`);
     process.exit(1);
   }
-  console.log('\nOK: no unsubstituted <...> placeholders remain.');
+  console.log(`OK: no unsubstituted <...> placeholders remain. Substituted config written to ${tmpConfig} for inspection.`);
   process.exit(0);
 }
 

--- a/scripts/cf_deploy_config.mjs
+++ b/scripts/cf_deploy_config.mjs
@@ -2,12 +2,17 @@
 // cf_deploy_config.mjs - config-only live deploy of the imagine-mcp CF
 // Worker + Container, driven by the committed wrangler.jsonc.
 //
-// The committed wrangler.jsonc carries two deploy-time placeholders that are
-// NOT checked in as live values (so the public repo never pins account/KV ids):
-//   <YOUR_ACCOUNT_ID>          -> the CF account id   (env CLOUDFLARE_ACCOUNT_ID)
-//   <imagine-kv-namespace-id>  -> the live KV id       (env IMAGINE_KV_NAMESPACE_ID)
-// This script substitutes both into a temp config and runs `wrangler deploy`
-// against it, so the committed wrangler.jsonc stays placeholder-clean.
+// The committed wrangler.jsonc carries three deploy-time placeholders that are
+// NOT checked in as live values (so the public repo never pins account/KV ids
+// or the maintainer's own domain):
+//   <YOUR_ACCOUNT_ID>          -> the CF account id     (env CLOUDFLARE_ACCOUNT_ID)
+//   <imagine-kv-namespace-id>  -> the live KV id         (env IMAGINE_KV_NAMESPACE_ID)
+//   <YOUR_PUBLIC_URL>          -> the public origin URL  (env PUBLIC_URL)
+// This script substitutes all three into a temp config and runs `wrangler deploy`
+// against it, so the committed wrangler.jsonc stays placeholder-clean. The
+// <YOUR_WORKER_DOMAIN> routes placeholder needs no value -- the routes block is
+// stripped below (the config-only token can't reconcile zone Workers Routes).
+// Pass --dry-run to print the substituted config and exit without deploying.
 //
 // It is config-only: it does NOT rebuild or push the container image. It reuses
 // the image tag already pushed to the CF managed registry (default `beta`,
@@ -20,6 +25,7 @@
 //   MSYS_NO_PATHCONV=1 skret run -e dev --path=/n24q02m/dev -- \
 //     bash -c 'export CLOUDFLARE_API_TOKEN=$CF_DEV_TOKEN \
 //       CLOUDFLARE_ACCOUNT_ID=<account> IMAGINE_KV_NAMESPACE_ID=<kv> \
+//       PUBLIC_URL=<https://your.domain> \
 //       && npm run cf:deploy'
 //
 // To build + push a fresh image first (and run the canary gate), use the fuller
@@ -33,11 +39,17 @@ const root = process.cwd();
 const srcConfig = join(root, 'wrangler.jsonc');
 const tmpConfig = join(root, 'wrangler.deploy-tmp.jsonc');
 
-const accountId = process.env.CLOUDFLARE_ACCOUNT_ID;
-const kvId = process.env.IMAGINE_KV_NAMESPACE_ID;
+// --dry-run substitutes + prints the temp config without deploying (no CF token
+// needed); account/KV fall back to obvious dummies so a quick PUBLIC_URL check
+// works with only PUBLIC_URL set.
+const dryRun = process.argv.includes('--dry-run');
+
+const accountId = process.env.CLOUDFLARE_ACCOUNT_ID || (dryRun ? 'DRYRUN_ACCOUNT' : undefined);
+const kvId = process.env.IMAGINE_KV_NAMESPACE_ID || (dryRun ? 'DRYRUN_KV_ID' : undefined);
+const publicUrl = process.env.PUBLIC_URL;
 const imageTag = process.env.IMAGINE_IMAGE_TAG || 'beta';
 
-if (!process.env.CLOUDFLARE_API_TOKEN) {
+if (!dryRun && !process.env.CLOUDFLARE_API_TOKEN) {
   console.error('CLOUDFLARE_API_TOKEN is required (skret /n24q02m/dev CF_DEV_TOKEN).');
   process.exit(1);
 }
@@ -49,11 +61,16 @@ if (!kvId) {
   console.error('IMAGINE_KV_NAMESPACE_ID is required (substitutes <imagine-kv-namespace-id>).');
   process.exit(1);
 }
+if (!publicUrl) {
+  console.error('PUBLIC_URL is required (substitutes <YOUR_PUBLIC_URL>).');
+  process.exit(1);
+}
 
 let config = readFileSync(srcConfig, 'utf8');
 config = config
   .replaceAll('<YOUR_ACCOUNT_ID>', accountId)
   .replaceAll('<imagine-kv-namespace-id>', kvId)
+  .replaceAll('<YOUR_PUBLIC_URL>', publicUrl)
   .replace(/(registry\.cloudflare\.com\/[^/]+\/imagine-mcp):[^"]+/, `$1:${imageTag}`)
   // Drop the routes block: imagine.n24q02m.com is already attached as a custom
   // domain, and editing zone Workers Routes needs a zone-scoped token the
@@ -66,6 +83,22 @@ config = config
   .replace(/^(\s*)"name":\s*"imagine-mcp-worker",\s*$/m, '$1"name": "imagine-mcp-worker",\n$1"workers_dev": false,\n$1"preview_urls": false,');
 
 writeFileSync(tmpConfig, config, 'utf8');
+
+if (dryRun) {
+  // Print the fully-substituted config and flag any placeholder still left, then
+  // exit without touching Cloudflare (the temp config is not deployed).
+  const leftover = [...new Set(config.match(/<[A-Za-z0-9_-]+>/g) || [])];
+  console.log('cf:deploy --dry-run - substituted config (not deploying):\n');
+  console.log(config);
+  rmSync(tmpConfig, { force: true });
+  if (leftover.length) {
+    console.error(`\nFAIL: unsubstituted placeholder(s) remain: ${leftover.join(', ')}`);
+    process.exit(1);
+  }
+  console.log('\nOK: no unsubstituted <...> placeholders remain.');
+  process.exit(0);
+}
+
 console.log('cf:deploy - deploying config-only Worker + Container update');
 
 try {

--- a/scripts/cf_deploy_config.mjs
+++ b/scripts/cf_deploy_config.mjs
@@ -46,7 +46,6 @@ const dryRun = process.argv.includes('--dry-run');
 
 const accountId = process.env.CLOUDFLARE_ACCOUNT_ID || (dryRun ? 'DRYRUN_ACCOUNT' : undefined);
 const kvId = process.env.IMAGINE_KV_NAMESPACE_ID || (dryRun ? 'DRYRUN_KV_ID' : undefined);
-const publicUrl = process.env.PUBLIC_URL;
 const imageTag = process.env.IMAGINE_IMAGE_TAG || 'beta';
 
 if (!dryRun && !process.env.CLOUDFLARE_API_TOKEN) {
@@ -61,16 +60,11 @@ if (!kvId) {
   console.error('IMAGINE_KV_NAMESPACE_ID is required (substitutes <imagine-kv-namespace-id>).');
   process.exit(1);
 }
-if (!publicUrl) {
-  console.error('PUBLIC_URL is required (substitutes <YOUR_PUBLIC_URL>).');
-  process.exit(1);
-}
 
 let config = readFileSync(srcConfig, 'utf8');
 config = config
   .replaceAll('<YOUR_ACCOUNT_ID>', accountId)
   .replaceAll('<imagine-kv-namespace-id>', kvId)
-  .replaceAll('<YOUR_PUBLIC_URL>', publicUrl)
   .replace(/(registry\.cloudflare\.com\/[^/]+\/imagine-mcp):[^"]+/, `$1:${imageTag}`)
   // Drop the routes block: imagine.n24q02m.com is already attached as a custom
   // domain, and editing zone Workers Routes needs a zone-scoped token the
@@ -81,6 +75,18 @@ config = config
   // *.workers.dev URL + Preview URLs. Pin them off so the only public surface
   // stays the already-attached custom domain.
   .replace(/^(\s*)"name":\s*"imagine-mcp-worker",\s*$/m, '$1"name": "imagine-mcp-worker",\n$1"workers_dev": false,\n$1"preview_urls": false,');
+
+// Substitute the public origin only if the base config still carries the
+// placeholder (a maintainer who hardcoded their own domain needs no PUBLIC_URL).
+const PUBLIC_URL_PLACEHOLDER = '<YOUR_PUBLIC_URL>';
+if (config.includes(PUBLIC_URL_PLACEHOLDER)) {
+  const publicUrl = process.env.PUBLIC_URL;
+  if (!publicUrl) {
+    console.error('PUBLIC_URL is not set (base wrangler.jsonc uses <YOUR_PUBLIC_URL>).');
+    process.exit(1);
+  }
+  config = config.split(PUBLIC_URL_PLACEHOLDER).join(publicUrl);
+}
 
 writeFileSync(tmpConfig, config, 'utf8');
 

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -29,11 +29,11 @@
   // and any provider keys you want server-default (GEMINI_API_KEY / OPENAI_API_KEY /
   // XAI_API_KEY) -- though per-sub keys via the /authorize form are preferred.
   "vars": {
-    "PUBLIC_URL": "https://imagine.n24q02m.com",
+    "PUBLIC_URL": "<YOUR_PUBLIC_URL>",
     "MCP_STORAGE_BACKEND": "cf-kv",
     "MCP_KV_BASE_URL": "http://kv.internal",
     "IMAGINE_OUTPUT_MODE": "base64"
   },
-  "routes": [{ "pattern": "imagine.n24q02m.com", "custom_domain": true }],
+  "routes": [{ "pattern": "<YOUR_WORKER_DOMAIN>", "custom_domain": true }],
   "observability": { "enabled": true }
 }


### PR DESCRIPTION
Base wrangler.jsonc now fully BYO: PUBLIC_URL + routes use placeholders. deploy_cf.py uses gitignored wrangler.deploy.jsonc; maintainer CD unaffected.