### PR TITLE
feat: pin structured output for domain tools

### DIFF
--- a/tests/test_g6_ux_status_accuracy.py
+++ b/tests/test_g6_ux_status_accuracy.py
@@ -14,7 +14,6 @@ before claiming "using_env" and returns needs_setup if none are set.
 
 from __future__ import annotations
 
-import json
 from unittest.mock import patch
 
 import pytest
@@ -44,7 +43,7 @@ class TestRelayStatusLiveDerivedState:
             return_value={"GEMINI_API_KEY": "test-key-123"},
         ):
             result = await app.call_tool("config", {"action": "relay_status"})
-            res = json.loads(result.content[0].text)
+            res = result.structured_content
 
         assert res["status"] == "configured"
         assert "gemini" in res["providers_configured"]
@@ -63,7 +62,7 @@ class TestRelayStatusLiveDerivedState:
             return_value={},
         ):
             result = await app.call_tool("config", {"action": "relay_status"})
-            res = json.loads(result.content[0].text)
+            res = result.structured_content
 
         assert res["status"] == "pending"
         assert res["providers_configured"] == []
@@ -86,7 +85,7 @@ class TestRelayCompleteLiveDerivedState:
             return_value={"OPENAI_API_KEY": "sk-test-123"},
         ):
             result = await app.call_tool("config", {"action": "relay_complete"})
-            res = json.loads(result.content[0].text)
+            res = result.structured_content
 
         assert res["status"] == "saved"
         assert "openai" in res["providers_configured"]
@@ -105,7 +104,7 @@ class TestRelayCompleteLiveDerivedState:
             return_value={},
         ):
             result = await app.call_tool("config", {"action": "relay_complete"})
-            res = json.loads(result.content[0].text)
+            res = result.structured_content
 
         assert res["status"] == "no_credentials"
         assert res["providers_configured"] == []
@@ -124,7 +123,7 @@ class TestRelaySkipHonesty:
         monkeypatch.delenv("XAI_API_KEY", raising=False)
 
         result = await app.call_tool("config", {"action": "relay_skip"})
-        res = json.loads(result.content[0].text)
+        res = result.structured_content
 
         assert res["status"] == "needs_setup"
         assert "open_relay" in res["message"]
@@ -139,7 +138,7 @@ class TestRelaySkipHonesty:
         monkeypatch.delenv("XAI_API_KEY", raising=False)
 
         result = await app.call_tool("config", {"action": "relay_skip"})
-        res = json.loads(result.content[0].text)
+        res = result.structured_content
 
         assert res["status"] == "using_env"
         assert res["message"] == "Using env vars for credentials."

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-import json
+from typing import Any
 from unittest.mock import patch
 
 import pytest
@@ -16,6 +16,13 @@ from imagine_mcp.server import (
     _set_runtime,
     build_app,
 )
+
+
+def _structured(result: Any) -> dict[str, Any]:
+    """Narrow ``ToolResult.structured_content`` for callers below -- also
+    pins that dict-returning tools always populate it (never None)."""
+    assert result.structured_content is not None
+    return result.structured_content
 
 
 def test_build_app_attributes() -> None:
@@ -123,24 +130,24 @@ async def test_tool_config_basic_actions() -> None:
 
     # status
     result = await app.call_tool("config", {"action": "status"})
-    res = json.loads(result.content[0].text)
+    res = _structured(result)
     assert res["version"] == __version__
 
     # warmup
     result = await app.call_tool("config", {"action": "warmup"})
-    res = json.loads(result.content[0].text)
+    res = _structured(result)
     assert res["status"] == "ok"
 
     # set
     result = await app.call_tool(
         "config", {"action": "set", "key": "log_level", "value": "info"}
     )
-    res = json.loads(result.content[0].text)
+    res = _structured(result)
     assert res["status"] == "ok"
 
     # invalid action
     result = await app.call_tool("config", {"action": "nope"})
