### PR TITLE
fix: reject unauthenticated /mcp at the Worker edge

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -99,6 +99,15 @@ jobs:
         with:
           files: coverage.xml
 
+      - name: Setup Bun (worker tests)
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
+
+      - name: Install worker dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Run worker tests
+        run: bun run test:worker
+
   # NOTE: CodeQL analysis is handled by GitHub's default setup for this public
   # repo (see Security -> Code scanning). Workflow-based CodeQL conflicts with
   # default setup ("CodeQL analyses from advanced configurations cannot be

--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,9 @@ package-lock.json
 .wrangler/
 .wrangler-dryrun/
 wrangler.deploy-tmp.jsonc
+# Live substituted deploy config (real account/KV/D1/Vectorize IDs), written by
+# scripts/deploy_cf.py -- never commit
+wrangler.deploy.jsonc
 
 # AI traces (per CLAUDE.md public repo policy — superpower content lives in private repo n24q02m/.superpower)
 .jules/

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -103,8 +103,36 @@ export const OUTBOUND_BY_HOST: Record<string, OutboundHandler<Env>> = {
   'kv.internal': kvOutbound,
 }
 
+// Bearer credential presence check for the edge auth gate below. Structural
+// only -- validity is the container's job (mcp-core's OAuth AS runs inside it).
+const BEARER = /^Bearer\s+\S/i
+
+function unauthenticated(request: Request): Response {
+  const { origin } = new URL(request.url)
+  return new Response(null, {
+    status: 401,
+    headers: {
+      'WWW-Authenticate': `Bearer resource_metadata="${origin}/.well-known/oauth-protected-resource"`,
+    },
+  })
+}
+
 export default {
   async fetch(request: Request, env: Env): Promise<Response> {
+    // Edge auth gate. mcp-core's OAuth AS runs INSIDE the container, so before
+    // this gate every anonymous /mcp request started the container and reset
+    // its 5m idle timer -- an unauthenticated caller could pin it awake and
+    // bill GiB-s around the clock. Verified 2026-07-09 on the sibling
+    // better-email-mcp deployment: a python-httpx client POSTed /mcp with no
+    // Authorization header every ~20s for 12h+. The check is STRUCTURAL: it
+    // rejects requests carrying no bearer credential at all and reproduces the
+    // container's own 401 (empty body + RFC 9728 WWW-Authenticate). Token
+    // VALIDITY is never judged here -- the container remains the sole
+    // authority, so no mcp-core auth logic is duplicated at the edge.
+    const url = new URL(request.url)
+    if (url.pathname === '/mcp' || url.pathname.startsWith('/mcp/')) {
+      if (!BEARER.test(request.headers.get('authorization') ?? '')) return unauthenticated(request)
+    }
     // Public entrypoint: ONLY routes inbound requests to the per-user container
     // DO. The kv.internal outbound handler is deliberately NOT dispatched here —
     // exposing it on the public fetch surface would let an external caller

--- a/tests/worker.test.ts
+++ b/tests/worker.test.ts
@@ -91,9 +91,14 @@ describe('single-user DO contract (E.2)', () => {
     }
   }
 
-  it('no Bearer token -> routes to the "default" DO', async () => {
+  it('no Bearer token on a non-/mcp path -> routes to the "default" DO', async () => {
+    // Uses /authorize, not /mcp: the edge auth gate (added alongside this test)
+    // now rejects an unauthenticated /mcp request before extractUserId() is
+    // ever reached, so /mcp is no longer a valid path to exercise the DO-naming
+    // fallback in isolation. /authorize is unauthenticated by design (it is
+    // where mcp-core's OAuth AS itself issues the token) and stays ungated.
     const { calls, env } = envWithDoSpy()
-    const res = await worker.fetch(new Request('https://imagine.n24q02m.com/mcp'), env as never)
+    const res = await worker.fetch(new Request('https://imagine.n24q02m.com/authorize'), env as never)
     expect(res.status).toBe(200)
     expect(calls).toEqual(['default'])
   })
@@ -109,13 +114,74 @@ describe('single-user DO contract (E.2)', () => {
     expect(calls).toEqual(['default'])
   })
 
-  it('Bearer token with sub -> routes to that sub DO (per-user isolation)', async () => {
+  it('Bearer token with sub -> still routes to the "default" DO (SINGLE-DO COLLAPSE, see extractUserId)', async () => {
     const { calls, env } = envWithDoSpy()
     const jwt = `h.${btoa(JSON.stringify({ sub: 'user-123' }))}.s`
     await worker.fetch(
-      new Request('https://imagine.n24q02m.com/mcp', { headers: { authorization: `Bearer ${jwt}` } }),
+      new Request('https://imagine.n24q02m.com/mcp', {
+        method: 'POST',
+        headers: { authorization: `Bearer ${jwt}` },
+      }),
       env as never,
     )
-    expect(calls).toEqual(['user-123'])
+    expect(calls).toEqual(['default'])
+  })
+})
+
+describe('edge auth gate rejects anonymous /mcp before touching the container DO', () => {
+  function envWithDoSpy() {
+    let stubCalls = 0
+    return {
+      calls: () => stubCalls,
+      env: {
+        IMAGINE: {
+          idFromName: (n: string) => ({ name: n }),
+          get: (_id: unknown) => ({
+            fetch: async () => {
+              stubCalls++
+              return new Response('routed', { status: 200 })
+            },
+          }),
+        },
+      },
+    }
+  }
+
+  it('POST /mcp with no Authorization -> 401, stub never called', async () => {
+    const { calls, env } = envWithDoSpy()
+    const res = await worker.fetch(new Request('https://imagine.n24q02m.com/mcp', { method: 'POST' }), env as never)
+    expect(res.status).toBe(401)
+    expect(res.headers.get('WWW-Authenticate')).toMatch(
+      /^Bearer resource_metadata="https:\/\/[^"]+\/\.well-known\/oauth-protected-resource"$/,
+    )
+    expect(await res.text()).toBe('')
+    expect(calls()).toBe(0)
+  })
+
+  it('OPTIONS /mcp with no Authorization -> 401, stub never called', async () => {
+    const { calls, env } = envWithDoSpy()
+    const res = await worker.fetch(new Request('https://imagine.n24q02m.com/mcp', { method: 'OPTIONS' }), env as never)
+    expect(res.status).toBe(401)
+    expect(calls()).toBe(0)
+  })
+
+  it('POST /mcp with Authorization: Bearer anything -> stub called exactly once', async () => {
+    const { calls, env } = envWithDoSpy()
+    const res = await worker.fetch(
+      new Request('https://imagine.n24q02m.com/mcp', {
+        method: 'POST',
+        headers: { authorization: 'Bearer anything' },
+      }),
+      env as never,
+    )
+    expect(res.status).toBe(200)
+    expect(calls()).toBe(1)
+  })
+
+  it('GET /authorize with no Authorization -> non-/mcp path passes through to the DO', async () => {
+    const { calls, env } = envWithDoSpy()
+    const res = await worker.fetch(new Request('https://imagine.n24q02m.com/authorize?foo=1'), env as never)
+    expect(res.status).toBe(200)
+    expect(calls()).toBe(1)
   })
 })


### PR DESCRIPTION
## The cost bug

mcp-core's OAuth Authorization Server runs INSIDE the container, so an anonymous
request to `/mcp` reaches the Durable Object, starts the container, and resets
its 5-minute idle timer. The container then answers 401 itself. Consequence:
any unauthenticated caller can keep the container awake indefinitely, and
Cloudflare bills container memory (GiB-s) around the clock.

Measured on the sibling `better-email-mcp` deployment (verified 2026-07-09): an
unauthenticated `python-httpx/0.28.1` client POSTed `/mcp` with NO
`Authorization` header roughly every 20 seconds for over 12 hours -- 1282 x
HTTP 401 in a 6-hour window -- pinning that container awake 24/7.
`imagine-mcp` happens to be asleep today only because nobody is hammering it;
the exposure is identical, and the endpoint is published publicly on
`imagine.n24q02m.com`. This PR preventively hardens it against the same
exposure.

## The fix

A purely structural edge gate in `src/worker.ts`: if the request path is
`/mcp` (or under it) and there is no bearer credential in the `Authorization`
header, answer 401 at the edge and never touch the Durable Object.

It does not judge token validity -- no JWT verification, no decoding, no
crypto import. The container stays the sole authority on whether a token is
good; a request carrying any `Bearer <something>` is forwarded exactly as
before. This keeps mcp-core's auth logic un-duplicated.

The 401 is byte-compatible with what the container returns today: status
401, empty body, header
`WWW-Authenticate: Bearer resource_metadata="<origin>/.well-known/oauth-protected-resource"`,
nothing else. The gate applies to every method (`POST`/`GET`/`HEAD`/`OPTIONS`)
since the container 401s all of them alike (no CORS preflight exemption).
Everything else (`/authorize`, `/token`, `/register`, `/.well-known/*`,
`/health`) keeps reaching the container unchanged.

## Existing tests updated to match

Running the full suite after adding the gate's own tests surfaced two
existing assertions in `tests/worker.test.ts` that no longer matched
reality:

1. `no Bearer token -> routes to the "default" DO` sent an unauthenticated
   request to `/mcp` and expected the DO stub to answer 200 -- that is
   literally the vulnerable behavior this PR removes. Since `/mcp` is now
   unreachable without a Bearer credential, the test now exercises
   `/authorize` instead (still unauthenticated by design -- it is where
   mcp-core's OAuth AS issues the token -- and stays outside the gate), which
   preserves its actual intent: verifying `extractUserId()`'s DO-naming
   fallback.
2. `Bearer token with sub -> routes to that sub DO (per-user isolation)`
   asserted per-sub DO routing, but `extractUserId()` was collapsed to a
   single reserved DO (`return 'default'`) on 2026-06-30 to resolve a
   `max_instances=1` deadlock (see the `SINGLE-DO COLLAPSE` comment in
   `src/worker.ts`) -- the assertion was never updated. Corrected to expect
   `'default'`.

Both were verified pre-existing / caused directly by this change (not
independent flakiness) by stashing this PR's diff and re-running against
unmodified `origin/main`.

## CI now actually runs the worker suite

`package.json` has had a `test:worker` script (vitest) all along, but no
workflow ever invoked it -- `ci.yml` only runs the Python suite
(`uv run pytest`). That is exactly why the two stale/conflicting assertions
above went unnoticed. Added a `Setup Bun` + `bun install --frozen-lockfile` +
`bun run test:worker` step to the existing `lint-and-test` job, matching this
repo's own `cd.yml` convention (which already uses `oven-sh/setup-bun` +
`bun install --frozen-lockfile` for the wrangler deploy step). Note: neither
`bun.lock` nor `package-lock.json` is committed to this repo (the latter is
explicitly gitignored), so `--frozen-lockfile` resolves fresh from
`package.json` each run rather than pinning exact versions -- pre-existing
repo state, unrelated to this change.

## Verification (real output)

- `npx vitest run tests/worker.test.ts` -- **13/13 passed** (9 pre-existing,
  2 corrected, 4 new gate tests), and `bun run test:worker` (the exact CI
  command) reproduces the same 13/13 locally.
- `npx tsc --noEmit` -- 8 pre-existing errors, all in the untouched
  outbound-handler test block (`tests/worker.test.ts` lines 22-61), verified
  identical against unmodified `origin/main` via `git stash`. No `typecheck`
  script is configured in `package.json` and no CI step runs `tsc`, so this
  has never been gated; out of scope for this PR (not caused by, and not
  fixed by, this change). Flagging for visibility.
- `npx wrangler deploy --dry-run --outdir .wrangler-dryrun` -- succeeds
  cleanly; worker still bundles (58.90 KiB / gzip 14.57 KiB), all bindings
  resolve.

Structural only -- the container remains the sole authority on token
validity; no mcp-core auth logic is duplicated at the edge.

## Untracked credential file, now gitignored

Auditing the working tree for stray credential artifacts (same class of issue
as `better-telegram-mcp` PR #902) found `wrangler.deploy.jsonc`: untracked,
NOT matched by any `.gitignore` pattern, and confirmed to hold live
substituted values (no `<YOUR_ACCOUNT_ID>` / `<imagine-kv-namespace-id>` /
`<YOUR_PUBLIC_URL>` placeholders remain -- checked structurally, contents were
never printed). `scripts/deploy_cf.py:67` actively reads/writes this exact
filename, and its own docstring already documents it as "gitignored" --
`.gitignore` only had `wrangler.deploy-tmp.jsonc` (the separate
`cf_deploy_config.mjs` script's temp file), a filename mismatch that left the
real one exposed to a plain `git add -A`. Added the missing pattern; file left
in place since `deploy_cf.py` still consumes it.

`bun.lock` is also untracked here but is not a credential -- it is a lockfile
`--frozen-lockfile` currently has nothing committed to freeze against (see
CI-wiring note above); not fixed in this PR (out of scope, no secret
exposure).

DO NOT MERGE -- opening for review per work order.
