### PR TITLE
🛡️ Sentinel: [HIGH] Fix auth bypass via path obfuscation

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -15,3 +15,7 @@
 **Vulnerability:** The application blindly casted `MCP_PORT` to an integer and passed `MCP_HOST` without verifying format validity. Malformed environment variables could cause unhandled exceptions leading to stack trace leakage or unexpected behavior.
 **Learning:** Application startup code should robustly validate user-provided environment configuration (like port numbers and IPs/hostnames) and handle exceptions securely (using clear log messages or generic exits instead of throwing internal tracebacks).
 **Prevention:** Use defensive parsing (`int()` with range checks for ports, `ipaddress.ip_address` or regex for hostnames) and employ `try...except` blocks that catch formatting errors, raising clean `SystemExit` messages using `from None` to hide internal stack traces from operators.
+## 2026-07-21 - [Path Obfuscation Auth Bypass]
+**Vulnerability:** Edge authentication gate in src/worker.ts bypassed using obfuscated URLs (e.g., //mcp or /%2Fmcp).
+**Learning:** Checking strict path strings against unnormalized request paths allows attackers to evade authentication checks before hitting internal endpoints.
+**Prevention:** Always decode and normalize URIs (using decodeURIComponent and replace) before conducting path-based security or routing decisions, and correctly handle malformed URIs.

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -130,7 +130,18 @@ export default {
     // VALIDITY is never judged here -- the container remains the sole
     // authority, so no mcp-core auth logic is duplicated at the edge.
     const url = new URL(request.url)
-    if (url.pathname === '/mcp' || url.pathname.startsWith('/mcp/')) {
+
+    let normalizedPath = url.pathname
+    try {
+      normalizedPath = decodeURIComponent(url.pathname).replace(/^\/+/, '/')
+    } catch (e) {
+      if (e instanceof URIError) {
+        return new Response('Bad Request', { status: 400 })
+      }
+      throw e
+    }
+
+    if (normalizedPath === '/mcp' || normalizedPath.startsWith('/mcp/')) {
       if (!BEARER.test(request.headers.get('authorization') ?? '')) return unauthenticated(request)
     }
     // Standing GET /mcp = the streamable-HTTP server-push SSE stream. On a
@@ -141,7 +152,7 @@ export default {
     // messages; request-scoped notifications ride the POST's own SSE
     // response. The spec allows declining the stream: both official SDKs
     // treat 405 as the optional-feature path and continue POST-only.
-    if (request.method === 'GET' && (url.pathname === '/mcp' || url.pathname.startsWith('/mcp/'))) {
+    if (request.method === 'GET' && (normalizedPath === '/mcp' || normalizedPath.startsWith('/mcp/'))) {
       return new Response(null, { status: 405, headers: { Allow: 'POST, DELETE' } })
     }
     // Public entrypoint: ONLY routes inbound requests to the per-user container

--- a/tests/worker.test.ts
+++ b/tests/worker.test.ts
@@ -171,6 +171,27 @@ describe('edge auth gate rejects anonymous /mcp before touching the container DO
     expect(calls()).toBe(0)
   })
 
+  it('POST //mcp (path obfuscation) with no Authorization -> 401, stub never called', async () => {
+    const { calls, env } = envWithDoSpy()
+    const res = await worker.fetch(new Request('https://imagine.n24q02m.com//mcp', { method: 'POST' }), env as never)
+    expect(res.status).toBe(401)
+    expect(calls()).toBe(0)
+  })
+
+  it('POST /%2Fmcp (URI encoded obfuscation) with no Authorization -> 401, stub never called', async () => {
+    const { calls, env } = envWithDoSpy()
+    const res = await worker.fetch(new Request('https://imagine.n24q02m.com/%2Fmcp', { method: 'POST' }), env as never)
+    expect(res.status).toBe(401)
+    expect(calls()).toBe(0)
+  })
+
+  it('POST /%zz (malformed URI) -> 400 Bad Request', async () => {
+    const { calls, env } = envWithDoSpy()
+    const res = await worker.fetch(new Request('https://imagine.n24q02m.com/%zz', { method: 'POST' }), env as never)
+    expect(res.status).toBe(400)
+    expect(calls()).toBe(0)
+  })
+
   it('POST /mcp with Authorization: Bearer anything -> stub called exactly once', async () => {
     const { calls, env } = envWithDoSpy()
     const res = await worker.fetch(


### PR DESCRIPTION
🚨 **Severity:** HIGH
💡 **Vulnerability:** The edge worker's authentication gate only checked `url.pathname === '/mcp'`. An attacker could bypass this check by providing obfuscated paths like `//mcp` or `/%2Fmcp`, allowing unauthenticated requests to reach internal handlers and cause resource consumption or unauthorized actions.
🎯 **Impact:** Allowed anonymous callers to bypass the Bearer token requirement, potentially pinning scale-to-zero containers awake and accumulating compute costs.
🔧 **Fix:** Introduced a `try/catch` block to decode and normalize `url.pathname` via `decodeURIComponent` and regex replacement. Malformed URIs now return `400 Bad Request`, and normalized paths correctly enforce auth.
✅ **Verification:** Added dedicated integration tests in `worker.test.ts` to assert `401 Unauthorized` responses for `//mcp` and `/%2Fmcp`, and `400 Bad Request` for invalid URI encoded payloads (e.g. `/%zz`). Tests pass successfully.

---
*PR created automatically by Jules for task [15796344314356911302](https://jules.google.com/task/15796344314356911302) started by @n24q02m*