### PR TITLE
fix: repo-state cleanup — case-collision + uv.lock self-version drift

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,3 +1,0 @@
-## 2024-05-24 - Headless Server UX Constraints
-**Learning:** imagine-mcp is a headless MCP server without a web frontend UI component. Standard web UX/a11y enhancements like ARIA labels or focus states are not applicable.
-**Action:** Do not attempt standard frontend UX enhancements on backend-only/headless projects.

--- a/uv.lock
+++ b/uv.lock
@@ -708,7 +708,7 @@ wheels = [
 
 [[package]]
 name = "imagine-mcp"
-version = "1.10.0b1"
+version = "1.10.1"
 source = { editable = "." }
 dependencies = [
     { name = "diskcache" },


### PR DESCRIPTION
Two pre-existing repo-state issues on `main` that break clean checkouts and tooling on case-insensitive filesystems.

## 1. Case-colliding `.Jules/palette.md` duplicate (primary)

`main` tracked BOTH `.Jules/palette.md` and `.jules/palette.md` — paths differing only in case that map to a single physical file on case-insensitive filesystems (Windows, macOS default). Every checkout there left one path perpetually reported as `modified`, which breaks pre-commit's stash/rollback with `patch does not apply`.

Removed the stale uppercase `.Jules/palette.md`. The lowercase `.jules/palette.md` is canonical:
- it is the sibling of `.jules/bolt.md` and `.jules/sentinel.md` (the standard lowercase journal set), whereas `.Jules/` held only the stray `palette.md`;
- it carries the more recently maintained content (last touched in #335, vs the uppercase copy from #41).

Verified: a fresh checkout of the branch has a clean `git status` (no perpetual-modified), and only `.jules/palette.md` remains tracked. The existing `check for case conflicts` pre-commit hook guards against reintroduction.

## 2. `uv.lock` self-version drift (secondary)

`uv.lock` recorded imagine-mcp's own package version as `1.10.0b1` while `pyproject.toml` (and HEAD, released as `v1.10.1`) is `1.10.1`. The mismatch made every `uv run`/`uv sync` regenerate `uv.lock`. Relocked with `uv lock` — the diff is exactly the editable root's self-version line; no other dependency pins changed.

Diffstat:
```
 .Jules/palette.md | 3 ---
 uv.lock           | 2 +-
```