### PR TITLE
fix: forward CF AI Gateway litellm envs into container

### DIFF
--- a/src/worker.ts
+++ b/src/worker.ts
@@ -48,6 +48,9 @@ const CONTAINER_ENV_KEYS = [
   'PUBLIC_URL', 'CREDENTIAL_SECRET', 'MCP_DCR_SERVER_SECRET',
   'MCP_RELAY_PASSWORD',
   'GEMINI_API_KEY', 'OPENAI_API_KEY', 'XAI_API_KEY', 'UNDERSTAND_MODELS',
+  // CF AI Gateway (llm-main) litellm routing + generate defaults
+  'OPENROUTER_API_BASE', 'OPENROUTER_API_KEY', 'JINA_AI_API_BASE', 'JINA_AI_API_KEY',
+  'GENERATE_MODELS',
 ] as const
 
 function pickContainerEnv(env: Env): Record<string, string> {


### PR DESCRIPTION
CONTAINER_ENV_KEYS in src/worker.ts did not forward the CF AI Gateway litellm routing envs (OPENROUTER_API_BASE/KEY, JINA_AI_API_BASE/KEY) or GENERATE_MODELS into the container, even though these are already provisioned in the server's skret namespace.

This adds the 5 missing keys so the Worker passes them through to the container process, matching the existing pattern for GEMINI_API_KEY/OPENAI_API_KEY/XAI_API_KEY/UNDERSTAND_MODELS.