### PR TITLE
fix: restrict pr-title gate to feat/fix + add no-bump release warning

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -80,6 +80,28 @@ jobs:
           prerelease_token: beta
           no_operation_mode: true
 
+      # PSR silently no-ops when it can't find a fix:/feat: commit since the last
+      # tag -- e.g. a bot PR squash-merged with a non-conventional subject (the
+      # commit-title no-bump trap the pr-title CI check guards at merge time; this
+      # step is the release-time backstop for anything that slipped past it).
+      # released=false alone is not an error (it is the normal outcome of a
+      # docs-only/chore-only window), so this only warns.
+      - name: Warn if commits exist since last tag but PSR computed no release
+        if: steps.dryrun.outputs.released != 'true'
+        run: |
+          set -uo pipefail
+          highest_tag="$(git tag -l 'v*' | sort -V | tail -1)"
+          if [ -z "$highest_tag" ]; then
+            echo "No existing tags -- nothing to compare."
+            exit 0
+          fi
+          commit_count="$(git rev-list "${highest_tag}..HEAD" --count)"
+          if [ "$commit_count" -gt 0 ]; then
+            echo "::warning::PSR computed no release (released=false) but ${commit_count} commit(s) exist since ${highest_tag}. This is expected if they are all chore/docs-only, but if one of them should have bumped the version (e.g. a bot-authored fix squashed with a non-conventional subject), inspect 'git log ${highest_tag}..HEAD --oneline' before assuming there is nothing to release."
+          else
+            echo "OK: no commits since ${highest_tag} -- released=false is expected."
+          fi
+
       # Fail early and loudly if the version PSR intends to publish already exists on
       # PyPI. PyPI never allows reusing a version number, so a hit here means the git
       # history has diverged from the registry. Catching it here converts two nasty

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,10 +40,14 @@ jobs:
           # so this server-side check is required to keep main history
           # conformant. See historical violations on commits 2bc6657, 76,
           # 77 (closed before this gate was wired).
+          # perf: dropped -- it is not in this repo's own PSR
+          # commit_parser_options.allowed_tags (pyproject.toml, only
+          # feat/fix), so a perf: commit that passed this check would still
+          # silently fail to bump the version, defeating the point of the
+          # gate.
           types: |
             fix
             feat
-            perf
           requireScope: false
           subjectPattern: ^(?![A-Z]).+$
           subjectPatternError: |


### PR DESCRIPTION
## Why

imagine-mcp is the only repo in the 12-repo MCP stack with a PR-title conventional-commit gate already (added after #452, a Sentinel PR whose title `Sentinel: [HIGH] Fix auth bypass via path obfuscation` failed the check and required a controller to manually retype the squash-commit subject at merge time). While rolling the same gate out to the other 11 repos (companion PRs), two gaps surfaced in this repo's own copy:

1. **`types:` allowed `perf` in addition to `fix`/`feat`.** This repo's `pyproject.toml` restricts PSR's own `commit_parser_options.allowed_tags` to `["feat", "fix"]` only -- so a `perf:`-titled PR would pass this check (green) yet still not bump the version (PSR silently drops it), which is the exact no-bump trap the gate exists to catch. Live evidence: commit `c963ea63` ("perf: (Bolt) remove redundant .exists() checks...", PR #462) is on `main` but does not appear to have triggered its own release -- it landed conventionally-titled but with a type PSR's parser config does not recognize.
2. **No release-time backstop.** The other 11 repos' companion PRs add a warning step in `cd.yml` right after the existing PSR dry-run: if `released=false` but commits exist since the last tag, emit a non-blocking `::warning::`. This repo didn't have it yet either.

## What

- `ci.yml`: dropped `perf` from the `pr-title` job's `types:` list -- now `fix`/`feat` only, matching this repo's own PSR `allowed_tags`.
- `cd.yml`: added the same release-time backstop step as the companion PRs.

## Verify

- `actionlint .github/workflows/ci.yml .github/workflows/cd.yml` -- clean.