### PR TITLE
🛡️ Sentinel: [MEDIUM] Add input validation for MCP_PORT and MCP_HOST

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -11,3 +11,7 @@
 **Vulnerability:** Use of `os.path.splitext()` for URL extensions is platform-dependent and susceptible to bypasses if query parameters or fragments are not perfectly stripped.
 **Learning:** `os.path.splitext()` follows the host OS's path rules (e.g., handling backslashes on Windows), which may not align with URL path semantics. Also, manual string splitting for URL components is error-prone compared to standard `urlparse`.
 **Prevention:** Use `urllib.parse.urlparse` to extract the path from a URL, and use `posixpath.splitext()` to ensure consistent extension extraction regardless of the server's operating system.
+## 2026-07-03 - [MEDIUM] Add input validation for MCP_PORT and MCP_HOST
+**Vulnerability:** The application blindly casted `MCP_PORT` to an integer and passed `MCP_HOST` without verifying format validity. Malformed environment variables could cause unhandled exceptions leading to stack trace leakage or unexpected behavior.
+**Learning:** Application startup code should robustly validate user-provided environment configuration (like port numbers and IPs/hostnames) and handle exceptions securely (using clear log messages or generic exits instead of throwing internal tracebacks).
+**Prevention:** Use defensive parsing (`int()` with range checks for ports, `ipaddress.ip_address` or regex for hostnames) and employ `try...except` blocks that catch formatting errors, raising clean `SystemExit` messages using `from None` to hide internal stack traces from operators.

--- a/src/imagine_mcp/server.py
+++ b/src/imagine_mcp/server.py
@@ -3,7 +3,9 @@
 from __future__ import annotations
 
 import asyncio
+import ipaddress
 import os
+import re
 from functools import cache
 from importlib.resources import files
 from pathlib import Path
@@ -332,9 +334,26 @@ async def run_http(port: int = 0) -> None:
                 "MCP_DCR_SERVER_SECRET missing. Multi-user remote mode "
                 "requires the DCR secret."
             )
-        port = int(os.environ.get("MCP_PORT", "8080"))
+
+        port_str = os.environ.get("MCP_PORT", "8080")
+        try:
+            port = int(port_str)
+            if not 0 <= port <= 65535:
+                raise ValueError()
+        except ValueError:
+            raise SystemExit(f"imagine-mcp refuses to start: Invalid MCP_PORT {port_str!r}.") from None
+
+        host_str = os.environ.get("MCP_HOST", "127.0.0.1")
+        try:
+            ipaddress.ip_address(host_str)
+        except ValueError:
+            if re.match(r"^\d{1,3}(\.\d{1,3}){3}$", host_str):
+                raise SystemExit(f"imagine-mcp refuses to start: Invalid MCP_HOST IP address {host_str!r}.") from None
+            if not re.match(r"^([a-zA-Z0-9]([a-zA-Z0-9\-]{0,61}[a-zA-Z0-9])?\.)*[a-zA-Z0-9]([a-zA-Z0-9\-]{0,61}[a-zA-Z0-9])?$", host_str):
+                raise SystemExit(f"imagine-mcp refuses to start: Invalid MCP_HOST hostname {host_str!r}.") from None
+
+        host = host_str
         mode_label = "http remote relay (multi-user)"
-        host = os.environ.get("MCP_HOST", "127.0.0.1")
     else:
         host = "127.0.0.1"
         mode_label = "http local relay"

--- a/src/imagine_mcp/server.py
+++ b/src/imagine_mcp/server.py
@@ -341,16 +341,25 @@ async def run_http(port: int = 0) -> None:
             if not 0 <= port <= 65535:
                 raise ValueError()
         except ValueError:
-            raise SystemExit(f"imagine-mcp refuses to start: Invalid MCP_PORT {port_str!r}.") from None
+            raise SystemExit(
+                f"imagine-mcp refuses to start: Invalid MCP_PORT {port_str!r}."
+            ) from None
 
         host_str = os.environ.get("MCP_HOST", "127.0.0.1")
         try:
             ipaddress.ip_address(host_str)
         except ValueError:
             if re.match(r"^\d{1,3}(\.\d{1,3}){3}$", host_str):
-                raise SystemExit(f"imagine-mcp refuses to start: Invalid MCP_HOST IP address {host_str!r}.") from None
-            if not re.match(r"^([a-zA-Z0-9]([a-zA-Z0-9\-]{0,61}[a-zA-Z0-9])?\.)*[a-zA-Z0-9]([a-zA-Z0-9\-]{0,61}[a-zA-Z0-9])?$", host_str):
-                raise SystemExit(f"imagine-mcp refuses to start: Invalid MCP_HOST hostname {host_str!r}.") from None
+                raise SystemExit(
+                    f"imagine-mcp refuses to start: Invalid MCP_HOST IP address {host_str!r}."
+                ) from None
+            if not re.match(
+                r"^([a-zA-Z0-9]([a-zA-Z0-9\-]{0,61}[a-zA-Z0-9])?\.)*[a-zA-Z0-9]([a-zA-Z0-9\-]{0,61}[a-zA-Z0-9])?$",
+                host_str,
+            ):
+                raise SystemExit(
+                    f"imagine-mcp refuses to start: Invalid MCP_HOST hostname {host_str!r}."
+                ) from None
 
         host = host_str
         mode_label = "http remote relay (multi-user)"

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -388,6 +388,7 @@ def test_main_calls_run_http() -> None:
             mock_run.assert_called_once()
         coro.close()
 
