### PR TITLE
perf: ⚡ Bolt: remove redundant .exists() checks before .unlink(missing_ok=True)

### DIFF
--- a/src/imagine_mcp/media.py
+++ b/src/imagine_mcp/media.py
@@ -454,8 +454,7 @@ def download_to_path(url: str, dest: Path) -> Path:
     except InvalidURLError as e:
         raise httpx.HTTPError(f"Download failed due to invalid redirect: {e}") from e
     except Exception:
-        if dest.exists():
-            dest.unlink(missing_ok=True)
+        dest.unlink(missing_ok=True)
         raise
     return dest
 
@@ -471,8 +470,7 @@ async def download_to_path_async(url: str, dest: Path) -> Path:
     except InvalidURLError as e:
         raise httpx.HTTPError(f"Download failed due to invalid redirect: {e}") from e
     except Exception:
-        if await asyncio.to_thread(dest.exists):
-            await asyncio.to_thread(dest.unlink, missing_ok=True)
+        await asyncio.to_thread(dest.unlink, missing_ok=True)
         raise
     return dest
 

--- a/src/imagine_mcp/providers/gemini.py
+++ b/src/imagine_mcp/providers/gemini.py
@@ -107,8 +107,7 @@ async def understand_video(
             config=types.GenerateContentConfig(max_output_tokens=max_tokens),
         )
     finally:
-        if await asyncio.to_thread(tmp_path.exists):
-            await asyncio.to_thread(tmp_path.unlink)
+        await asyncio.to_thread(tmp_path.unlink, missing_ok=True)
 
     return {
         "text": resp.text,
@@ -194,8 +193,7 @@ async def understand_multimodal(
         )
     finally:
         for f in tmp_files:
-            if await asyncio.to_thread(f.exists):
-                await asyncio.to_thread(f.unlink)
+            await asyncio.to_thread(f.unlink, missing_ok=True)
 
     return {
         "text": resp.text,

--- a/uv.lock
+++ b/uv.lock
@@ -708,7 +708,7 @@ wheels = [
 
 [[package]]
 name = "imagine-mcp"
-version = "1.9.0b4"
+version = "1.9.0"
 source = { editable = "." }
 dependencies = [
     { name = "diskcache" },


### PR DESCRIPTION
💡 What:
Removed redundant `Path.exists()` checks before calling `Path.unlink(missing_ok=True)` in `src/imagine_mcp/media.py` and `src/imagine_mcp/providers/gemini.py`.

🎯 Why:
Python's `Path.unlink()` supports the `missing_ok=True` parameter (since Python 3.8), which natively handles the case where a file doesn't exist. Checking `.exists()` beforehand is unnecessary. In async contexts, checking `.exists()` required an additional `asyncio.to_thread()` call, which adds thread pool scheduling overhead. Removing this check reduces thread pool dispatch overhead and also eliminates a potential Time-of-Check to Time-of-Use (TOCTOU) race condition where a file might be deleted between the `.exists()` check and the `.unlink()` call.

📊 Impact:
Eliminates one unnecessary synchronous file stat operation or thread pool dispatch per cleanup path, making file cleanup faster and safer.

🔬 Measurement:
Run the tests (`uv run pytest tests/test_media.py tests/test_providers_gemini.py`) to verify file cleanup works exactly as before.

---
*PR created automatically by Jules for task [11562138952602647534](https://jules.google.com/task/11562138952602647534) started by @n24q02m*