### PR TITLE
fix: 🛡️ Sentinel: prevent error leakage in reset_credentials

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -19,3 +19,7 @@
 **Vulnerability:** Edge authentication gate in src/worker.ts bypassed using obfuscated URLs (e.g., //mcp or /%2Fmcp).
 **Learning:** Checking strict path strings against unnormalized request paths allows attackers to evade authentication checks before hitting internal endpoints.
 **Prevention:** Always decode and normalize URIs (using decodeURIComponent and replace) before conducting path-based security or routing decisions, and correctly handle malformed URIs.
+## 2026-07-25 - [MEDIUM] Error messages leaking internal details
+**Vulnerability:** The `reset_credentials` function in `src/imagine_mcp/relay_setup.py` caught exceptions and returned `str(exc)` in the JSON response, potentially exposing internal paths, stack traces, or configuration details to the client.
+**Learning:** Returning raw exception strings directly to users can unintentionally leak sensitive system information (e.g. `PermissionError: [Errno 13] /home/user/...`).
+**Prevention:** When handling exceptions that return data to the client, log the raw exception (`exc`) securely on the backend, but return a sanitized, generic error message (e.g., "An internal error occurred").

--- a/src/imagine_mcp/relay_setup.py
+++ b/src/imagine_mcp/relay_setup.py
@@ -143,4 +143,7 @@ def reset_credentials() -> dict[str, Any]:
         return {"status": "reset", "server": SERVER_NAME}
     except Exception as exc:
         logger.error("reset_credentials failed: {}", exc)
-        return {"status": "error", "error": str(exc)}
+        return {
+            "status": "error",
+            "error": "An internal error occurred while resetting credentials.",
+        }


### PR DESCRIPTION
🚨 **Severity:** MEDIUM
💡 **Vulnerability:** The `reset_credentials` function in `src/imagine_mcp/relay_setup.py` caught exceptions and returned `str(exc)` in its JSON response. This could leak internal system details, stack traces, or file paths (e.g. `[Errno 13] Permission denied: '/home/user/.imagine-mcp/config.json'`) to the client.
🎯 **Impact:** Exposes internal configuration paths or system state, allowing attackers to map internal environments.
🔧 **Fix:** Replaced the raw exception string in the response with a generic "An internal error occurred" message, while keeping the raw `exc` securely logged on the backend.
✅ **Verification:** Verified that error states return a generic response and ran the full suite via `uv run pytest` and `pnpm run test:worker` alongside `ruff` linting.

---
*PR created automatically by Jules for task [8662213019764661340](https://jules.google.com/task/8662213019764661340) started by @n24q02m*