+
 @pytest.mark.asyncio
 async def test_run_http_remote_relay_invalid_port(monkeypatch) -> None:
     from imagine_mcp.server import run_http
@@ -397,18 +398,25 @@ async def test_run_http_remote_relay_invalid_port(monkeypatch) -> None:
 
     # Test non-integer port
     monkeypatch.setenv("MCP_PORT", "not-a-port")
-    with pytest.raises(SystemExit, match="imagine-mcp refuses to start: Invalid MCP_PORT"):
+    with pytest.raises(
+        SystemExit, match="imagine-mcp refuses to start: Invalid MCP_PORT"
+    ):
         await run_http()
 
     # Test negative port
     monkeypatch.setenv("MCP_PORT", "-1")
-    with pytest.raises(SystemExit, match="imagine-mcp refuses to start: Invalid MCP_PORT"):
+    with pytest.raises(
+        SystemExit, match="imagine-mcp refuses to start: Invalid MCP_PORT"
+    ):
         await run_http()
 
     # Test out of range port
     monkeypatch.setenv("MCP_PORT", "70000")
-    with pytest.raises(SystemExit, match="imagine-mcp refuses to start: Invalid MCP_PORT"):
+    with pytest.raises(
+        SystemExit, match="imagine-mcp refuses to start: Invalid MCP_PORT"
+    ):
         await run_http()
+
 
 @pytest.mark.asyncio
 async def test_run_http_remote_relay_invalid_host(monkeypatch) -> None:
@@ -419,10 +427,14 @@ async def test_run_http_remote_relay_invalid_host(monkeypatch) -> None:
 
     # Test malformed IP
     monkeypatch.setenv("MCP_HOST", "999.999.999.999")
-    with pytest.raises(SystemExit, match="imagine-mcp refuses to start: Invalid MCP_HOST IP address"):
+    with pytest.raises(
+        SystemExit, match="imagine-mcp refuses to start: Invalid MCP_HOST IP address"
+    ):
         await run_http()
 
     # Test invalid hostname format
     monkeypatch.setenv("MCP_HOST", "invalid host name")
-    with pytest.raises(SystemExit, match="imagine-mcp refuses to start: Invalid MCP_HOST hostname"):
+    with pytest.raises(
+        SystemExit, match="imagine-mcp refuses to start: Invalid MCP_HOST hostname"
+    ):
         await run_http()

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -387,3 +387,42 @@ def test_main_calls_run_http() -> None:
             main()
             mock_run.assert_called_once()
         coro.close()
+
+@pytest.mark.asyncio
+async def test_run_http_remote_relay_invalid_port(monkeypatch) -> None:
+    from imagine_mcp.server import run_http
+
+    monkeypatch.setenv("PUBLIC_URL", "https://ex.com")
+    monkeypatch.setenv("MCP_DCR_SERVER_SECRET", "secret")
+
+    # Test non-integer port
+    monkeypatch.setenv("MCP_PORT", "not-a-port")
+    with pytest.raises(SystemExit, match="imagine-mcp refuses to start: Invalid MCP_PORT"):
+        await run_http()
+
+    # Test negative port
+    monkeypatch.setenv("MCP_PORT", "-1")
+    with pytest.raises(SystemExit, match="imagine-mcp refuses to start: Invalid MCP_PORT"):
+        await run_http()
+
+    # Test out of range port
+    monkeypatch.setenv("MCP_PORT", "70000")
+    with pytest.raises(SystemExit, match="imagine-mcp refuses to start: Invalid MCP_PORT"):
+        await run_http()
+
+@pytest.mark.asyncio
+async def test_run_http_remote_relay_invalid_host(monkeypatch) -> None:
+    from imagine_mcp.server import run_http
+
+    monkeypatch.setenv("PUBLIC_URL", "https://ex.com")
+    monkeypatch.setenv("MCP_DCR_SERVER_SECRET", "secret")
+
+    # Test malformed IP
+    monkeypatch.setenv("MCP_HOST", "999.999.999.999")
+    with pytest.raises(SystemExit, match="imagine-mcp refuses to start: Invalid MCP_HOST IP address"):
+        await run_http()
+
+    # Test invalid hostname format
+    monkeypatch.setenv("MCP_HOST", "invalid host name")
+    with pytest.raises(SystemExit, match="imagine-mcp refuses to start: Invalid MCP_HOST hostname"):
+        await run_http()


### PR DESCRIPTION
**🚨 Severity:** MEDIUM
**💡 Vulnerability:** The application extracted `MCP_PORT` and `MCP_HOST` from the environment without thorough validation. An invalid format would raise a `ValueError` crashing the application unexpectedly and potentially leaking stack trace information to logs.
**🎯 Impact:** Unvalidated input risks operational instability (crashing), configuration bypasses (malformed strings slipping into downstream libraries), and stack trace leakage which is an information disclosure risk.
**🔧 Fix:** Wrapped `MCP_PORT` extraction in a `try...except ValueError` block that checks bounds (0-65535) and explicitly catches format errors to raise a clear `SystemExit(...) from None`. Wrapped `MCP_HOST` in an `ipaddress` validation check and fallback regex validation to prevent malformed strings like '999.999.999.999' from bypassing network libraries.
**✅ Verification:** Ran `uv run pytest tests/test_server.py` covering invalid, out of bounds, and negative port numbers as well as invalid IP formats and invalid hostname syntaxes.

---
*PR created automatically by Jules for task [15244423804041403288](https://jules.google.com/task/15244423804041403288) started by @n24q02m*