### PR TITLE
perf: ⚡ Bolt: remove redundant exists checks for async unlink

### DIFF
--- a/src/imagine_mcp/media.py
+++ b/src/imagine_mcp/media.py
@@ -471,8 +471,9 @@ async def download_to_path_async(url: str, dest: Path) -> Path:
     except InvalidURLError as e:
         raise httpx.HTTPError(f"Download failed due to invalid redirect: {e}") from e
     except Exception:
-        if await asyncio.to_thread(dest.exists):
-            await asyncio.to_thread(dest.unlink, missing_ok=True)
+        # ⚡ Bolt: Remove redundant exists() check before unlink(missing_ok=True)
+        # to avoid unnecessary thread-pool dispatch overhead.
+        await asyncio.to_thread(dest.unlink, missing_ok=True)
         raise
     return dest
 

--- a/src/imagine_mcp/providers/gemini.py
+++ b/src/imagine_mcp/providers/gemini.py
@@ -107,8 +107,9 @@ async def understand_video(
             config=types.GenerateContentConfig(max_output_tokens=max_tokens),
         )
     finally:
-        if await asyncio.to_thread(tmp_path.exists):
-            await asyncio.to_thread(tmp_path.unlink)
+        # ⚡ Bolt: Remove redundant exists() check before unlink(missing_ok=True)
+        # to avoid unnecessary thread-pool dispatch overhead.
+        await asyncio.to_thread(tmp_path.unlink, missing_ok=True)
 
     return {
         "text": resp.text,
@@ -194,8 +195,9 @@ async def understand_multimodal(
         )
     finally:
         for f in tmp_files:
-            if await asyncio.to_thread(f.exists):
-                await asyncio.to_thread(f.unlink)
+            # ⚡ Bolt: Remove redundant exists() check before unlink(missing_ok=True)
+            # to avoid unnecessary thread-pool dispatch overhead.
+            await asyncio.to_thread(f.unlink, missing_ok=True)
 
     return {
         "text": resp.text,

--- a/uv.lock
+++ b/uv.lock
@@ -708,7 +708,7 @@ wheels = [
 
 [[package]]
 name = "imagine-mcp"
-version = "1.9.0b2"
+version = "1.9.0b3"
 source = { editable = "." }
 dependencies = [
     { name = "diskcache" },


### PR DESCRIPTION
💡 What: Replaced the two-step `if exists(): unlink()` pattern with a single `unlink(missing_ok=True)` in `src/imagine_mcp/providers/gemini.py` and `src/imagine_mcp/media.py`.
🎯 Why: The previous pattern required two separate thread-pool dispatches (one for `exists`, one for `unlink`) which caused unnecessary context switching and overhead. It was also a Time-of-Check to Time-of-Use (TOCTOU) race condition. Relying on `missing_ok=True` is more efficient and safer.
📊 Impact: Removes one full roundtrip to the thread pool for every temporary file cleanup operation.
🔬 Measurement: Verify all tests in `tests/test_providers_gemini.py` and `tests/test_media.py` pass cleanly.

---
*PR created automatically by Jules for task [15127849745801628968](https://jules.google.com/task/15127849745801628968) started by @n24q02m*