### PR TITLE
fix: enforce fix(deps) semantic commit prefix in renovate config

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -124,5 +124,16 @@
       ],
       "enabled": false
     }
-  ]
+  ],
+  "semanticCommits": "enabled",
+  "commitMessagePrefix": "fix(deps):",
+  "commitMessageAction": "update",
+  "commitMessageTopic": "{{depName}}",
+  "semanticCommitType": "fix",
+  "semanticCommitScope": "deps",
+  "golang": {
+    "postUpdateOptions": [
+      "gomodTidy"
+    ]
+  }
 }


### PR DESCRIPTION
Without an explicit `semanticCommitType` override, Renovate falls back to its own default mapping and emits `chore(deps):` commit titles for major-version and github-actions bumps — violating this org's `fix:`/`feat:`-only commit prefix convention. This repo already enforces the convention via a PR-title CI gate (amannn/action-semantic-pull-request), which is exactly what caught PR #435 earlier today.

Adds the same `semanticCommits`/`commitMessagePrefix`/`semanticCommitType` block already in use by mcp-core and web-core, so future Renovate PR titles pass the title gate without manual intervention.