### PR TITLE
perf: ⚡ Bolt: Pipeline async I/O in Gemini provider

### DIFF
--- a/src/imagine_mcp/providers/gemini.py
+++ b/src/imagine_mcp/providers/gemini.py
@@ -113,9 +113,11 @@ async def understand_multimodal(
     await asyncio.to_thread(tmp_dir.mkdir, parents=True, exist_ok=True)
 
     try:
-        # ⚡ Bolt: Optimize network I/O from O(N) to O(1) latency using asyncio.gather
-        # to fetch parts concurrently.
-        async def _fetch_part(idx: int, u: str, mt: str) -> Any:
+        # ⚡ Bolt: Pipeline media type resolution and fetching with TaskGroup for fail-fast error handling.
+        # Expected impact: Eliminates barrier synchronization latency on the happy path while
+        # immediately cancelling pending slow fetches if any fast resolution task fails.
+        async def _process_url(idx: int, u: str) -> Any:
+            mt = media_types[idx] if media_types else await detect_media_type_async(u)
             if mt == "image":
                 img_resp = await get_ssrf_safe_async_client().get(
                     u, follow_redirects=True, timeout=60
@@ -133,28 +135,14 @@ async def understand_multimodal(
                 await download_to_path_async(u, tmp_path)
                 return await client.aio.files.upload(file=tmp_path)
 
-        async def _resolve_mt(idx: int, u: str) -> str:
-            return media_types[idx] if media_types else await detect_media_type_async(u)
+        try:
+            async with asyncio.TaskGroup() as tg:
+                tasks = [tg.create_task(_process_url(i, u)) for i, u in enumerate(urls)]
+        except ExceptionGroup as eg:
+            raise eg.exceptions[0] from None
 
-        # ⚡ Bolt: Use return_exceptions=True to ensure no background tasks are leaked
-        # if one download or upload fails. This also avoids skipping cleanup logic.
-        gathered_mts = await asyncio.gather(
-            *(_resolve_mt(i, u) for i, u in enumerate(urls)), return_exceptions=True
-        )
-        resolved_mts: list[str] = []
-        for res in gathered_mts:
-            if isinstance(res, BaseException):
-                raise res
-            resolved_mts.append(res)
-
-        results = await asyncio.gather(
-            *(_fetch_part(i, urls[i], resolved_mts[i]) for i in range(len(urls))),
-            return_exceptions=True,
-        )
-        for res in results:
-            if isinstance(res, BaseException):
-                raise res
-            parts.append(res)
+        for task in tasks:
+            parts.append(task.result())
 
         resp = await client.aio.models.generate_content(
             model=model,


### PR DESCRIPTION
💡 What: Refactored `understand_multimodal` in the Gemini provider to use a single `asyncio.TaskGroup` pipeline instead of sequential `asyncio.gather` calls for media type resolution and content fetching.

🎯 Why: The previous implementation resolved all media types before beginning *any* content fetching (barrier synchronization). If one media type resolution failed quickly but others were slow, it unnecessarily delayed error propagation. The new pipeline starts fetching a URL's content immediately as soon as its individual media type is resolved, and automatically cancels all other pending tasks if any task fails.

📊 Impact: Reduces O(N) barrier latency to O(1) latency per item while maintaining robust resource cleanup and safe error propagation.

🔬 Measurement: Verify by running `uv run pytest tests/test_providers_gemini.py` or observe reduced latency when processing multiple mixed-media URLs.

---
*PR created automatically by Jules for task [12047979958619469413](https://jules.google.com/task/12047979958619469413) started by @n24q02m*