### PR TITLE
perf: ⚡ Bolt: Remove redundant exists() check before unlink(missing_ok=True)

### DIFF
--- a/src/imagine_mcp/media.py
+++ b/src/imagine_mcp/media.py
@@ -454,8 +454,9 @@ def download_to_path(url: str, dest: Path) -> Path:
     except InvalidURLError as e:
         raise httpx.HTTPError(f"Download failed due to invalid redirect: {e}") from e
     except Exception:
-        if dest.exists():
-            dest.unlink(missing_ok=True)
+        # ⚡ Bolt: Removed redundant exists() check before unlink(missing_ok=True)
+        # to avoid unnecessary I/O operation.
+        dest.unlink(missing_ok=True)
         raise
     return dest
 
@@ -471,8 +472,9 @@ async def download_to_path_async(url: str, dest: Path) -> Path:
     except InvalidURLError as e:
         raise httpx.HTTPError(f"Download failed due to invalid redirect: {e}") from e
     except Exception:
-        if await asyncio.to_thread(dest.exists):
-            await asyncio.to_thread(dest.unlink, missing_ok=True)
+        # ⚡ Bolt: Removed redundant exists() check before unlink(missing_ok=True)
+        # to avoid unnecessary thread-pool dispatch overhead.
+        await asyncio.to_thread(dest.unlink, missing_ok=True)
         raise
     return dest
 

--- a/uv.lock
+++ b/uv.lock
@@ -708,7 +708,7 @@ wheels = [
 
 [[package]]
 name = "imagine-mcp"
-version = "1.9.0b2"
+version = "1.9.0b3"
 source = { editable = "." }
 dependencies = [
     { name = "diskcache" },


### PR DESCRIPTION
💡 **What**: Removed the redundant `if dest.exists():` check before calling `dest.unlink(missing_ok=True)` in `download_to_path` and `download_to_path_async` within `src/imagine_mcp/media.py`.

🎯 **Why**: The `missing_ok=True` parameter in `pathlib.Path.unlink` safely suppresses `FileNotFoundError`, making the manual `exists()` check strictly redundant. In `download_to_path_async`, this also eliminates an unnecessary `await asyncio.to_thread` dispatch to the thread pool for the exception path, reducing overhead.

📊 **Impact**: Reduces I/O operations and context-switching overhead in the async failure path.

🔬 **Measurement**: Verify by inspecting the code, confirming tests pass successfully.

---
*PR created automatically by Jules for task [14980250170421377612](https://jules.google.com/task/14980250170421377612) started by @n24q02m*