-    res = json.loads(result.content[0].text)
+    res = _structured(result)
     assert res["status"] == "error"
 
 
@@ -153,7 +160,7 @@ async def test_tool_config_cache_clear(monkeypatch) -> None:
 
     with patch("imagine_mcp.cache.ResponseCache.clear") as mock_clear:
         result = await app.call_tool("config", {"action": "cache_clear"})
-        res = json.loads(result.content[0].text)
+        res = _structured(result)
         assert res["status"] == "ok"
         mock_clear.assert_called_once()
 
@@ -162,7 +169,7 @@ async def test_tool_config_cache_clear(monkeypatch) -> None:
 async def test_tool_config_models_action_removed() -> None:
     app = build_app()
     result = await app.call_tool("config", {"action": "models"})
-    res = json.loads(result.content[0].text)
+    res = _structured(result)
     assert res["status"] == "error"
     assert "Unknown action 'models'" in res["message"]
 
@@ -176,7 +183,7 @@ async def test_tool_understand_wrapper() -> None:
         result = await app.call_tool(
             "understand", {"media_urls": ["http://ex.com/i.jpg"], "prompt": "tell me"}
         )
-        res = json.loads(result.content[0].text)
+        res = _structured(result)
         assert res == {"res": "ok"}
         mock_dispatch.assert_called_once()
 
@@ -235,7 +242,7 @@ async def test_tool_generate_wrapper() -> None:
         result = await app.call_tool(
             "generate", {"media_type": "image", "prompt": "draw me"}
         )
-        res = json.loads(result.content[0].text)
+        res = _structured(result)
         assert res == {"res": "gen"}
         mock_dispatch.assert_called_once()
 
@@ -249,20 +256,20 @@ async def test_tool_config_relay_actions(monkeypatch) -> None:
         "imagine_mcp.server._providers_configured_live", return_value=["gemini"]
     ):
         result = await app.call_tool("config", {"action": "relay_status"})
-        res = json.loads(result.content[0].text)
+        res = _structured(result)
         assert res["status"] == "configured"
         assert res["providers_configured"] == ["gemini"]
 
     # relay_complete
     with patch("imagine_mcp.server._providers_configured_live", return_value=[]):
         result = await app.call_tool("config", {"action": "relay_complete"})
-        res = json.loads(result.content[0].text)
+        res = _structured(result)
         assert res["status"] == "no_credentials"
 
     # relay_skip (using env)
     monkeypatch.setenv("GEMINI_API_KEY", "test")
     result = await app.call_tool("config", {"action": "relay_skip"})
-    res = json.loads(result.content[0].text)
+    res = _structured(result)
     assert res["status"] == "using_env"
 
     # relay_skip (needs setup)
@@ -270,7 +277,7 @@ async def test_tool_config_relay_actions(monkeypatch) -> None:
     monkeypatch.delenv("OPENAI_API_KEY", raising=False)
     monkeypatch.delenv("XAI_API_KEY", raising=False)
     result = await app.call_tool("config", {"action": "relay_skip"})
-    res = json.loads(result.content[0].text)
+    res = _structured(result)
     assert res["status"] == "needs_setup"
 
     # relay_reset
@@ -278,7 +285,7 @@ async def test_tool_config_relay_actions(monkeypatch) -> None:
         "imagine_mcp.relay_setup.reset_credentials", return_value={"status": "reset"}
     ):
         result = await app.call_tool("config", {"action": "relay_reset"})
-        res = json.loads(result.content[0].text)
+        res = _structured(result)
         assert res == {"status": "reset"}
 
 
@@ -291,13 +298,13 @@ async def test_tool_config_open_relay() -> None:
         "imagine_mcp.relay_setup.ensure_config", return_value={"some": "config"}
     ):
         result = await app.call_tool("config", {"action": "open_relay"})
