### PR TITLE
fix: bump mcp-core to 1.21.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,13 +47,14 @@ dependencies = [
     "pillow>=12.3.0",
     "diskcache>=5.6.3",
     "loguru>=0.7.3",
-    # 1.20.0 carries the build_cli `config`/`doctor` PerPluginStore key fix
-    # (#666). cli.py already passes PLUGIN_NAME ("imagine") as build_cli's
-    # server_name to sidestep the mismatch, so no CLI regression here.
-    # Floor is the stable release, not the b2 prerelease it replaced: naming a
-    # prerelease in the specifier opts this dependency into prerelease
-    # resolution for anyone installing the published package.
-    "n24q02m-mcp-core[llm]>=1.20.0,<2",
+    # Floor is 1.21.0 rather than 1.20.0 because HTTP mode runs mcp-core's
+    # OAuth AS: 1.21.0 stops it minting an auth code when the credential save
+    # fails (core#682) and adds `iss` to the authorization response
+    # (RFC 9207 / SEP-2468, core#688). A lower floor would let a downstream
+    # install resolve back past both.
+    # Keep the floor on a stable release -- naming a prerelease here opts this
+    # dependency into prerelease resolution for anyone installing the package.
+    "n24q02m-mcp-core[llm]>=1.21.0,<2",
     "platformdirs>=4.11.0",
     # Security floors: transitive deps pinned to patched releases.
     # urllib3 < 2.7.0 -> PYSEC-2026-141/142; idna < 3.15 -> CVE-2026-45409.

--- a/uv.lock
+++ b/uv.lock
@@ -493,11 +493,11 @@ wheels = [
 
 [[package]]
 name = "filelock"
-version = "3.29.7"
+version = "3.32.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/35/94/00f2059e4835eace3ae8fde680b932c496f8ec7bdc99168dfa53fb2e6b79/filelock-3.29.7.tar.gz", hash = "sha256:5b481979797ae69e72f0b389d89a80bdd585c260c5b3f1fb9c0a5ba9bb3f195d", size = 71521, upload-time = "2026-07-08T05:46:58.716Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/c0/80/8232b582c4b318b817cf1274ba74976b07b34d35ef439b3eb948f98645a1/filelock-3.32.0.tar.gz", hash = "sha256:7be2ad23a14607ccc71808e68fe30848aeace7058ace17852f68e2a68e310402", size = 213757, upload-time = "2026-07-21T13:17:42.898Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/60/02/be4a57b60c7149b55b9e3b3c13f609cd8eb5307c751f22bd8fb8d262e75b/filelock-3.29.7-py3-none-any.whl", hash = "sha256:987db6f789a3a2a59f55081801b2b3697cb97e2a736b5f1a9e99b559285fbc51", size = 46036, upload-time = "2026-07-08T05:46:57.53Z" },
+    { url = "https://files.pythonhosted.org/packages/06/79/b4c714bef36bc4ec2beeae1e0c124f0223888cd8c6feb1cdc56038116920/filelock-3.32.0-py3-none-any.whl", hash = "sha256:d396bea984af47333ef05e50eae7eff88c84256de6112aea0ec48a233c064fe3", size = 97732, upload-time = "2026-07-21T13:17:41.55Z" },
 ]
 
 [[package]]
@@ -751,7 +751,7 @@ requires-dist = [
     { name = "idna", specifier = ">=3.18" },
     { name = "loguru", specifier = ">=0.7.3" },
     { name = "mcp", extras = ["cli"], specifier = ">=1.28.1" },
-    { name = "n24q02m-mcp-core", extras = ["llm"], specifier = ">=1.20.0,<2" },
+    { name = "n24q02m-mcp-core", extras = ["llm"], specifier = ">=1.21.0,<2" },
     { name = "openai", specifier = ">=2.48.0" },
     { name = "pillow", specifier = ">=12.3.0" },
     { name = "platformdirs", specifier = ">=4.11.0" },
@@ -1127,7 +1127,7 @@ wheels = [
 
 [[package]]
 name = "n24q02m-mcp-core"
-version = "1.20.0"
+version = "1.21.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "authlib" },
@@ -1142,9 +1142,9 @@ dependencies = [
     { name = "starlette" },
     { name = "tomli-w" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/8f/99/a7e0e3c18bd5a4091dd8b6062b9277dd059de4d5e359ad4ee3735bbf572d/n24q02m_mcp_core-1.20.0.tar.gz", hash = "sha256:9050d6c2892dc931d82621e938dd2cb6e54091623414c914c6878d5d55c8c105", size = 345341, upload-time = "2026-07-18T09:08:59.199Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/2d/30/590222f26ace6b3f4eb9d39f6338993a77a487056131e3b8e44cac1f3a01/n24q02m_mcp_core-1.21.0.tar.gz", hash = "sha256:0902edef3c11cae453b12054b5c86b01f2c44b340baa62ba20178913c5605e0c", size = 347475, upload-time = "2026-07-25T07:39:49.345Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/10/dd/d0e7ab1ce6e19a3049a55e393f98a43e9d838d431f3950f48df3acac7c11/n24q02m_mcp_core-1.20.0-py3-none-any.whl", hash = "sha256:f610bfb686c51c7c965842e7890d22c3a382a3957269c13858d17be5e9399841", size = 189453, upload-time = "2026-07-18T09:08:57.997Z" },
+    { url = "https://files.pythonhosted.org/packages/61/09/0777b67ea7e8fdf96294342bf6aa3b5d76a368a67f46a870a7e4a3bf7966/n24q02m_mcp_core-1.21.0-py3-none-any.whl", hash = "sha256:9f78057826aa32a752bed5d7512bc78f0574b4b56a619f4b1b6cfa12d22cfb89", size = 190145, upload-time = "2026-07-25T07:39:47.979Z" },
 ]
 
 [package.optional-dependencies]


### PR DESCRIPTION
Closes #494. mcp-core cut stable v1.21.0 today; the standing decision was to wait for that stable rather than take `1.21.0-beta.1`, so this is the first point the bump is in scope.

## Why the floor moves, not just the lock

The previous pin `>=1.20.0,<2` already admitted 1.21.0, so a relock alone would have satisfied the issue. The floor moves because HTTP mode runs mcp-core's OAuth AS and 1.21.0 changes two things on that path:

- **core#682** -- no authorization code is minted when the credential save fails. Previously a failed save could still hand back a usable code.
- **core#688** -- `iss` is returned in the authorization response (RFC 9207 / SEP-2468).

Leaving the floor at 1.20.0 would let a downstream install resolve back past both. Kept as a range rather than `==`, and kept on a stable release -- naming a prerelease in the specifier opts this dependency into prerelease resolution for anyone installing the published package, which is what left the lock stranded on `1.20.0b2` before #493.

## Rest of the 1.20.0..1.21.0 range

Nothing else touches this repo's surface: dependency bumps, relay-form a11y (`aria-live`, `aria-describedby`), core-ts stable-sub parity, header-parsing micro-fix, and packaging changes on mcp-core's own side (pydantic kept as a range in the published libraries, explicit ruff lint rules, restrictive cache-file permissions).

## Verification

- `uv lock` -> `Updated n24q02m-mcp-core v1.20.0 -> v1.21.0`
- `pytest -m "not live"`: **311 passed**, against 1.21.0
- `ruff check` / `ruff format --check` / `ty check`: clean
- All pre-commit hooks ran; no `--no-verify`