### PR TITLE
fix: pin rangeStrategy on delayed packageRules (renovate artifacts)

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -47,7 +47,8 @@
       "groupSlug": "non-major-dev",
       "automerge": true,
       "automergeType": "pr",
-      "minimumReleaseAge": "7 days"
+      "minimumReleaseAge": "7 days",
+      "rangeStrategy": "pin"
     },
     {
       "description": "Auto-merge patch updates after cooldown",
@@ -58,7 +59,8 @@
       "groupSlug": "all-patch",
       "automerge": true,
       "automergeType": "pr",
-      "minimumReleaseAge": "7 days"
+      "minimumReleaseAge": "7 days",
+      "rangeStrategy": "pin"
     },
     {
       "description": "Auto-merge GitHub Actions digest updates after cooldown",


### PR DESCRIPTION
## Root cause

Renovate's `artifacts` check has been failing on this repo's dependency-update PRs with:

```
Artifact update for <dep> resolved to version <NEWER>, which is a pending version
that has not yet passed the Minimum Release Age threshold.
```

`renovate.json` sets a global `rangeStrategy: "bump"` (keeps an open-ended version range in the manifest) together with `minimumReleaseAge: "7 days"` on the `non-major-dev` and `all-patch` packageRules. Renovate only *proposes* a version that has aged 7 days, but when it then runs the package manager (`uv lock` / `npm install` / etc.) to regenerate the lockfile, that step independently re-resolves the still-open range against the live registry — and can pick an even newer version that has NOT yet passed the 7-day gate. Renovate then fails the artifact-update step for its own safety, since the lockfile now contains a version it never vetted.

This is a known Renovate limitation: `minimumReleaseAge` does not constrain package-manager resolution while the written range stays open (renovatebot/renovate#41624).

## Fix

Add `rangeStrategy: "pin"` as a local override on exactly the packageRules that carry `minimumReleaseAge: "7 days"` (`non-major-dev`, `all-patch`). Pinning makes Renovate write the exact vetted version into the manifest, so the lockfile step resolves to that same version instead of re-opening the range. The global `rangeStrategy: "bump"` is left untouched for every other dependency.

`gha-digests` also carries `minimumReleaseAge` but is intentionally left as-is: GitHub Actions are SHA-pinned directly with no separate package-manager lockfile-resolution step, so it isn't subject to this failure mode.

Investigated across mcp-core#647, better-telegram-mcp#911, wet-mcp#1532, mnemo-mcp#973, imagine-mcp#434, web-core#636 (same template, same root cause in all 6).
