### PR TITLE
perf: ⚡ Bolt: remove redundant exists() check before file unlink

### DIFF
--- a/src/imagine_mcp/media.py
+++ b/src/imagine_mcp/media.py
@@ -454,8 +454,9 @@ def download_to_path(url: str, dest: Path) -> Path:
     except InvalidURLError as e:
         raise httpx.HTTPError(f"Download failed due to invalid redirect: {e}") from e
     except Exception:
-        if dest.exists():
-            dest.unlink(missing_ok=True)
+        # ⚡ Bolt: Removed redundant dest.exists() check before unlink(missing_ok=True)
+        # Expected impact: saves an unnecessary file stat call.
+        dest.unlink(missing_ok=True)
         raise
     return dest
 
@@ -471,8 +472,9 @@ async def download_to_path_async(url: str, dest: Path) -> Path:
     except InvalidURLError as e:
         raise httpx.HTTPError(f"Download failed due to invalid redirect: {e}") from e
     except Exception:
-        if await asyncio.to_thread(dest.exists):
-            await asyncio.to_thread(dest.unlink, missing_ok=True)
+        # ⚡ Bolt: Removed redundant await asyncio.to_thread(dest.exists) check
+        # Expected impact: avoids an unnecessary thread-pool dispatch and context switch.
+        await asyncio.to_thread(dest.unlink, missing_ok=True)
         raise
     return dest
 


### PR DESCRIPTION
💡 What: Removed the redundant `exists()` checks before calling `unlink(missing_ok=True)` in both `download_to_path` and `download_to_path_async` within `src/imagine_mcp/media.py`.
🎯 Why: `Path.unlink(missing_ok=True)` inherently suppresses the `FileNotFoundError` if the file doesn't exist. Checking `exists()` right before is redundant and adds an unnecessary file `stat` system call (and an unnecessary thread-pool dispatch in the async version).
📊 Impact: Saves one unnecessary file stat call per download attempt in the synchronous path, and avoids an unnecessary thread-pool dispatch/context switch in the async path during exception handling/cleanup.
🔬 Measurement: Run the test suite (`uv run pytest tests/test_media.py`) to verify that the exception handling and file cleanup paths still work correctly without raising unexpected errors.

---
*PR created automatically by Jules for task [17626037050156090731](https://jules.google.com/task/17626037050156090731) started by @n24q02m*