### PR TITLE
fix: bump mcp-core to 1.20.0b2 for plugin-name and CLI fixes

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,7 +47,11 @@ dependencies = [
     "pillow>=12.3.0",
     "diskcache>=5.6.3",
     "loguru>=0.7.3",
-    "n24q02m-mcp-core[llm]>=1.19.0,<2",
+    # 1.20.0b2 fixes build_cli's `config`/`doctor` PerPluginStore key
+    # (#666). cli.py already passes PLUGIN_NAME ("imagine") as
+    # build_cli's server_name to sidestep the mismatch, so no CLI
+    # regression here -- bumped for cascade parity with wet/mnemo/crg.
+    "n24q02m-mcp-core[llm]>=1.20.0b2,<2",
     "platformdirs>=4.10.0",
     # Security floors: transitive deps pinned to patched releases.
     # urllib3 < 2.7.0 -> PYSEC-2026-141/142; idna < 3.15 -> CVE-2026-45409.

--- a/uv.lock
+++ b/uv.lock
@@ -708,7 +708,7 @@ wheels = [
 
 [[package]]
 name = "imagine-mcp"
-version = "1.9.0"
+version = "1.10.0b1"
 source = { editable = "." }
 dependencies = [
     { name = "diskcache" },
@@ -751,7 +751,7 @@ requires-dist = [
     { name = "idna", specifier = ">=3.18" },
     { name = "loguru", specifier = ">=0.7.3" },
     { name = "mcp", extras = ["cli"], specifier = ">=1.28.1" },
-    { name = "n24q02m-mcp-core", extras = ["llm"], specifier = ">=1.19.0,<2" },
+    { name = "n24q02m-mcp-core", extras = ["llm"], specifier = ">=1.20.0b2,<2" },
     { name = "openai", specifier = ">=2.44.0" },
     { name = "pillow", specifier = ">=12.3.0" },
     { name = "platformdirs", specifier = ">=4.10.0" },
@@ -1127,7 +1127,7 @@ wheels = [
 
 [[package]]
 name = "n24q02m-mcp-core"
-version = "1.19.0"
+version = "1.20.0b2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "authlib" },
@@ -1142,9 +1142,9 @@ dependencies = [
     { name = "starlette" },
     { name = "tomli-w" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/96/82/5cf9177a7188dbf074a30ad057b9f7aeca8c546d34587311315215f92a9c/n24q02m_mcp_core-1.19.0.tar.gz", hash = "sha256:2109af5f1bd8a9387c135d7477b3deadfdcc3adbcfce354c7d4e3d49068d757a", size = 320002, upload-time = "2026-07-14T12:27:39.314Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/c6/92/68abd1fc6491e83b4a91271b2690952dfe13bffb7c5cf27954ae3fe35bea/n24q02m_mcp_core-1.20.0b2.tar.gz", hash = "sha256:b2e85cf7eacb45457fba491bdd8927cc92947ff0184904ba9719ecd94fbd28a4", size = 345349, upload-time = "2026-07-17T06:24:34.645Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/cb/c6/d755370d27c6963dfa14e924b35c5ccfb2830361ed4d989813fbb4bc94ec/n24q02m_mcp_core-1.19.0-py3-none-any.whl", hash = "sha256:b91bae678620470f084ba91d9d4767ef05843d42316a3c9d5c4fb25325210be8", size = 178192, upload-time = "2026-07-14T12:27:38.065Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/79/a4c91fa9a9778ae7b1b58ac51b196a4b35de2de33faf6dfee0e79a6a3f6b/n24q02m_mcp_core-1.20.0b2-py3-none-any.whl", hash = "sha256:67b5ec30bd4712cf9a29a5de397a4c9338846cb2e6cf9233b98f976f44b5919a", size = 189470, upload-time = "2026-07-17T06:24:33.11Z" },
 ]
 
 [package.optional-dependencies]


### PR DESCRIPTION
## Summary
- Bump `n24q02m-mcp-core[llm]` floor from `>=1.19.0,<2` to `>=1.20.0b2,<2`.
- Picks up mcp-core#666 (`build_cli`'s `config`/`doctor` PerPluginStore key defaulting to the display `server_name` instead of the plugin slug). `cli.py` already passes `PLUGIN_NAME` (`"imagine"`) as `build_cli`'s `server_name` to sidestep the mismatch by construction, so `config status` was correct before and after -- bumped for cascade parity with wet-mcp/mnemo-mcp/better-code-review-graph.

## Test plan
- [x] `uv lock` resolves `n24q02m-mcp-core` 1.19.0 -> 1.20.0b2 from PyPI (no local path source).
- [x] `imagine-mcp config status` verified identical correct output (`imagine: configured (source: file)`) with a saved cred both before (1.19.0) and after (1.20.0b2) the bump -- no regression.
- [x] Full `uv run pytest` suite: 304 passed, 3 deselected, 0 failed.