### PR TITLE
fix: lowercase renovate lock-file and pin PR subjects

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -20,7 +20,8 @@
       "before 5am"
     ],
     "automerge": true,
-    "automergeType": "pr"
+    "automergeType": "pr",
+    "commitMessageAction": "lock file maintenance"
   },
   "packageRules": [
     {
@@ -123,6 +124,14 @@
         "java"
       ],
       "enabled": false
+    },
+    {
+      "description": "Lowercase pin subjects (PR title lint requires lowercase start)",
+      "matchUpdateTypes": [
+        "pin",
+        "pinDigest"
+      ],
+      "commitMessageAction": "pin"
     }
   ],
   "semanticCommits": "enabled",


### PR DESCRIPTION
The `Validate PR title` check rejects subjects starting with an uppercase character. Renovate's default actions produce `fix(deps): Lock file maintenance` and `fix(deps): Pin dependencies`, which failed CI today (#441, #433 — both retitled by hand as the immediate unblock). This makes Renovate emit lowercase subjects so it never recurs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01F9w18hRCCpz3Z73wQHMGhd