### PR TITLE
perf: ⚡ Bolt: consolidate consecutive asyncio.to_thread calls in emit_media

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -48,3 +48,7 @@
 ## 2026-07-02 - [Pipeline Async I/O Gathers]
 **Learning:** Pipelining sequential asynchronous phases (like URL validation followed by fetching) into a single concurrent phase per URL using `asyncio.gather` can severely degrade error handling and latency if the first phase was intended as a fast fail-safe. If `return_exceptions=True` is used, a quick validation failure will be masked and delayed until all other slow tasks finish, wasting resources and degrading latency.
 **Action:** Preserve barrier synchronization between fast validation phases and slow I/O phases when the fast phase is intended to fail-fast. Do not pipeline them into a single `gather` call if it compromises early error detection.
+
+## 2024-07-07 - Consolidate Consecutive Synchronous I/O in Async Contexts
+**Learning:** Executing consecutive synchronous file operations (e.g., `mkdir` followed by `write_bytes`) by wrapping each individually in `asyncio.to_thread` introduces unnecessary thread-pool scheduling and context-switching overhead.
+**Action:** When performing multiple related blocking operations in an async context, consolidate them into a single synchronous helper function and execute that helper via a single `asyncio.to_thread()` call.

--- a/src/imagine_mcp/media.py
+++ b/src/imagine_mcp/media.py
@@ -502,8 +502,15 @@ async def emit_media(
         out[f"{key}_base64"] = _b64.b64encode(data).decode()
     if output_mode in ("path", "both"):
         out_dir = Path(_pd.user_cache_dir("imagine-mcp")) / "generations"
-        await asyncio.to_thread(out_dir.mkdir, parents=True, exist_ok=True)
-        out_path = out_dir / f"{_uuid.uuid4().hex}{suffix}"
-        await asyncio.to_thread(out_path.write_bytes, data)
+
+        # ⚡ Bolt: Consolidate multiple asyncio.to_thread calls into a single synchronous
+        # helper to significantly reduce context-switching overhead for small I/O operations.
+        def _write_file_sync() -> Path:
+            out_dir.mkdir(parents=True, exist_ok=True)
+            out_path = out_dir / f"{_uuid.uuid4().hex}{suffix}"
+            out_path.write_bytes(data)
+            return out_path
+
+        out_path = await asyncio.to_thread(_write_file_sync)
         out[f"{key}_path"] = str(out_path)
     return out


### PR DESCRIPTION
💡 What: Consolidated the `mkdir` and `write_bytes` synchronous operations in `emit_media` into a single synchronous helper function executed via a single `asyncio.to_thread` call.
🎯 Why: Calling `asyncio.to_thread` repeatedly for consecutive small I/O operations incurs unnecessary thread-pool scheduling and context-switching overhead.
📊 Impact: Reduces thread context-switching overhead during file writes in generation paths.
🔬 Measurement: Verify by checking `emit_media` in `src/imagine_mcp/media.py` and running the test suite (`uv run pytest`).

---
*PR created automatically by Jules for task [9381590056278143733](https://jules.google.com/task/9381590056278143733) started by @n24q02m*