### PR TITLE
fix: decline standing GET /mcp SSE stream at the edge

### DIFF
--- a/src/worker.ts
+++ b/src/worker.ts
@@ -133,6 +133,17 @@ export default {
     if (url.pathname === '/mcp' || url.pathname.startsWith('/mcp/')) {
       if (!BEARER.test(request.headers.get('authorization') ?? '')) return unauthenticated(request)
     }
+    // Standing GET /mcp = the streamable-HTTP server-push SSE stream. On a
+    // scale-to-zero container this is pure idle cost: @cloudflare/containers
+    // counts an open stream as an in-flight request forever (inflight > 0 =>
+    // activity never expires), so a single idle client pins the container
+    // awake 24/7. None of this stack's servers send server-initiated
+    // messages; request-scoped notifications ride the POST's own SSE
+    // response. The spec allows declining the stream: both official SDKs
+    // treat 405 as the optional-feature path and continue POST-only.
+    if (request.method === 'GET' && (url.pathname === '/mcp' || url.pathname.startsWith('/mcp/'))) {
+      return new Response(null, { status: 405, headers: { Allow: 'POST, DELETE' } })
+    }
     // Public entrypoint: ONLY routes inbound requests to the per-user container
     // DO. The kv.internal outbound handler is deliberately NOT dispatched here —
     // exposing it on the public fetch surface would let an external caller

--- a/tests/worker.test.ts
+++ b/tests/worker.test.ts
@@ -107,8 +107,14 @@ describe('single-user DO contract (E.2)', () => {
     const { calls, env } = envWithDoSpy()
     // header.payload.sig where payload has no `sub`
     const jwt = `h.${btoa(JSON.stringify({ aud: 'x' }))}.s`
+    // POST, not GET: GET /mcp is declined with 405 at the edge (see "edge gate
+    // declines standing GET /mcp SSE stream" below) before extractUserId() is
+    // ever reached, so it is no longer a valid path to exercise DO routing.
     await worker.fetch(
-      new Request('https://imagine.n24q02m.com/mcp', { headers: { authorization: `Bearer ${jwt}` } }),
+      new Request('https://imagine.n24q02m.com/mcp', {
+        method: 'POST',
+        headers: { authorization: `Bearer ${jwt}` },
+      }),
       env as never,
     )
     expect(calls).toEqual(['default'])
@@ -183,5 +189,54 @@ describe('edge auth gate rejects anonymous /mcp before touching the container DO
     const res = await worker.fetch(new Request('https://imagine.n24q02m.com/authorize?foo=1'), env as never)
     expect(res.status).toBe(200)
     expect(calls()).toBe(1)
+  })
+})
+
+describe('edge gate declines the standing GET /mcp SSE stream (405)', () => {
+  function envWithDoSpy() {
+    let stubCalls = 0
+    return {
+      calls: () => stubCalls,
+      env: {
+        IMAGINE: {
+          idFromName: (n: string) => ({ name: n }),
+          get: (_id: unknown) => ({
+            fetch: async () => {
+              stubCalls++
+              return new Response('routed', { status: 200 })
+            },
+          }),
+        },
+      },
+    }
+  }
+
+  it('GET /mcp with a Bearer token -> 405, Allow: POST, DELETE, stub never called', async () => {
+    const { calls, env } = envWithDoSpy()
+    const res = await worker.fetch(
+      new Request('https://imagine.n24q02m.com/mcp', { headers: { authorization: 'Bearer x' } }),
+      env as never,
+    )
+    expect(res.status).toBe(405)
+    expect(res.headers.get('Allow')).toBe('POST, DELETE')
+    expect(calls()).toBe(0)
+  })
+
+  it('GET /mcp/sub with a Bearer token -> 405, stub never called', async () => {
+    const { calls, env } = envWithDoSpy()
+    const res = await worker.fetch(
+      new Request('https://imagine.n24q02m.com/mcp/sub', { headers: { authorization: 'Bearer x' } }),
+      env as never,
+    )
+    expect(res.status).toBe(405)
+    expect(res.headers.get('Allow')).toBe('POST, DELETE')
+    expect(calls()).toBe(0)
+  })
+
+  it('GET /mcp with no Authorization -> still 401 (bearer gate runs before the 405 decline)', async () => {
+    const { calls, env } = envWithDoSpy()
+    const res = await worker.fetch(new Request('https://imagine.n24q02m.com/mcp'), env as never)
+    expect(res.status).toBe(401)
+    expect(calls()).toBe(0)
   })
 })


### PR DESCRIPTION
## Summary
- The edge worker's public `fetch` handler now returns `405 Allow: POST, DELETE` for any GET on `/mcp` or `/mcp/*`, right after the bearer-presence gate and before routing to the container Durable Object.
- `@cloudflare/containers` counts an open proxied stream as an in-flight request forever, so a standing GET /mcp SSE stream from any MCP client pins the scale-to-zero container awake 24/7 even though it currently sleeps correctly. This is parity/protection against any future client that opens one.
- The streamable-HTTP spec allows declining the GET stream this way; both official SDKs already treat 405 on GET as the optional-feature path and continue operating POST-only. Request-scoped notifications ride the POST's own SSE response, so nothing is lost.

## Test plan
- [x] `bunx vitest run tests/worker.test.ts` — 16/16 passing, including 3 new cases: GET /mcp with bearer -> 405 (Allow header asserted), GET /mcp/sub with bearer -> 405, GET /mcp without bearer -> still 401 (edge auth gate keeps precedence).
- [x] Updated one pre-existing test that implicitly sent an unauthenticated-shaped GET to /mcp to instead use POST, since GET is now always declined regardless of auth.