### PR TITLE
perf: ⚡ Bolt: remove redundant exists() check before unlink(missing_ok=True)

### DIFF
--- a/src/imagine_mcp/media.py
+++ b/src/imagine_mcp/media.py
@@ -454,8 +454,9 @@ def download_to_path(url: str, dest: Path) -> Path:
     except InvalidURLError as e:
         raise httpx.HTTPError(f"Download failed due to invalid redirect: {e}") from e
     except Exception:
-        if dest.exists():
-            dest.unlink(missing_ok=True)
+        # ⚡ Bolt: Removed redundant dest.exists() check before dest.unlink(missing_ok=True)
+        # to avoid unnecessary file stat calls.
+        dest.unlink(missing_ok=True)
         raise
     return dest
 
@@ -471,8 +472,9 @@ async def download_to_path_async(url: str, dest: Path) -> Path:
     except InvalidURLError as e:
         raise httpx.HTTPError(f"Download failed due to invalid redirect: {e}") from e
     except Exception:
-        if await asyncio.to_thread(dest.exists):
-            await asyncio.to_thread(dest.unlink, missing_ok=True)
+        # ⚡ Bolt: Removed redundant dest.exists check before dest.unlink(missing_ok=True)
+        # to eliminate unnecessary file stat calls and thread-pool dispatch overhead.
+        await asyncio.to_thread(dest.unlink, missing_ok=True)
         raise
     return dest
 


### PR DESCRIPTION
💡 What: Removed the redundant `if dest.exists():` and `if await asyncio.to_thread(dest.exists):` checks before calling `dest.unlink(missing_ok=True)` in `src/imagine_mcp/media.py`.
🎯 Why: The `unlink(missing_ok=True)` method already handles the case where the file doesn't exist safely. Checking `exists()` beforehand introduces an unnecessary filesystem `stat` call and, in the async version, incurs the overhead of dispatching to a thread pool for a microsecond operation.
📊 Impact: Eliminates an unnecessary synchronous filesystem `stat` operation and an `asyncio.to_thread` dispatch on the file deletion path.
🔬 Measurement: Run `uv run pytest tests/test_media.py` to verify functionality.

---
*PR created automatically by Jules for task [9984751340332949339](https://jules.google.com/task/9984751340332949339) started by @n24q02m*