### PR TITLE
fix: 🛡️ Sentinel: [HIGH] Fix auth bypass via path obfuscation

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -15,3 +15,7 @@
 **Vulnerability:** The application blindly casted `MCP_PORT` to an integer and passed `MCP_HOST` without verifying format validity. Malformed environment variables could cause unhandled exceptions leading to stack trace leakage or unexpected behavior.
 **Learning:** Application startup code should robustly validate user-provided environment configuration (like port numbers and IPs/hostnames) and handle exceptions securely (using clear log messages or generic exits instead of throwing internal tracebacks).
 **Prevention:** Use defensive parsing (`int()` with range checks for ports, `ipaddress.ip_address` or regex for hostnames) and employ `try...except` blocks that catch formatting errors, raising clean `SystemExit` messages using `from None` to hide internal stack traces from operators.
+## 2024-05-18 - Auth bypass via path obfuscation
+**Vulnerability:** Edge authorization gate could be bypassed by using obfuscated paths like `//mcp` or `/%2Fmcp`.
+**Learning:** URL routing mechanisms and security gates that rely on exact string matches without canonicalization are susceptible to path obfuscation attacks.
+**Prevention:** Always normalize and decode paths before applying string-matching security rules, ensuring consistent representations.

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -130,7 +130,15 @@ export default {
     // VALIDITY is never judged here -- the container remains the sole
     // authority, so no mcp-core auth logic is duplicated at the edge.
     const url = new URL(request.url)
-    if (url.pathname === '/mcp' || url.pathname.startsWith('/mcp/')) {
+
+    let normalizedPath = url.pathname
+    try {
+      normalizedPath = decodeURIComponent(url.pathname).replace(/^\/+/, '/')
+    } catch {
+      // Ignore malformed URIs (e.g. invalid % sequences), fall back to raw pathname
+    }
+
+    if (normalizedPath === '/mcp' || normalizedPath.startsWith('/mcp/')) {
       if (!BEARER.test(request.headers.get('authorization') ?? '')) return unauthenticated(request)
     }
     // Standing GET /mcp = the streamable-HTTP server-push SSE stream. On a
@@ -141,7 +149,7 @@ export default {
     // messages; request-scoped notifications ride the POST's own SSE
     // response. The spec allows declining the stream: both official SDKs
     // treat 405 as the optional-feature path and continue POST-only.
-    if (request.method === 'GET' && (url.pathname === '/mcp' || url.pathname.startsWith('/mcp/'))) {
+    if (request.method === 'GET' && (normalizedPath === '/mcp' || normalizedPath.startsWith('/mcp/'))) {
       return new Response(null, { status: 405, headers: { Allow: 'POST, DELETE' } })
     }
     // Public entrypoint: ONLY routes inbound requests to the per-user container

--- a/tests/worker.test.ts
+++ b/tests/worker.test.ts
@@ -171,6 +171,29 @@ describe('edge auth gate rejects anonymous /mcp before touching the container DO
     expect(calls()).toBe(0)
   })
 
+  it('POST //mcp (obfuscated path) with no Authorization -> 401, stub never called', async () => {
+    const { calls, env } = envWithDoSpy()
+    const res = await worker.fetch(new Request('https://imagine.n24q02m.com//mcp', { method: 'POST' }), env as never)
+    expect(res.status).toBe(401)
+    expect(calls()).toBe(0)
+  })
+
+  it('POST /%2Fmcp (URI-encoded obfuscated path) with no Authorization -> 401, stub never called', async () => {
+    const { calls, env } = envWithDoSpy()
+    const res = await worker.fetch(new Request('https://imagine.n24q02m.com/%2Fmcp', { method: 'POST' }), env as never)
+    expect(res.status).toBe(401)
+    expect(calls()).toBe(0)
+  })
+
+  it('POST /mcp with a malformed URI (e.g. invalid %) falls back to raw path without crashing', async () => {
+    const { calls, env } = envWithDoSpy()
+    // A malformed path that decodeURIComponent would throw on, but isn't /mcp
+    // envWithDoSpy gives it an IMAGINE stub that returns 200, so it will pass through to the DO.
+    const res = await worker.fetch(new Request('https://imagine.n24q02m.com/foo%2'), env as never)
+    expect(res.status).toBe(200) // Passes through safely
+    expect(calls()).toBe(1)
+  })
+
   it('POST /mcp with Authorization: Bearer anything -> stub called exactly once', async () => {
     const { calls, env } = envWithDoSpy()
     const res = await worker.fetch(


### PR DESCRIPTION
🚨 **Severity:** HIGH
💡 **Vulnerability:** The edge authentication gate in `src/worker.ts` could be bypassed by using obfuscated paths like `//mcp` or `/%2Fmcp`. Because the gate relied on exact string matching (`url.pathname === '/mcp'`), malformed or obfuscated paths were passed downstream without requiring a Bearer token.
🎯 **Impact:** An unauthenticated user could bypass the edge check, pinning the downstream container awake and potentially exposing internal endpoints to anonymous traffic, which could lead to unauthorized access or resource exhaustion (billing attacks).
🔧 **Fix:** Introduced path normalization using `decodeURIComponent` and a regex (`replace(/^\/+/, '/')`) wrapped in a `try/catch` block. This ensures that even obfuscated or malformed URIs are consistently evaluated by the edge auth gate.
✅ **Verification:** Added multiple tests in `tests/worker.test.ts` to explicitly assert that `//mcp` and `/%2Fmcp` paths return 401 Unauthorized, and that malformed URIs (e.g., `/foo%2`) do not crash the Worker. Verified successfully using `pnpm run test:worker`.

---
*PR created automatically by Jules for task [13096854277746950965](https://jules.google.com/task/13096854277746950965) started by @n24q02m*