### PR TITLE
perf: ⚡ Bolt: consolidate consecutive file I/O thread dispatches

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -48,3 +48,6 @@
 ## 2026-07-02 - [Pipeline Async I/O Gathers]
 **Learning:** Pipelining sequential asynchronous phases (like URL validation followed by fetching) into a single concurrent phase per URL using `asyncio.gather` can severely degrade error handling and latency if the first phase was intended as a fast fail-safe. If `return_exceptions=True` is used, a quick validation failure will be masked and delayed until all other slow tasks finish, wasting resources and degrading latency.
 **Action:** Preserve barrier synchronization between fast validation phases and slow I/O phases when the fast phase is intended to fail-fast. Do not pipeline them into a single `gather` call if it compromises early error detection.
+## 2025-02-23 - Thread Pool Context Switching Overhead
+**Learning:** Consecutive single-shot synchronous I/O operations (like `mkdir` then `write_bytes`) executed individually via `asyncio.to_thread()` create severe thread-pool scheduling and context-switching overhead, effectively negating the benefits of offloading them from the main event loop.
+**Action:** Always consolidate sequential, synchronous file system operations into a single synchronous helper function and dispatch it with a single `asyncio.to_thread()` call.

--- a/src/imagine_mcp/media.py
+++ b/src/imagine_mcp/media.py
@@ -471,8 +471,8 @@ async def download_to_path_async(url: str, dest: Path) -> Path:
     except InvalidURLError as e:
         raise httpx.HTTPError(f"Download failed due to invalid redirect: {e}") from e
     except Exception:
-        if await asyncio.to_thread(dest.exists):
-            await asyncio.to_thread(dest.unlink, missing_ok=True)
+        # ⚡ Bolt: Remove redundant exists() check to save an unnecessary thread-pool dispatch; unlink(missing_ok=True) is safe
+        await asyncio.to_thread(dest.unlink, missing_ok=True)
         raise
     return dest
 
@@ -502,8 +502,13 @@ async def emit_media(
         out[f"{key}_base64"] = _b64.b64encode(data).decode()
     if output_mode in ("path", "both"):
         out_dir = Path(_pd.user_cache_dir("imagine-mcp")) / "generations"
-        await asyncio.to_thread(out_dir.mkdir, parents=True, exist_ok=True)
         out_path = out_dir / f"{_uuid.uuid4().hex}{suffix}"
-        await asyncio.to_thread(out_path.write_bytes, data)
+
+        def _write_media_sync() -> None:
+            out_dir.mkdir(parents=True, exist_ok=True)
+            out_path.write_bytes(data)
+
+        # ⚡ Bolt: Consolidate consecutive sync file operations to avoid multiple thread-pool dispatches
+        await asyncio.to_thread(_write_media_sync)
         out[f"{key}_path"] = str(out_path)
     return out


### PR DESCRIPTION
💡 **What**: 
- Consolidated sequential synchronous file system operations (`mkdir` and `write_bytes`) into a single helper function within `emit_media`.
- Removed a redundant `dest.exists()` check before `dest.unlink(missing_ok=True)` in `download_to_path_async`.

🎯 **Why**: 
Each `asyncio.to_thread` dispatch incurs scheduling and context-switching overhead. Firing multiple sequential dispatches for atomic, sequential file system operations negates the benefits of offloading them. Consolidating these calls limits thread-pool overhead. Furthermore, `pathlib.Path.unlink(missing_ok=True)` inherently guards against missing files, rendering a preceding `exists()` check wasteful and unnecessary.

📊 **Impact**: 
Reduces the number of thread-pool context switches by ~50% per generated media file and ~50% per failed download cleanup operation.

🔬 **Measurement**: 
Ensure tests pass (`uv run pytest tests/test_media.py`), as `emit_media` and download paths are fully covered, guaranteeing the refactored code safely handles file creation and cleanup.

---
*PR created automatically by Jules for task [12823928956413162608](https://jules.google.com/task/12823928956413162608) started by @n24q02m*