### PR TITLE
fix: gate oc mention job on comment author write access

### DIFF
--- a/.github/workflows/opencode.yml
+++ b/.github/workflows/opencode.yml
@@ -15,7 +15,7 @@ jobs:
   # Anyone (including the owner) can summon the agent with /oc on an issue or PR.
   # It may also record a new rule into .github/review-learnings.md on request.
   mention:
-    if: ${{ github.event.comment != null && (contains(github.event.comment.body, '/oc') || contains(github.event.comment.body, '/opencode')) }}
+    if: ${{ github.event.comment != null && (contains(github.event.comment.body, '/oc') || contains(github.event.comment.body, '/opencode') && contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association) }}
     runs-on: ubuntu-latest
     permissions:
       contents: write

--- a/.github/workflows/opencode.yml
+++ b/.github/workflows/opencode.yml
@@ -15,7 +15,7 @@ jobs:
   # Anyone (including the owner) can summon the agent with /oc on an issue or PR.
   # It may also record a new rule into .github/review-learnings.md on request.
   mention:
-    if: ${{ github.event.comment != null && (contains(github.event.comment.body, '/oc') || contains(github.event.comment.body, '/opencode') && contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association) }}
+    if: ${{ github.event.comment != null && (contains(github.event.comment.body, '/oc') || contains(github.event.comment.body, '/opencode')) && contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association) }}
     runs-on: ubuntu-latest
     permissions:
       contents: write


### PR DESCRIPTION
Only the mention job is affected; auto-issue/auto-pr keep serving outside contributors by design. Closes the non-writer prompt-injection path and the loud CI failures on bot /oc comments. Mirrors n24q02m/.github#3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01F9w18hRCCpz3Z73wQHMGhd