-        res = json.loads(result.content[0].text)
+        res = _structured(result)
         assert res["status"] == "saved"
 
     # Degraded
     with patch("imagine_mcp.relay_setup.ensure_config", return_value=None):
         result = await app.call_tool("config", {"action": "open_relay"})
-        res = json.loads(result.content[0].text)
+        res = _structured(result)
         assert res["status"] == "degraded"
 
 

--- a/tests/test_structured_output.py
+++ b/tests/test_structured_output.py
@@ -1,0 +1,67 @@
+"""S13 W1.1 pin: outputSchema + structuredContent for imagine-mcp tools.
+
+Verifies FastMCP's automatic structured-output derivation for the
+``-> dict[str, Any]`` tools (understand/generate/config) and pins the
+degenerate string-wrap behavior for ``help`` (kept ``-> str`` by design,
+see ``.superpowers/sdd/plan.md`` Global Constraints #1-2).
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+from fastmcp import Client
+
+from imagine_mcp.server import build_app
+
+_DICT_TOOLS = {"understand", "generate", "config"}
+
+
+@pytest.fixture
+def app():
+    return build_app()
+
+
+async def test_dict_tools_expose_object_output_schema(app) -> None:
+    """understand/generate/config -> dict[str, Any] auto-derives a loose
+    object outputSchema (envelope-lỏng per plan Global Constraint 1)."""
+    async with Client(app) as client:
+        tools = await client.list_tools()
+
+    by_name = {t.name: t for t in tools}
+    for name in _DICT_TOOLS:
+        schema = by_name[name].outputSchema
+        assert schema is not None, f"{name} missing outputSchema"
+        assert schema["type"] == "object"
+        assert schema.get("additionalProperties") is True
+
+
+async def test_help_keeps_degenerate_string_wrap(app) -> None:
+    """help() stays -> str by design; FastMCP wraps it as {"result": <str>}
+    (x-fastmcp-wrap-result) instead of a useful object schema. Pinned so a
+    future edit doesn't "fix" help into dict[str, Any] by mistake."""
+    async with Client(app) as client:
+        tools = await client.list_tools()
+        result = await client.call_tool("help", {"topic": "understand"})
+
+    schema = next(t for t in tools if t.name == "help").outputSchema
+    assert schema is not None
+    assert schema.get("x-fastmcp-wrap-result") is True
+    assert schema.get("additionalProperties") is None
+    assert schema["properties"].keys() == {"result"}
+
+    assert result.structured_content == {"result": result.content[0].text}
+    assert "understand" in result.content[0].text.lower()
+
+
+async def test_config_call_emits_structured_content_matching_text(app) -> None:
+    """config(action="status") -> dict dual-emits: structuredContent carries
+    the dict directly, and the legacy TextContent JSON decodes to the same
+    payload (backward-compat wire per plan Global Constraint 5)."""
+    async with Client(app) as client:
+        result = await client.call_tool("config", {"action": "status"})
+
+    assert isinstance(result.structured_content, dict)
+    assert result.structured_content["version"]
+    assert json.loads(result.content[0].text) == result.structured_content


### PR DESCRIPTION
## S13 / WS-D X1 (imagine half — already dict, this pins it)

imagine's `understand`/`generate`/`config` tools already return `-> dict[str, Any]`, so FastMCP already auto-derives `outputSchema` ({type:object, additionalProperties:true}) + emits `structuredContent` alongside the dual TextContent. This PR adds protocol-level tests pinning that behavior (in-memory fastmcp.Client) so a future refactor to `-> str` can't silently regress it; `help` stays `-> str` (degenerate wrap, by design, also pinned).

Zero production code changed (`git diff -- src/` empty); 21 test json.loads sites migrated to `.structured_content` (content assertions preserved), 4 unrelated (stdio JSON-RPC / CF template) left as-is.

Evidence: 314 passed / 3 deselected; ruff + ty (0 diagnostics) + pre-commit clean. Task-reviewed: Approved (zero prod-code verified independently via git diff).