### PR TITLE
feat: setup_* taxonomy + built-in CLI (W6.1 + W5.1)

### DIFF
--- a/README.md
+++ b/README.md
@@ -227,9 +227,9 @@ Full docs at **[mcp.n24q02m.com/servers/imagine-mcp/setup/](https://mcp.n24q02m.
 |:-----|:--------|:------------|
 | `understand` | -- | Describe or reason over one or more image/video URLs. `media_urls: list[str]`, `prompt: str`, `provider`, `tier`, `max_tokens`. |
 | `generate` | -- | Generate an image or video from a text prompt. `media_type: image\|video`, optional `reference_image_url`, optional `job_id` (video poll), `aspect_ratio`, `duration_seconds`. |
-| `config` | `open_relay`, `relay_status`, `relay_skip`, `relay_reset`, `relay_complete`, `warmup`, `status`, `set`, `cache_clear` | Credential + runtime config: open relay form, check credential state, set runtime knobs (log level, default provider, TTL), clear response cache. |
+| `config` | `setup_status`, `setup_skip`, `setup_reset`, `setup_complete`, `warmup`, `status`, `set`, `cache_clear` (`relay_status`/`relay_skip`/`relay_reset`/`relay_complete` honored as deprecated aliases) | Credential + runtime config: check credential state, set runtime knobs (log level, default provider, TTL), clear response cache. |
 | `help` | -- | Full Markdown documentation for `understand`, `generate`, or `config` topics. |
-| `config__open_relay` | -- | Framework-injected helper (mcp-core) equivalent to `config(action="open_relay")`; opens the browser credential form. |
+| `config__open_relay` | -- | Framework-injected helper (mcp-core); opens the browser credential form. |
 
 Model choice is caller-driven (litellm `provider/model` passthrough or a `*_MODELS`
 env chain) -- see [Model chains](#configuration) above.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,7 +56,7 @@ dependencies = [
 ]
 
 [project.scripts]
-imagine-mcp = "imagine_mcp.__main__:main"
+imagine-mcp = "imagine_mcp.cli:main"
 
 [project.urls]
 Homepage = "https://github.com/n24q02m/imagine-mcp"

--- a/src/imagine_mcp/__main__.py
+++ b/src/imagine_mcp/__main__.py
@@ -1,74 +1,16 @@
-"""Entry point with mode dispatch.
+"""imagine-mcp entry point."""
 
-Two independent modes (per spec 2026-05-01-stdio-pure-http-multiuser.md):
-
-- ``stdio`` (default) -- pure local single-user. Reads creds from env vars
-  only; exits 1 if all three of ``GEMINI_API_KEY``/``OPENAI_API_KEY``/
-  ``XAI_API_KEY`` are missing. Universal MCP client compatibility
-  (Claude Code, Cursor, VS Code Copilot, etc.). No daemon, no browser.
-
-- ``http`` (opt-in via ``--http`` flag, ``MCP_TRANSPORT=http`` or
-  ``TRANSPORT_MODE=http`` env var) -- HTTP daemon, always multi-user
-  remote-style. Set ``PUBLIC_URL`` + ``MCP_DCR_SERVER_SECRET`` to bind
-  publicly with per-JWT-sub credential isolation; otherwise serves on
-  127.0.0.1:<port> for local self-host.
-"""
-
-from __future__ import annotations
-
-import asyncio
-import os
-import sys
-
-_STDIO_MISSING_CRED_MSG = """\
-[imagine-mcp] No provider API keys set. Stdio mode requires at least one of:
-  - GEMINI_API_KEY
-  - OPENAI_API_KEY
-  - XAI_API_KEY
-
-Options:
-  1. Set env in plugin config:
-     {"command": "uvx", "args": ["imagine-mcp"], "env": {"GEMINI_API_KEY": "..."}}
-
-  2. Switch to HTTP mode (browser-based setup):
-     See https://mcp.n24q02m.com/servers/imagine-mcp/setup/ "Self-Hosting HTTP Mode"
-
-Documentation: https://mcp.n24q02m.com/servers/imagine-mcp/setup/
-"""
+from imagine_mcp.cli import main as _cli_main
 
 
-def main() -> None:
-    is_http = (
-        "--http" in sys.argv
-        or os.environ.get("MCP_TRANSPORT") == "http"
-        or os.environ.get("TRANSPORT_MODE") == "http"
-    )
+def _cli() -> int:
+    """Dispatch argv through the shared mcp_core CLI builder.
 
-    if is_http:
-        from imagine_mcp.server import run_http
-
-        asyncio.run(run_http())
-        return
-
-    # Default: stdio. FastMCP stdio server directly on stdin/stdout.
-    # No daemon, no bridge. Env-only creds; exit 1 if all 3 missing
-    # (server has no functional tools without at least one provider).
-    if not any(
-        os.environ.get(k)
-        for k in (
-            "GEMINI_API_KEY",
-            "OPENAI_API_KEY",
-            "XAI_API_KEY",
-            "GOOGLE_VERTEX_EXPRESS_API_KEY",
-        )
-    ):
-        sys.stderr.write(_STDIO_MISSING_CRED_MSG)
-        raise SystemExit(1)
-
-    from imagine_mcp.server import build_app
-
-    build_app().run(transport="stdio")
+    Bare invocation and any leading-dash argv (e.g. --http) start the
+    server; a leading positional argv[0] routes to a subcommand instead.
+    """
+    return _cli_main()
 
 
 if __name__ == "__main__":
-    main()
+    raise SystemExit(_cli())

--- a/src/imagine_mcp/cli.py
+++ b/src/imagine_mcp/cli.py
@@ -1,0 +1,118 @@
+"""Console-script entry: mounts the shared mcp_core CLI builder.
+
+Bare invocation and any leading-dash argv (e.g. --http) start the server via
+``_serve`` exactly as ``__main__.main()`` used to before this module existed;
+a leading positional argv[0] routes to a subcommand (``config``/``relay``/
+``doctor``) instead. ``--version``/``-h``/``--help`` are intercepted here,
+before ``build_cli`` ever sees them: ``build_cli`` treats every leading-dash
+argv as an opaque server flag and passes it straight through to ``serve``
+(see ``mcp_core/cli.py`` module docstring) -- without this interception
+``imagine-mcp --version`` would start the stdio server and hang on stdin
+instead of printing a version and exiting.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+import sys
+
+from mcp_core import build_cli
+
+from imagine_mcp.relay_setup import PLUGIN_NAME
+
+_STDIO_MISSING_CRED_MSG = """\
+[imagine-mcp] No provider API keys set. Stdio mode requires at least one of:
+  - GEMINI_API_KEY
+  - OPENAI_API_KEY
+  - XAI_API_KEY
+
+Options:
+  1. Set env in plugin config:
+     {"command": "uvx", "args": ["imagine-mcp"], "env": {"GEMINI_API_KEY": "..."}}
+
+  2. Switch to HTTP mode (browser-based setup):
+     See https://mcp.n24q02m.com/servers/imagine-mcp/setup/ "Self-Hosting HTTP Mode"
+
+Documentation: https://mcp.n24q02m.com/servers/imagine-mcp/setup/
+"""
+
+_HELP_TEXT = """\
+imagine-mcp -- image/video understanding & generation (Gemini/OpenAI/Grok)
+
+Usage:
+  imagine-mcp                  Start the server (stdio, default)
+  imagine-mcp --http           Start the server (HTTP daemon)
+  imagine-mcp doctor           Environment + config health check
+  imagine-mcp config status    Show credential configuration state
+  imagine-mcp config delete    Delete stored credentials (--yes to skip the prompt)
+  imagine-mcp relay status     Show the active relay session, if any
+  imagine-mcp relay open       Reopen the active relay session in a browser
+  imagine-mcp relay reset      Clear relay session + mode state
+  imagine-mcp -h, --help       Show this help and exit
+  imagine-mcp --version, -V    Show the installed version and exit
+
+Credentials are set via the config__open_relay MCP tool (HTTP mode's browser
+form) or the GEMINI_API_KEY / OPENAI_API_KEY / XAI_API_KEY env vars.
+"""
+
+
+def _serve(argv: list[str]) -> int | None:
+    """Start the server -- stdio (default) or HTTP (--http / env opt-in).
+
+    Transport dispatch unchanged from the pre-CLI ``__main__.main()``: stdio
+    is env-only creds, single-user, no daemon/browser; HTTP is opt-in and
+    always multi-user/remote-style (see ``imagine_mcp.server.run_http``).
+    """
+    is_http = (
+        "--http" in argv
+        or os.environ.get("MCP_TRANSPORT") == "http"
+        or os.environ.get("TRANSPORT_MODE") == "http"
+    )
+
+    if is_http:
+        from imagine_mcp.server import run_http
+
+        asyncio.run(run_http())
+        return None
+
+    if not any(
+        os.environ.get(k)
+        for k in (
+            "GEMINI_API_KEY",
+            "OPENAI_API_KEY",
+            "XAI_API_KEY",
+            "GOOGLE_VERTEX_EXPRESS_API_KEY",
+        )
+    ):
+        sys.stderr.write(_STDIO_MISSING_CRED_MSG)
+        raise SystemExit(1)
+
+    from imagine_mcp.server import build_app
+
+    build_app().run(transport="stdio")
+    return None
+
+
+def _version() -> str:
+    from imagine_mcp import __version__
+
+    return __version__
+
+
+def main() -> int:
+    argv = sys.argv[1:]
+    if argv[:1] == ["--version"] or argv[:1] == ["-V"]:
+        print(_version())
+        return 0
+    if argv[:1] == ["-h"] or argv[:1] == ["--help"]:
+        print(_HELP_TEXT, end="")
+        return 0
+
+    # build_cli's server_name doubles as the PerPluginStore/doctor identifier
+    # (~/.{name}-mcp/config.json) -- it must be PLUGIN_NAME ("imagine"), the
+    # same name save_credentials()/load_config_from_file() write through, not
+    # the "imagine-mcp" console-script/package name. Passing the latter would
+    # make `config status`/`doctor` silently check ~/.imagine-mcp-mcp/ (a path
+    # nothing ever writes to) and always report "not configured".
+    return build_cli(PLUGIN_NAME, serve=_serve, version=_version())(None)

--- a/src/imagine_mcp/dispatcher.py
+++ b/src/imagine_mcp/dispatcher.py
@@ -116,7 +116,7 @@ def _default_provider() -> str:
     keys = ", ".join(env for env, _ in _DEFAULT_PROVIDER_PRIORITY)
     raise CredentialMissingError(
         "No provider API key configured. Set one of: "
-        f"{keys}, or run config(action='open_relay') to configure via browser."
+        f"{keys}, or call the config__open_relay tool to configure via browser."
     )
 
 
@@ -139,7 +139,7 @@ def _default_generate_provider() -> str:
     keys = ", ".join(_PROVIDER_TO_ENV.values())
     raise CredentialMissingError(
         "No provider API key configured. Set one of: "
-        f"{keys}, or run config(action='open_relay') to configure via browser."
+        f"{keys}, or call the config__open_relay tool to configure via browser."
     )
 
 

--- a/src/imagine_mcp/docs/config.md
+++ b/src/imagine_mcp/docs/config.md
@@ -14,16 +14,24 @@ config(
 
 ## Actions
 
-### Credential / relay
+### Credential / setup
+
+Open the credential form via the `config__open_relay` tool (registered
+alongside `config` -- see the tool list), not a `config` action.
 
 | Action | Purpose |
 |--------|---------|
-| `open_relay` | Start relay session; server opens browser with credential form |
-| `relay_status` | Poll current relay session status |
-| `relay_complete` | Persist relay submission to the encrypted per-plugin store (`~/.imagine-mcp/config.json`) |
-| `relay_skip` | Skip relay; rely on env vars only |
-| `relay_reset` | Delete stored credentials (forces re-setup) |
+| `setup_status` | Poll current relay session status |
+| `setup_complete` | Persist relay submission to the encrypted per-plugin store (`~/.imagine-mcp/config.json`) |
+| `setup_skip` | Skip relay; rely on env vars only |
+| `setup_reset` | Delete stored credentials (forces re-setup) |
 | `warmup` | Pre-load heavy resources (no-op in v1) |
+
+`relay_status`/`relay_skip`/`relay_reset`/`relay_complete` are honored as
+deprecated aliases for one release cycle (each logs a deprecation warning) --
+migrate to the `setup_*` names above. `open_relay` is no longer a `config`
+action (dual-exposure removed 2026-07; call the `config__open_relay` tool
+instead).
 
 ### Runtime
 
@@ -37,13 +45,13 @@ config(
 
 ```python
 # First-time setup
-config(action="open_relay")
-# -> {"status": "saved", "providers_configured": [...]} or {"status": "degraded", "message": "..."}
+config__open_relay()
+# -> {"url": "...", "browser_opened": true, "status": "unconfigured"}
 
-config(action="relay_status")
+config(action="setup_status")
 # -> {"status": "pending", "providers_configured": []} or {"status": "configured", "providers_configured": [...]}
 
-config(action="relay_complete")
+config(action="setup_complete")
 # -> {"status": "saved", "providers_configured": ["gemini", "openai", "grok"]} or {"status": "no_credentials", "providers_configured": []}
 
 config(action="status")

--- a/src/imagine_mcp/docs/understand.md
+++ b/src/imagine_mcp/docs/understand.md
@@ -85,5 +85,5 @@ currently configured chain.
 - `InvalidProviderError` -- provider not in {gemini, openai, grok}
 - `InvalidTierError` -- tier not in {poor, rich}
 - `ProviderUnsupportedError` -- provider does not support the media type
-- `CredentialMissingError` -- API key not configured (run `config(action="open_relay")`)
+- `CredentialMissingError` -- API key not configured (call the `config__open_relay` tool)
 - `RateLimitError` -- provider 429

--- a/src/imagine_mcp/providers/base.py
+++ b/src/imagine_mcp/providers/base.py
@@ -78,8 +78,8 @@ class ClientManager:
 
         if not key:
             raise CredentialMissingError(
-                f"{self.provider_name} API key missing. Run config(action='open_relay') for "
-                f"browser-based setup, or set {self.env_key}."
+                f"{self.provider_name} API key missing. Call the config__open_relay "
+                f"tool for browser-based setup, or set {self.env_key}."
             )
         return key
 

--- a/src/imagine_mcp/server.py
+++ b/src/imagine_mcp/server.py
@@ -242,8 +242,10 @@ def build_app() -> FastMCP:
     @app.tool(
         description=(
             "Server config + credential setup (MERGED). Actions: "
-            "(relay) open_relay|relay_status|relay_skip|relay_reset|"
-            "relay_complete|warmup; (runtime) status|set|cache_clear."
+            "(setup) setup_status|setup_skip|setup_reset|setup_complete|warmup "
+            "(relay_status|relay_skip|relay_reset|relay_complete honored as "
+            "deprecated aliases); (runtime) status|set|cache_clear. "
+            "Use the config__open_relay tool to open the credential form."
         ),
         annotations=ToolAnnotations(
             readOnlyHint=False,
@@ -261,47 +263,47 @@ def build_app() -> FastMCP:
         from imagine_mcp import relay_setup
 
         match action:
-            case "open_relay":
-                result = await relay_setup.ensure_config(force=True)
-                if result is None:
-                    return {
-                        "status": "degraded",
-                        "message": (
-                            "No credentials loaded. Set MCP_RELAY_URL and retry, "
-                            "or run the server in `http local relay mode` (default)."
-                        ),
-                    }
-                return {
-                    "status": "saved",
-                    "providers_configured": await asyncio.to_thread(
-                        _providers_configured_live
-                    ),
-                }
-            case "relay_status":
+            case "relay_status" | "setup_status":
+                if action == "relay_status":
+                    logger.warning(
+                        "Deprecated action 'relay_status' honored; migrate to 'setup_status'."
+                    )
                 _live_providers = await asyncio.to_thread(_providers_configured_live)
                 return {
                     "status": "configured" if _live_providers else "pending",
                     "providers_configured": _live_providers,
                 }
-            case "relay_complete":
+            case "relay_complete" | "setup_complete":
+                if action == "relay_complete":
+                    logger.warning(
+                        "Deprecated action 'relay_complete' honored; migrate to 'setup_complete'."
+                    )
                 _live_providers = await asyncio.to_thread(_providers_configured_live)
                 return {
                     "status": "saved" if _live_providers else "no_credentials",
                     "providers_configured": _live_providers,
                 }
-            case "relay_skip":
+            case "relay_skip" | "setup_skip":
+                if action == "relay_skip":
+                    logger.warning(
+                        "Deprecated action 'relay_skip' honored; migrate to 'setup_skip'."
+                    )
                 _env_providers = await asyncio.to_thread(_providers_configured)
                 if not _env_providers:
                     return {
                         "status": "needs_setup",
-                        "message": "No env vars set. Run config(action='open_relay') to configure via browser.",
+                        "message": "No env vars set. Call the config__open_relay tool to configure via browser.",
                     }
                 return {
                     "status": "using_env",
                     "message": "Using env vars for credentials.",
                     "providers": _env_providers,
                 }
-            case "relay_reset":
+            case "relay_reset" | "setup_reset":
+                if action == "relay_reset":
+                    logger.warning(
+                        "Deprecated action 'relay_reset' honored; migrate to 'setup_reset'."
+                    )
                 return await asyncio.to_thread(relay_setup.reset_credentials)
             case "warmup":
                 return {
@@ -334,9 +336,10 @@ def build_app() -> FastMCP:
                 return {
                     "status": "error",
                     "message": (
-                        f"Unknown action {action!r}. Valid: open_relay|relay_status|"
-                        "relay_skip|relay_reset|relay_complete|warmup|"
-                        "status|set|cache_clear"
+                        f"Unknown action {action!r}. Valid: setup_status|"
+                        "setup_skip|setup_reset|setup_complete|warmup|"
+                        "status|set|cache_clear (call the config__open_relay "
+                        "tool to open the credential form)"
                     ),
                 }
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,271 @@
+"""Tests for imagine_mcp.cli -- shared mcp_core CLI builder mount (W5.1).
+
+Bare invocation and any leading-dash argv start the server unchanged (the
+stdio/--http dispatch that used to live directly in ``__main__.main()`` moved
+into ``_serve`` here without behaviour changes); ``build_cli`` fronts it with
+``config``/``relay``/``doctor`` subcommand routing. ``--version``/``-h`` are
+handled before ``build_cli`` ever sees them: ``mcp_core.cli.build_cli`` passes
+every leading-dash argv straight through to ``serve`` (it does not special-
+case ``--version``/``-h`` itself -- see ``mcp_core/cli.py`` module docstring),
+so without this interception ``imagine-mcp --version`` would start the stdio
+server and hang on stdin instead of printing a version and exiting.
+"""
+
+from __future__ import annotations
+
+import sys
+from unittest.mock import patch
+
+import pytest
+
+from imagine_mcp import __version__
+
+_CRED_KEYS = (
+    "GEMINI_API_KEY",
+    "OPENAI_API_KEY",
+    "XAI_API_KEY",
+    "GOOGLE_VERTEX_EXPRESS_API_KEY",
+)
+_MODE_KEYS = ("MCP_TRANSPORT", "TRANSPORT_MODE")
+
+
+@pytest.fixture(autouse=True)
+def _clean_env(monkeypatch):
+    for key in (*_CRED_KEYS, *_MODE_KEYS):
+        monkeypatch.delenv(key, raising=False)
+    yield
+
+
+@pytest.fixture
+def cli_storage(tmp_path, monkeypatch):
+    """Redirect PerPluginStore (``Path.home``) and the relay session lock
+    (``mcp_core`` ``set_lock_dir``) into ``tmp_path`` so the built-in
+    ``config``/``relay``/``doctor`` subcommand tests never touch the real
+    user home directory. Mirrors mcp-core's own ``cli_storage`` fixture in
+    ``packages/core-py/tests/test_cli.py``.
+    """
+    from mcp_core.storage.session_lock import set_lock_dir
+
+    monkeypatch.setattr("pathlib.Path.home", lambda: tmp_path)
+    set_lock_dir(str(tmp_path / "locks"))
+    yield tmp_path
+    set_lock_dir(None)
+
+
+class TestServeDispatch:
+    """Bare/flag argv route to ``_serve`` (stdio/--http) unchanged."""
+
+    def test_bare_invocation_exits_1_without_credentials(self, capsys):
+        from imagine_mcp import cli
+
+        with (
+            patch.object(sys, "argv", ["imagine-mcp"]),
+            pytest.raises(SystemExit) as exc,
+        ):
+            cli.main()
+
+        assert exc.value.code == 1
+        assert "No provider API keys set" in capsys.readouterr().err
+
+    def test_bare_invocation_runs_stdio_when_credential_present(self, monkeypatch):
+        from imagine_mcp import cli
+
+        monkeypatch.setenv("OPENAI_API_KEY", "key")
+        calls: dict[str, object] = {}
+
+        class _App:
+            def run(self, *, transport):
+                calls["transport"] = transport
+
+        monkeypatch.setattr("imagine_mcp.server.build_app", lambda: _App())
+        with patch.object(sys, "argv", ["imagine-mcp"]):
+            rc = cli.main()
+
+        assert rc == 0
+        assert calls == {"transport": "stdio"}
+
+    def test_http_flag_passes_through_and_starts_http_mode(self, monkeypatch):
+        from imagine_mcp import cli
+
+        called = False
+
+        async def _run_http():
+            nonlocal called
+            called = True
+
+        monkeypatch.setattr("imagine_mcp.server.run_http", _run_http)
+        with patch.object(sys, "argv", ["imagine-mcp", "--http"]):
+            rc = cli.main()
+
+        assert rc == 0
+        assert called is True
+
+    @pytest.mark.parametrize("env_key", ["MCP_TRANSPORT", "TRANSPORT_MODE"])
+    def test_transport_env_starts_http_mode(self, monkeypatch, env_key):
+        from imagine_mcp import cli
+
+        monkeypatch.setenv(env_key, "http")
+        called = False
+
+        async def _run_http():
+            nonlocal called
+            called = True
+
+        monkeypatch.setattr("imagine_mcp.server.run_http", _run_http)
+        with patch.object(sys, "argv", ["imagine-mcp"]):
+            rc = cli.main()
+
+        assert rc == 0
+        assert called is True
+
+
+class TestVersionAndHelp:
+    """The gap this task closes: imagine-mcp had no --version/-h at all."""
+
+    def test_version_flag_prints_and_exits_0(self, capsys):
+        from imagine_mcp import cli
+
+        with patch.object(sys, "argv", ["imagine-mcp", "--version"]):
+            rc = cli.main()
+
+        assert rc == 0
+        assert capsys.readouterr().out.strip() == __version__
+
+    def test_short_version_flag(self, capsys):
+        from imagine_mcp import cli
+
+        with patch.object(sys, "argv", ["imagine-mcp", "-V"]):
+            rc = cli.main()
+
+        assert rc == 0
+        assert capsys.readouterr().out.strip() == __version__
+
+    def test_help_flag_prints_usage_and_exits_0(self, capsys):
+        from imagine_mcp import cli
+
+        with patch.object(sys, "argv", ["imagine-mcp", "-h"]):
+            rc = cli.main()
+
+        assert rc == 0
+        out = capsys.readouterr().out
+        assert "imagine-mcp" in out
+        assert "doctor" in out
+        assert "config status" in out
+        assert "relay" in out
+
+    def test_long_help_flag(self, capsys):
+        from imagine_mcp import cli
+
+        with patch.object(sys, "argv", ["imagine-mcp", "--help"]):
+            rc = cli.main()
+
+        assert rc == 0
+        assert "Usage:" in capsys.readouterr().out
+
+
+class TestBuiltinSubcommands:
+    """``config``/``relay``/``doctor`` are ``mcp_core.cli`` built-ins.
+
+    The critical correctness property under test: ``build_cli``'s
+    ``server_name`` identifier must match ``relay_setup.PLUGIN_NAME``
+    (``"imagine"``), NOT the ``imagine-mcp`` console-script/package name.
+    ``PerPluginStore`` keys its on-disk path off that name
+    (``~/.{name}-mcp/config.json``) -- passing ``"imagine-mcp"`` (as the
+    wet-mcp/better-telegram-mcp CLI wiring does for their own SERVER_NAME)
+    would make ``config status``/``doctor`` silently inspect
+    ``~/.imagine-mcp-mcp/`` (double suffix), a path nothing ever writes to,
+    so they would always report "not configured" even when the server is
+    actually configured. These tests would fail if that mismatch were
+    reintroduced.
+    """
+
+    def test_config_status_reflects_real_saved_credentials(self, cli_storage, capsys):
+        from mcp_core.storage.per_plugin_store import PerPluginStore
+
+        from imagine_mcp.relay_setup import PLUGIN_NAME
+
+        PerPluginStore(PLUGIN_NAME).save({"GEMINI_API_KEY": "test-key"})
+
+        from imagine_mcp import cli
+
+        with patch.object(sys, "argv", ["imagine-mcp", "config", "status"]):
+            rc = cli.main()
+
+        assert rc == 0
+        out = capsys.readouterr().out
+        assert "configured" in out
+        assert "not configured" not in out
+        assert "test-key" not in out
+
+    def test_config_status_not_configured(self, cli_storage, capsys):
+        from imagine_mcp import cli
+
+        with patch.object(sys, "argv", ["imagine-mcp", "config", "status"]):
+            rc = cli.main()
+
+        assert rc == 0
+        assert "not configured" in capsys.readouterr().out
+
+    def test_config_delete_with_yes_deletes_real_store(self, cli_storage):
+        from mcp_core.storage.per_plugin_store import PerPluginStore
+
+        from imagine_mcp.relay_setup import PLUGIN_NAME
+
+        PerPluginStore(PLUGIN_NAME).save({"GEMINI_API_KEY": "test-key"})
+
+        from imagine_mcp import cli
+
+        with patch.object(sys, "argv", ["imagine-mcp", "config", "delete", "--yes"]):
+            rc = cli.main()
+
+        assert rc == 0
+        assert PerPluginStore(PLUGIN_NAME).load() is None
+
+    def test_doctor_reports_real_configured_state(self, cli_storage, capsys):
+        from mcp_core.storage.per_plugin_store import PerPluginStore
+
+        from imagine_mcp.relay_setup import PLUGIN_NAME
+
+        PerPluginStore(PLUGIN_NAME).save({"GEMINI_API_KEY": "test-key"})
+
+        from imagine_mcp import cli
+
+        with patch.object(sys, "argv", ["imagine-mcp", "doctor"]):
+            rc = cli.main()
+
+        out = capsys.readouterr().out
+        assert rc == 0
+        assert "[ok] config: configured" in out
+        assert "[warn] config: not configured" not in out
+
+    def test_doctor_healthy_when_unconfigured(self, cli_storage, capsys):
+        from imagine_mcp import cli
+
+        with patch.object(sys, "argv", ["imagine-mcp", "doctor"]):
+            rc = cli.main()
+
+        out = capsys.readouterr().out
+        assert rc == 0
+        assert "[fail]" not in out
+        assert "[warn] config: not configured" in out
+
+    def test_relay_status_reports_no_active_session(self, cli_storage, capsys):
+        from imagine_mcp import cli
+
+        with patch.object(sys, "argv", ["imagine-mcp", "relay", "status"]):
+            rc = cli.main()
+
+        assert rc == 1
+        assert "no active relay session" in capsys.readouterr().err
+
+    def test_unknown_subcommand_lists_builtins(self, capsys):
+        from imagine_mcp import cli
+
+        with patch.object(sys, "argv", ["imagine-mcp", "bogus"]):
+            rc = cli.main()
+
+        assert rc == 2
+        err = capsys.readouterr().err
+        assert "config" in err
+        assert "relay" in err
+        assert "doctor" in err

--- a/tests/test_main_entry.py
+++ b/tests/test_main_entry.py
@@ -1,67 +1,21 @@
-"""Tests for the ``__main__`` entry point mode dispatch.
+"""Tests for imagine_mcp.__main__ -- thin wrapper delegating to imagine_mcp.cli.main.
 
-``main()`` picks stdio vs http and, in stdio mode, hard-exits when no
-provider key is configured (the server has no usable tools without one).
+Dispatch (bare/--http/env-mode/--version/-h/config/relay/doctor) is exercised
+in tests/test_cli.py against the real mcp_core build_cli builder; this only
+verifies the delegation wiring for `python -m imagine_mcp` / the console
+script (mirrors better-telegram-mcp's tests/test_main.py::TestCli).
 """
 
 from __future__ import annotations
 
-import sys
-
-import pytest
-
-from imagine_mcp.__main__ import main
-
-_CRED_KEYS = ("GEMINI_API_KEY", "OPENAI_API_KEY", "XAI_API_KEY")
-_MODE_KEYS = ("MCP_TRANSPORT", "TRANSPORT_MODE")
+from unittest.mock import patch
 
 
-@pytest.fixture(autouse=True)
-def _clean_env(monkeypatch):
-    for key in (*_CRED_KEYS, *_MODE_KEYS):
-        monkeypatch.delenv(key, raising=False)
-    monkeypatch.setattr(sys, "argv", ["imagine-mcp"])
-    yield
+def test_delegates_to_cli_main():
+    from imagine_mcp.__main__ import _cli
 
+    with patch("imagine_mcp.__main__._cli_main", return_value=0) as mock_cli_main:
+        rc = _cli()
 
-def test_stdio_mode_exits_when_no_credentials(monkeypatch, capsys):
-    with pytest.raises(SystemExit) as exc:
-        main()
-    assert exc.value.code == 1
-    assert "No provider API keys set" in capsys.readouterr().err
-
-
-def test_stdio_mode_runs_app_when_credential_present(monkeypatch):
-    monkeypatch.setenv("OPENAI_API_KEY", "key")
-    calls: dict[str, object] = {}
-
-    class _App:
-        def run(self, *, transport):
-            calls["transport"] = transport
-
-    monkeypatch.setattr("imagine_mcp.server.build_app", lambda: _App())
-    main()
-    assert calls == {"transport": "stdio"}
-
-
-@pytest.mark.parametrize(
-    ("argv", "env"),
-    [
-        (["imagine-mcp", "--http"], None),
-        (["imagine-mcp"], ("MCP_TRANSPORT", "http")),
-        (["imagine-mcp"], ("TRANSPORT_MODE", "http")),
-    ],
-)
-def test_http_mode_dispatch(monkeypatch, argv, env):
-    monkeypatch.setattr(sys, "argv", argv)
-    if env is not None:
-        monkeypatch.setenv(*env)
-    called = False
-
-    async def _run_http():
-        nonlocal called
-        called = True
-
-    monkeypatch.setattr("imagine_mcp.server.run_http", _run_http)
-    main()
-    assert called is True
+    mock_cli_main.assert_called_once_with()
+    assert rc == 0

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -268,64 +268,121 @@ async def test_tool_generate_wrapper() -> None:
 
 
 @pytest.mark.asyncio
-async def test_tool_config_relay_actions(monkeypatch) -> None:
+async def test_tool_config_setup_actions(monkeypatch) -> None:
+    """Canonical setup_* action names (W6.1 taxonomy: matches the other 7
+    servers' config(action='setup_*') family)."""
     app = build_app()
 
-    # relay_status
+    # setup_status
     with patch(
         "imagine_mcp.server._providers_configured_live", return_value=["gemini"]
     ):
-        result = await app.call_tool("config", {"action": "relay_status"})
+        result = await app.call_tool("config", {"action": "setup_status"})
         res = _structured(result)
         assert res["status"] == "configured"
         assert res["providers_configured"] == ["gemini"]
 
-    # relay_complete
+    # setup_complete
     with patch("imagine_mcp.server._providers_configured_live", return_value=[]):
-        result = await app.call_tool("config", {"action": "relay_complete"})
+        result = await app.call_tool("config", {"action": "setup_complete"})
         res = _structured(result)
         assert res["status"] == "no_credentials"
 
-    # relay_skip (using env)
+    # setup_skip (using env)
     monkeypatch.setenv("GEMINI_API_KEY", "test")
-    result = await app.call_tool("config", {"action": "relay_skip"})
+    result = await app.call_tool("config", {"action": "setup_skip"})
     res = _structured(result)
     assert res["status"] == "using_env"
 
-    # relay_skip (needs setup)
+    # setup_skip (needs setup) -- hints at the config__open_relay tool now
+    # that config(action='open_relay') is no longer dual-exposed.
     monkeypatch.delenv("GEMINI_API_KEY", raising=False)
     monkeypatch.delenv("OPENAI_API_KEY", raising=False)
     monkeypatch.delenv("XAI_API_KEY", raising=False)
-    result = await app.call_tool("config", {"action": "relay_skip"})
+    result = await app.call_tool("config", {"action": "setup_skip"})
     res = _structured(result)
     assert res["status"] == "needs_setup"
+    assert "config__open_relay" in res["message"]
 
-    # relay_reset
+    # setup_reset
     with patch(
         "imagine_mcp.relay_setup.reset_credentials", return_value={"status": "reset"}
     ):
-        result = await app.call_tool("config", {"action": "relay_reset"})
+        result = await app.call_tool("config", {"action": "setup_reset"})
         res = _structured(result)
         assert res == {"status": "reset"}
 
 
 @pytest.mark.asyncio
-async def test_tool_config_open_relay() -> None:
+async def test_tool_config_relay_actions_deprecated_aliases(monkeypatch) -> None:
+    """relay_status/relay_skip/relay_reset/relay_complete still work (1-cycle
+    deprecation alias for setup_status/setup_skip/setup_reset/setup_complete)
+    but each logs a deprecation warning; the canonical setup_* names do not."""
     app = build_app()
 
-    # Success
-    with patch(
-        "imagine_mcp.relay_setup.ensure_config", return_value={"some": "config"}
+    with (
+        patch("imagine_mcp.server._providers_configured_live", return_value=["gemini"]),
+        patch("imagine_mcp.server.logger.warning") as mock_warn,
     ):
-        result = await app.call_tool("config", {"action": "open_relay"})
+        result = await app.call_tool("config", {"action": "relay_status"})
         res = _structured(result)
-        assert res["status"] == "saved"
+        assert res["status"] == "configured"
+        assert res["providers_configured"] == ["gemini"]
+    mock_warn.assert_called_once()
+    assert "relay_status" in mock_warn.call_args[0][0]
+    assert "setup_status" in mock_warn.call_args[0][0]
 
-    # Degraded
-    with patch("imagine_mcp.relay_setup.ensure_config", return_value=None):
-        result = await app.call_tool("config", {"action": "open_relay"})
-        res = _structured(result)
-        assert res["status"] == "degraded"
+    with (
+        patch("imagine_mcp.server._providers_configured_live", return_value=[]),
+        patch("imagine_mcp.server.logger.warning") as mock_warn,
+    ):
+        result = await app.call_tool("config", {"action": "relay_complete"})
+        assert _structured(result)["status"] == "no_credentials"
+    mock_warn.assert_called_once()
+    assert "relay_complete" in mock_warn.call_args[0][0]
+    assert "setup_complete" in mock_warn.call_args[0][0]
+
+    monkeypatch.setenv("GEMINI_API_KEY", "test")
+    with patch("imagine_mcp.server.logger.warning") as mock_warn:
+        result = await app.call_tool("config", {"action": "relay_skip"})
+        assert _structured(result)["status"] == "using_env"
+    mock_warn.assert_called_once()
+    assert "relay_skip" in mock_warn.call_args[0][0]
+    assert "setup_skip" in mock_warn.call_args[0][0]
+
+    with (
+        patch(
+            "imagine_mcp.relay_setup.reset_credentials",
+            return_value={"status": "reset"},
+        ),
+        patch("imagine_mcp.server.logger.warning") as mock_warn,
+    ):
+        result = await app.call_tool("config", {"action": "relay_reset"})
+        assert _structured(result) == {"status": "reset"}
+    mock_warn.assert_called_once()
+    assert "relay_reset" in mock_warn.call_args[0][0]
+    assert "setup_reset" in mock_warn.call_args[0][0]
+
+    # Canonical names never warn.
+    with (
+        patch("imagine_mcp.server._providers_configured_live", return_value=["gemini"]),
+        patch("imagine_mcp.server.logger.warning") as mock_warn,
+    ):
+        await app.call_tool("config", {"action": "setup_status"})
+    mock_warn.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_tool_config_open_relay_action_removed() -> None:
+    """W6.1: config(action='open_relay') dual-exposure is gone -- the
+    standalone config__open_relay tool (see
+    tests/test_config_open_relay_registered.py) is the only entry point."""
+    app = build_app()
+
+    result = await app.call_tool("config", {"action": "open_relay"})
+    res = _structured(result)
+    assert res["status"] == "error"
+    assert "Unknown action 'open_relay'" in res["message"]
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

Two related changes from the S16 MCP-stack backlog spec, cross-server-consistency workstreams W6.1 and W5.1:

- **W6.1 (config taxonomy)**: `config(action=...)` gains the canonical `setup_status`/`setup_skip`/`setup_reset`/`setup_complete` names, matching the other 7 servers in the stack. The previous `relay_status`/`relay_skip`/`relay_reset`/`relay_complete` names are honored as deprecated aliases for one release cycle (each logs a deprecation warning). The dual-exposed `config(action="open_relay")` is removed -- it duplicated the standalone `config__open_relay` tool with a different, legacy implementation (the unused ECDH `create_session`/`poll_for_result` flow); `config__open_relay` is now the only way to open the credential form. Guidance strings that pointed at `config(action='open_relay')` now point at the `config__open_relay` tool.
- **W5.1 (CLI)**: imagine-mcp had no operator CLI at all -- not even `--version`/`-h`. `src/imagine_mcp/cli.py` mounts `mcp_core.build_cli`, giving `imagine-mcp doctor`, `imagine-mcp config status|delete`, `imagine-mcp relay status|open|reset`, and `imagine-mcp --version`/`-h` (intercepted before `build_cli`, which doesn't handle them itself). The stdio/`--http` transport dispatch that used to live in `__main__.main()` moved into `cli.py::_serve` unchanged.

## Notable correctness fix (not a copy of the existing pattern)

`build_cli`'s `server_name` argument doubles as the `PerPluginStore`/doctor identifier (`~/.{name}-mcp/config.json`). It must be `relay_setup.PLUGIN_NAME` (`"imagine"`) -- the name credentials are actually saved under -- not the `"imagine-mcp"` package name. Verified empirically that wet-mcp and better-telegram-mcp's existing CLI wiring passes their `SERVER_NAME` (`"wet-mcp"`/`"better-telegram-mcp"`) instead, which makes `<name> config status`/`<name> doctor` inspect the wrong path (`~/.wet-mcp-mcp/`) and always report "not configured" even when actually configured -- a latent bug in those two repos, out of scope here (flagged separately). Also verified `wet-mcp --version` currently hangs (starts the stdio server, waits on stdin) since `build_cli` passes every leading-dash argv straight through to `serve`; imagine's `cli.main()` intercepts `--version`/`-h` itself to avoid the same gap.

## Test plan

- [x] TDD: new tests written first and confirmed failing before implementation (both commits)
- [x] `uv run pytest tests/` -- 304 passed, 3 deselected (`live` marker)
- [x] `uv run ruff check .` / `uv run ruff format --check .` -- clean
- [x] `uv run ty check` -- clean
- [x] Empirical end-to-end check (real installed binary, not mocked): `imagine-mcp --version`, `-h`, `--help` all print and exit 0 instead of hanging
- [x] Empirical end-to-end check: `imagine-mcp doctor` / `imagine-mcp config status` against a real temp `HOME` correctly report "not configured" when empty and "configured" after a real `PerPluginStore("imagine").save(...)` write