### PR TITLE
perf: ⚡ Bolt: Pipeline Gemini multimodal async I/O gathers

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -52,3 +52,7 @@
 ## 2024-07-07 - Consolidate Consecutive Synchronous I/O in Async Contexts
 **Learning:** Executing consecutive synchronous file operations (e.g., `mkdir` followed by `write_bytes`) by wrapping each individually in `asyncio.to_thread` introduces unnecessary thread-pool scheduling and context-switching overhead.
 **Action:** When performing multiple related blocking operations in an async context, consolidate them into a single synchronous helper function and execute that helper via a single `asyncio.to_thread()` call.
+
+## 2024-05-18 - Pipeline sequential Async I/O Gathers
+**Learning:** In flows that require sequentially resolving metadata (like media types) before fetching the actual content, using separate `asyncio.gather` calls introduces unnecessary barrier synchronization latency. The second phase cannot start for *any* item until the first phase completes for *all* items.
+**Action:** Pipeline the detection and fetching into a single asynchronous helper function per item, and execute them concurrently using `asyncio.TaskGroup()`. This eliminates barrier latency while maintaining fail-fast error propagation.

--- a/src/imagine_mcp/providers/gemini.py
+++ b/src/imagine_mcp/providers/gemini.py
@@ -113,9 +113,10 @@ async def understand_multimodal(
     await asyncio.to_thread(tmp_dir.mkdir, parents=True, exist_ok=True)
 
     try:
-        # ⚡ Bolt: Optimize network I/O from O(N) to O(1) latency using asyncio.gather
-        # to fetch parts concurrently.
-        async def _fetch_part(idx: int, u: str, mt: str) -> Any:
+        # ⚡ Bolt: Optimize network I/O by pipelining detection and fetching into a single TaskGroup.
+        # This eliminates barrier synchronization latency while maintaining fail-fast behavior.
+        async def _process_part(idx: int, u: str) -> Any:
+            mt = media_types[idx] if media_types else await detect_media_type_async(u)
             if mt == "image":
                 img_resp = await get_ssrf_safe_async_client().get(
                     u, follow_redirects=True, timeout=60
@@ -133,28 +134,16 @@ async def understand_multimodal(
                 await download_to_path_async(u, tmp_path)
                 return await client.aio.files.upload(file=tmp_path)
 
-        async def _resolve_mt(idx: int, u: str) -> str:
-            return media_types[idx] if media_types else await detect_media_type_async(u)
+        try:
+            async with asyncio.TaskGroup() as tg:
+                tasks = [
+                    tg.create_task(_process_part(i, u)) for i, u in enumerate(urls)
+                ]
+        except ExceptionGroup as eg:
+            raise eg.exceptions[0] from None
 
-        # ⚡ Bolt: Use return_exceptions=True to ensure no background tasks are leaked
-        # if one download or upload fails. This also avoids skipping cleanup logic.
-        gathered_mts = await asyncio.gather(
-            *(_resolve_mt(i, u) for i, u in enumerate(urls)), return_exceptions=True
-        )
-        resolved_mts: list[str] = []
-        for res in gathered_mts:
-            if isinstance(res, BaseException):
-                raise res
-            resolved_mts.append(res)
-
-        results = await asyncio.gather(
-            *(_fetch_part(i, urls[i], resolved_mts[i]) for i in range(len(urls))),
-            return_exceptions=True,
-        )
-        for res in results:
-            if isinstance(res, BaseException):
-                raise res
-            parts.append(res)
+        for task in tasks:
+            parts.append(task.result())
 
         resp = await client.aio.models.generate_content(
             model=model,


### PR DESCRIPTION
💡 What: Replaced two sequential `asyncio.gather` calls in `understand_multimodal` with a single `asyncio.TaskGroup` to pipeline detection and fetching.

🎯 Why: The previous sequential gathers introduced barrier synchronization latency; the second phase (fetching) could not start for any URL until the first phase (type resolution) completed for all URLs.

📊 Impact: Reduces end-to-end latency for multimodal requests by allowing each item to begin its download immediately after its individual media type is resolved, eliminating unnecessary waiting time. Also converts the error handling from fail-slow (`return_exceptions=True`) to fail-fast.

🔬 Measurement: Observe overall response latency for multi-URL Gemini understand requests, particularly when URLs have significantly different latency characteristics for HEAD vs GET requests. No new tests were added as existing unit tests effectively cover the function and pass perfectly.

---
*PR created automatically by Jules for task [7706652296160334370](https://jules.google.com/task/7706652296160334370) started by @n24q02m*