### PR TITLE
fix: validate understand passthrough media fetch is a real image

### DIFF
--- a/src/imagine_mcp/dispatcher.py
+++ b/src/imagine_mcp/dispatcher.py
@@ -207,6 +207,14 @@ def _unsupported(provider: str, media: str, action: str) -> ProviderUnsupportedE
     return ProviderUnsupportedError(msg)
 
 
+# Identifying User-Agent for the understand media fetch. Some hosts (notably
+# Wikimedia) reject a request carrying no/blank UA with an HTTP 403 whose body
+# is an error string; sending one lets those clean fetches succeed. The
+# raise_for_status + magic-byte guard in ``_process_url`` still rejects any
+# error body that slips through, so this is defence-in-depth, not the core fix.
+_MEDIA_FETCH_USER_AGENT = "imagine-mcp (+https://github.com/n24q02m/imagine-mcp)"
+
+
 async def _passthrough_understand(
     media_urls: list[str],
     prompt: str,
@@ -231,7 +239,7 @@ async def _passthrough_understand(
         supports_vision,
     )
 
-    from imagine_mcp.media import get_ssrf_safe_async_client
+    from imagine_mcp.media import get_ssrf_safe_async_client, sniff_image_mime
 
     if not media_urls:
         raise InvalidMediaTypeError("media_urls is empty")
@@ -248,10 +256,33 @@ async def _passthrough_understand(
     async def _process_url(i: int, u: str) -> dict[str, Any]:
         await _validate_url(u, f"media_urls[{i}]")
         resp_img = await get_ssrf_safe_async_client().get(
-            u, follow_redirects=True, timeout=60
+            u,
+            follow_redirects=True,
+            timeout=60,
+            headers={"User-Agent": _MEDIA_FETCH_USER_AGENT},
         )
+        # Fail LOUD on a non-2xx fetch instead of base64-ing the error body: a
+        # UA-block / hotlink-protect / rate-limit / 404 page would otherwise be
+        # passed to the vision model as a data: URL and silently hallucinated
+        # over (isError=false, confident wrong answer).
+        resp_img.raise_for_status()
+        # Validate the body is a genuine raster image via its magic bytes before
+        # base64-ing it. The Content-Type header is untrusted (a 200 error page
+        # can claim image/*, and a real image can arrive as
+        # application/octet-stream), so the sniffed magic bytes -- not the
+        # header -- both decide the mime and gate acceptance. resolve_image_mime
+        # is deliberately NOT reused here: it falls back to image/jpeg for
+        # unknown bytes, which would relabel an error page as an image.
+        mime_type = sniff_image_mime(resp_img.content)
+        if mime_type is None:
+            ctype = resp_img.headers.get("content-type")
+            raise InvalidMediaTypeError(
+                f"media_urls[{i}] did not return a recognizable image "
+                f"(HTTP {resp_img.status_code}, content-type={ctype!r}, "
+                f"{len(resp_img.content)} bytes). Refusing to send non-image "
+                "content to the vision model."
+            )
         img_b64 = base64.b64encode(resp_img.content).decode()
-        mime_type = resp_img.headers.get("content-type", "image/png")
         data_url = f"data:{mime_type};base64,{img_b64}"
         return {"type": "image_url", "image_url": {"url": data_url}}
 

--- a/tests/test_dispatcher.py
+++ b/tests/test_dispatcher.py
@@ -21,6 +21,12 @@ from imagine_mcp.errors import (
     ProviderUnsupportedError,
 )
 
+# Minimal genuine image body: the 8-byte PNG signature is enough for the
+# understand fetch path's magic-byte guard (``sniff_image_mime``) to accept it
+# as image/png. Used as a stand-in for a real downloaded image so the mocked
+# fetch represents genuine image bytes rather than an arbitrary placeholder.
+_PNG_BYTES = b"\x89PNG\r\n\x1a\n"
+
 
 @pytest.fixture
 def clean_provider_env(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -351,7 +357,7 @@ async def test_passthrough_understand_routes_to_litellm(
     monkeypatch.setattr("mcp_core.llm.acompletion", fake_acompletion)
     # Avoid real image download.
     mock_resp = MagicMock()
-    mock_resp.content = b"fake-image-bytes"
+    mock_resp.content = _PNG_BYTES
     mock_resp.headers = {"content-type": "image/png"}
     mock_client = AsyncMock()
     mock_client.get.return_value = mock_resp
@@ -392,7 +398,7 @@ async def test_passthrough_understand_unknown_model_warns(
 
     monkeypatch.setattr("mcp_core.llm.acompletion", fake_acompletion)
     mock_resp = MagicMock()
-    mock_resp.content = b"x"
+    mock_resp.content = _PNG_BYTES
     mock_resp.headers = {"content-type": "image/png"}
     mock_client = AsyncMock()
     mock_client.get.return_value = mock_resp
@@ -544,7 +550,7 @@ async def test_dispatch_understand_uses_chain_default(
 
     monkeypatch.setattr("mcp_core.llm.acompletion", fake_acompletion)
     mock_resp = MagicMock()
-    mock_resp.content = b"x"
+    mock_resp.content = _PNG_BYTES
     mock_resp.headers = {"content-type": "image/png"}
     mock_client = AsyncMock()
     mock_client.get.return_value = mock_resp
@@ -588,7 +594,7 @@ async def test_dispatch_understand_single_chain_no_fallbacks(
 
     monkeypatch.setattr("mcp_core.llm.acompletion", fake_acompletion)
     mock_resp = MagicMock()
-    mock_resp.content = b"x"
+    mock_resp.content = _PNG_BYTES
     mock_resp.headers = {"content-type": "image/png"}
     mock_client = AsyncMock()
     mock_client.get.return_value = mock_resp
@@ -634,7 +640,7 @@ async def test_dispatch_understand_explicit_provider_does_not_override_chain(
         AsyncMock(return_value="image"),
     )
     mock_resp = MagicMock()
-    mock_resp.content = b"x"
+    mock_resp.content = _PNG_BYTES
     mock_resp.headers = {"content-type": "image/png"}
     mock_client = AsyncMock()
     mock_client.get.return_value = mock_resp
@@ -702,3 +708,207 @@ def test_validate_invalid_tier() -> None:
 
     with pytest.raises(InvalidTierError, match="Unknown tier"):
         _validate("gemini", "invalid-tier")
+
+
+@pytest.mark.asyncio
+async def test_passthrough_understand_raises_on_http_error(
+    clean_provider_env: None, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A non-2xx media fetch (e.g. Wikimedia 403 "Please set a user agent") is
+    surfaced loudly. The error body must never be base64'd and handed to the
+    vision model as if it were an image (silent failure -> confident garbage).
+    """
+    from unittest.mock import MagicMock
+
+    import httpx
+
+    monkeypatch.setenv("GEMINI_API_KEY", "gem-test")
+    monkeypatch.setattr(
+        "imagine_mcp.dispatcher._validate_url", AsyncMock(return_value=None)
+    )
+
+    acompletion_calls: list[dict[str, object]] = []
+
+    async def fake_acompletion(**kwargs: object) -> object:
+        acompletion_calls.append(kwargs)
+        benign = MagicMock()
+        benign.choices = [MagicMock()]
+        return benign
+
+    monkeypatch.setattr("mcp_core.llm.acompletion", fake_acompletion)
+
+    error_resp = MagicMock()
+    error_resp.status_code = 403
+    error_resp.content = b"Please set a user agent"
+    error_resp.headers = {"content-type": "text/plain"}
+    error_resp.raise_for_status.side_effect = httpx.HTTPStatusError(
+        "403 Forbidden", request=MagicMock(), response=MagicMock()
+    )
+    mock_client = AsyncMock()
+    mock_client.get.return_value = error_resp
+    monkeypatch.setattr(
+        "imagine_mcp.media.get_ssrf_safe_async_client", lambda: mock_client
+    )
+
+    with pytest.raises(httpx.HTTPStatusError):
+        await dispatch_understand(
+            media_urls=["https://upload.wikimedia.org/cat.jpg"],
+            prompt="describe",
+            provider=None,
+            tier="poor",
+            model="gemini/gemini-3.1-pro-preview",
+        )
+    assert acompletion_calls == [], "vision model called on a failed fetch"
+
+
+@pytest.mark.asyncio
+async def test_passthrough_understand_rejects_non_image_body(
+    clean_provider_env: None, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A 200 response whose body is not an image (HTML/text error page with no
+    image magic bytes) is rejected with a clear error -- not base64'd and sent
+    to the vision model."""
+    from unittest.mock import MagicMock
+
+    monkeypatch.setenv("GEMINI_API_KEY", "gem-test")
+    monkeypatch.setattr(
+        "imagine_mcp.dispatcher._validate_url", AsyncMock(return_value=None)
+    )
+
+    acompletion_calls: list[dict[str, object]] = []
+
+    async def fake_acompletion(**kwargs: object) -> object:
+        acompletion_calls.append(kwargs)
+        benign = MagicMock()
+        benign.choices = [MagicMock()]
+        return benign
+
+    monkeypatch.setattr("mcp_core.llm.acompletion", fake_acompletion)
+
+    html_resp = MagicMock()
+    html_resp.status_code = 200
+    html_resp.content = b"<!DOCTYPE html><html><body>Rate limited</body></html>"
+    html_resp.headers = {"content-type": "text/html"}
+    html_resp.raise_for_status = MagicMock(return_value=None)
+    mock_client = AsyncMock()
+    mock_client.get.return_value = html_resp
+    monkeypatch.setattr(
+        "imagine_mcp.media.get_ssrf_safe_async_client", lambda: mock_client
+    )
+
+    with pytest.raises(InvalidMediaTypeError, match="image"):
+        await dispatch_understand(
+            media_urls=["https://example.com/notreally.png"],
+            prompt="describe",
+            provider=None,
+            tier="poor",
+            model="gemini/gemini-3.1-pro-preview",
+        )
+    assert acompletion_calls == [], "vision model called on a non-image body"
+
+
+@pytest.mark.asyncio
+async def test_passthrough_understand_accepts_real_image(
+    clean_provider_env: None, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A 200 response with genuine image magic bytes proceeds normally; the data
+    URL mime is derived from the sniffed magic bytes and litellm is called."""
+    from unittest.mock import MagicMock
+
+    monkeypatch.setenv("GEMINI_API_KEY", "gem-test")
+    monkeypatch.setattr(
+        "imagine_mcp.dispatcher._validate_url", AsyncMock(return_value=None)
+    )
+
+    msg = MagicMock()
+    msg.content = "a real cat"
+    choice = MagicMock()
+    choice.message = msg
+    resp = MagicMock()
+    resp.choices = [choice]
+
+    captured: dict[str, object] = {}
+
+    async def fake_acompletion(**kwargs: object) -> object:
+        captured.update(kwargs)
+        return resp
+
+    monkeypatch.setattr("mcp_core.llm.acompletion", fake_acompletion)
+
+    img_resp = MagicMock()
+    img_resp.status_code = 200
+    img_resp.content = _PNG_BYTES
+    # A lying/generic content-type must not steer the mime: magic bytes win.
+    img_resp.headers = {"content-type": "application/octet-stream"}
+    img_resp.raise_for_status = MagicMock(return_value=None)
+    mock_client = AsyncMock()
+    mock_client.get.return_value = img_resp
+    monkeypatch.setattr(
+        "imagine_mcp.media.get_ssrf_safe_async_client", lambda: mock_client
+    )
+
+    result = await dispatch_understand(
+        media_urls=["https://example.com/cat.png"],
+        prompt="describe",
+        provider=None,
+        tier="poor",
+        model="gemini/gemini-3.1-pro-preview",
+    )
+    assert result["text"] == "a real cat"
+    from typing import Any, cast
+
+    messages = cast(list[dict[str, Any]], captured["messages"])
+    content = messages[0]["content"]
+    image_parts = [part for part in content if part.get("type") == "image_url"]
+    assert image_parts, "expected an image_url part in the vision message"
+    assert image_parts[0]["image_url"]["url"].startswith("data:image/png;base64,")
+
+
+@pytest.mark.asyncio
+async def test_passthrough_understand_sends_user_agent(
+    clean_provider_env: None, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The media fetch sends a real, identifying User-Agent header -- many hosts
+    (e.g. Wikimedia) 403 a request that carries no/blank UA."""
+    from unittest.mock import MagicMock
+
+    monkeypatch.setenv("GEMINI_API_KEY", "gem-test")
+    monkeypatch.setattr(
+        "imagine_mcp.dispatcher._validate_url", AsyncMock(return_value=None)
+    )
+
+    msg = MagicMock()
+    msg.content = "ok"
+    choice = MagicMock()
+    choice.message = msg
+    resp = MagicMock()
+    resp.choices = [choice]
+
+    async def fake_acompletion(**kwargs: object) -> object:
+        return resp
+
+    monkeypatch.setattr("mcp_core.llm.acompletion", fake_acompletion)
+
+    img_resp = MagicMock()
+    img_resp.status_code = 200
+    img_resp.content = _PNG_BYTES
+    img_resp.headers = {"content-type": "image/png"}
+    img_resp.raise_for_status = MagicMock(return_value=None)
+    mock_client = AsyncMock()
+    mock_client.get.return_value = img_resp
+    monkeypatch.setattr(
+        "imagine_mcp.media.get_ssrf_safe_async_client", lambda: mock_client
+    )
+
+    await dispatch_understand(
+        media_urls=["https://example.com/cat.png"],
+        prompt="describe",
+        provider=None,
+        tier="poor",
+        model="gemini/gemini-3.1-pro-preview",
+    )
+    _args, kwargs = mock_client.get.call_args
+    headers = kwargs.get("headers") or {}
+    user_agent = headers.get("User-Agent", "")
+    assert user_agent, "media fetch must send a non-empty User-Agent header"
+    assert "imagine" in user_agent.lower()


### PR DESCRIPTION
## Problem

The `understand` litellm-passthrough path (`dispatcher._passthrough_understand._process_url`) base64-encoded whatever a `media_urls` fetch returned and passed it to the vision model **without checking the HTTP status or that the body was actually an image**.

When a media host returns a non-image error body — e.g. Wikimedia replies `403 text/plain "Please set a user agent"` because the fetch sent no User-Agent, or any UA-block / hotlink-protect / rate-limit / 404 page — the error text was encoded as `data:text/plain;base64,<error>` (or mislabeled `image/png` via the header fallback) and handed to the model as "the image". The model then produced a confident, hallucinated description with `isError=false` — a silent failure: the user gets a wrong answer with no signal anything went wrong.

The native gemini path already validates via `resolve_image_mime()`; only the passthrough path trusted the raw `content-type` header with an `image/png` fallback and no status check.

## Fix (fail loud, not silent)

In the passthrough media fetch:

1. **`raise_for_status()`** — a non-2xx surfaces loudly instead of being encoded as a fake image.
2. **Magic-byte validation** — the body is accepted only if `sniff_image_mime()` recognizes it as a genuine raster image (PNG/JPEG/GIF/WEBP/HEIC...). The untrusted `Content-Type` header no longer decides acceptance or the mime; the sniffed magic bytes do. A non-image body is rejected with a clear `InvalidMediaTypeError`. (`resolve_image_mime()` is deliberately not reused here — its `image/jpeg` fallback would relabel an error page as an image, which is the exact bug.)
3. **Identifying `User-Agent`** — sent on the fetch so hosts that require one (e.g. Wikimedia) return the real image rather than a 403 (defence-in-depth; the guard above is the core fix).

Scoped to the passthrough understand fetch/validation. The native path and the catalog-drop (#464) / XPIA-envelope (#466) behavior are untouched.

## Tests (RED -> GREEN, TDD)

New tests in `tests/test_dispatcher.py`:

- `test_passthrough_understand_raises_on_http_error` — a 403 `text/plain` "Please set a user agent" surfaces loudly; the vision model is **not** called.
- `test_passthrough_understand_rejects_non_image_body` — a 200 non-image (HTML) body is rejected with a clear error; the model is not called.
- `test_passthrough_understand_accepts_real_image` — a 200 with real image magic bytes proceeds; the data-URL mime is derived from the sniffed bytes even when the header lies.
- `test_passthrough_understand_sends_user_agent` — the fetch carries a non-empty, identifying User-Agent.

Existing happy-path fixtures were updated from placeholder bytes (`b"x"`) to a real PNG signature so they represent a genuine downloaded image under the corrected validation (assertions unchanged).

Full suite: 306 passed (3 `live` deselected); ruff + ty clean.