### PR TITLE
feat: document CLI, smithery, and self-host endpoint in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,10 @@ mcp-name: io.github.n24q02m/imagine-mcp
 
 - [Features](#features)
 - [Install](#install)
+- [Smithery](#smithery)
 - [Configuration](#configuration)
+- [CLI](#cli)
+- [Hosted endpoint](#hosted-endpoint)
 - [Documentation](#documentation)
 - [Tools](#tools)
 - [Comparison](#comparison)
@@ -107,8 +110,17 @@ browser-based HTTP setup, see the [Setup docs](https://mcp.n24q02m.com/servers/i
 
 **Install with an AI agent** -- paste this to your AI coding agent:
 
-> Install MCP server `imagine-mcp` following the steps at  
+> Install MCP server `imagine-mcp` following the steps at
 > https://raw.githubusercontent.com/n24q02m/claude-plugins/main/plugins/imagine-mcp/setup-with-agent.md
+
+## Smithery
+
+imagine-mcp ships a [`smithery.yaml`](smithery.yaml) so it can be installed and
+run through [Smithery](https://smithery.ai). The entry launches the published
+PyPI package over stdio (`uvx --python 3.13 imagine-mcp`) with an empty config
+schema -- no setup fields are required at deploy time. Provider keys are supplied
+at runtime through the server's own credential flow (env vars in stdio mode, or
+the browser setup form in HTTP mode; see [Configuration](#configuration)).
 
 ## Configuration
 
@@ -170,6 +182,35 @@ native provider SDKs (Gemini, OpenAI, Grok). Example:
 
 `config(action="set", key=..., value=...)` adjusts `log_level`, `default_provider`,
 `default_tier`, and `cache_ttl_seconds` at runtime.
+
+## CLI
+
+The `imagine-mcp` console command installed by the package takes **no
+subcommands** -- it starts the MCP server directly. Transport is selected by a
+single flag or its environment-variable equivalents:
+
+```bash
+imagine-mcp            # stdio transport (default); reads provider keys from env vars
+imagine-mcp --http     # HTTP daemon; credentials via the browser setup form
+```
+
+| Invocation | Equivalent env | Result |
+|---|---|---|
+| `imagine-mcp` | `MCP_TRANSPORT` unset | stdio, single-user, env-var credentials |
+| `imagine-mcp --http` | `MCP_TRANSPORT=http` (or `TRANSPORT_MODE=http`) | HTTP daemon -- local `127.0.0.1` self-host, or multi-user remote when `PUBLIC_URL` + `MCP_DCR_SERVER_SECRET` are set |
+
+In stdio mode the server exits if none of the provider keys are set. The remote
+HTTP bind knobs (`MCP_HOST`, `MCP_PORT`) apply only when `PUBLIC_URL` is set; see
+[Configuration](#configuration).
+
+## Hosted endpoint
+
+A maintainer-run instance is live at **`https://imagine.n24q02m.com/mcp`** for
+clients that support remote HTTP MCP servers. It is OAuth-gated -- an
+unauthenticated request returns `401` with a `WWW-Authenticate: Bearer` challenge
+-- and credentials are provisioned through the browser setup form. Point an
+HTTP-capable MCP client at that URL and complete the OAuth flow to connect.
+Prefer to run your own? See [Deploy to Cloudflare](#deploy-to-cloudflare).
 
 ## Documentation
 


### PR DESCRIPTION
## Summary

Refreshes `README.md` with three new sections documenting user-facing surfaces that were previously undocumented. Surgical, README-only change.

- **`## CLI`** -- documents the real command surface. The `imagine-mcp` console script (`[project.scripts]` -> `imagine_mcp.__main__:main`) has **no subcommands**: a single command with one flag, `--http`. Everything else is env-driven. Table maps `imagine-mcp` (stdio, default) and `imagine-mcp --http` (`MCP_TRANSPORT=http` / `TRANSPORT_MODE=http`) to their behaviour, and notes the remote bind knobs (`MCP_HOST`/`MCP_PORT`) apply only when `PUBLIC_URL` is set.
- **`## Smithery`** -- notes the verified `smithery.yaml` (stdio, `uvx --python 3.13 imagine-mcp`, empty config schema; credentials supplied at runtime).
- **`## Hosted endpoint`** -- documents the live maintainer-run instance at `https://imagine.n24q02m.com/mcp` (verified `401` + `WWW-Authenticate: Bearer` challenge -- OAuth-gated).
- Table of contents updated with the three new anchors.

## Notes

- All new copy is capability-only -- no model IDs / provider model names / dims introduced.
- CLI surface discovered directly from `src/imagine_mcp/__main__.py` and `src/imagine_mcp/server.py` (not invented).
- Pre-commit run clean on `README.md` (hooks not skipped); whitespace/EOF fixers applied.