### PR TITLE
fix: add bot PR governance workflow

### DIFF
--- a/.github/workflows/bot-governance.yml
+++ b/.github/workflows/bot-governance.yml
@@ -1,0 +1,90 @@
+name: Bot PR Governance
+
+on:
+  pull_request:
+    types:
+      - opened
+
+permissions:
+  pull-requests: write
+  contents: read
+
+jobs:
+  governance:
+    name: Bot PR Rate Limit & Duplicate Check
+    runs-on: ubuntu-latest
+    steps:
+      - name: Detect and govern bot PRs
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          BRANCH: ${{ github.head_ref }}
+          ACTOR: ${{ github.actor }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          PR_TITLE: ${{ github.event.pull_request.title }}
+          REPO: ${{ github.repository }}
+        run: |
+          set -e
+
+          # Detect if this is a bot-created PR by branch name pattern.
+          # Two signals:
+          #   1. Explicit bot-tool prefixes (Bolt, Palette, Jules, fix/web-scraper)
+          #   2. Any branch ending with a long numeric task/trace ID (-[0-9]{14,})
+          IS_BOT_PR=false
+          if echo "$BRANCH" | grep -qE \
+              '^(bolt[-/]|palette-ux-|fix/web-scraper-|jules[-/])'; then
+            IS_BOT_PR=true
+          elif echo "$BRANCH" | grep -qE -- \
+              '-[0-9]{14,}$'; then
+            IS_BOT_PR=true
+          fi
+
+          if [ "$IS_BOT_PR" = "false" ]; then
+            echo "Not a bot PR ($BRANCH), skipping governance checks."
+            exit 0
+          fi
+
+          echo "Bot PR detected on branch: $BRANCH"
+          gh pr edit "$PR_NUMBER" --add-label "bot-generated" --repo "$REPO" || true
+
+          # --- Rate limit: max 5 bot PRs/actor/day ---
+          SINCE=$(date -u -d '24 hours ago' +%Y-%m-%dT%H:%M:%SZ 2>/dev/null || \
+                  date -u -v-24H +%Y-%m-%dT%H:%M:%SZ)
+          COUNT=$(gh pr list --repo "$REPO" --state open \
+                   --json createdAt,headRefName,author \
+                   --jq "[.[] |
+                          select(.author.login == \"$ACTOR\") |
+                          select(.createdAt > \"$SINCE\") |
+                          select(.headRefName | test(
+                            \"^(bolt[-/]|palette-ux-|fix/web-scraper-|jules[-/])\" +
+                            \"|-[0-9]{14,}$\"
+                          ))] | length" 2>/dev/null || echo 0)
+
+          echo "Bot PRs by $ACTOR in last 24h: $COUNT"
+
+          if [ "${COUNT:-0}" -gt 5 ]; then
+            gh pr close "$PR_NUMBER" --repo "$REPO" \
+              --comment "**Bot rate limit exceeded**: $COUNT PRs created in the last 24 hours (limit: 5/day). This PR has been automatically closed to reduce PR backlog and CI resource waste. Please consolidate related fixes."
+            echo "PR #$PR_NUMBER closed: rate limit exceeded ($COUNT/5 today)"
+            exit 0
+          fi
+
+          # --- Duplicate detection by title keyword ---
+          KEYWORD=$(echo "$PR_TITLE" | sed 's/[^a-zA-Z0-9 _-]//g' | \
+                    tr '[:upper:]' '[:lower:]' | cut -c1-50 | xargs)
+          if [ -z "$KEYWORD" ]; then
+            echo "No keyword extracted, skipping duplicate check."
+            exit 0
+          fi
+
+          DUPES=$(gh pr list --repo "$REPO" --state open --search "$KEYWORD" \
+                   --json number \
+                   --jq "[.[] | select(.number != $PR_NUMBER)] | length" \
+                   2>/dev/null || echo 0)
+
+          echo "Similar open PRs for '$KEYWORD': $DUPES"
+          if [ "${DUPES:-0}" -ge 1 ]; then
+            gh pr edit "$PR_NUMBER" --repo "$REPO" \
+              --add-label "possible-duplicate" || true
+            gh pr comment "$PR_NUMBER" --repo "$REPO" \
+              --body "**Possible duplicate**: found ${DUPES} open PR(s) with similar title ('${KEYWORD}'). Check before merging: \`gh pr list --search '${KEYWORD}' --state open\`"
+          fi


### PR DESCRIPTION
Adds the bot-PR governance workflow already running on Aiora and the KP repos. Policy is settled: keep the bots on, clear their output daily, and add signature-based auto-close on top.

This is the control for what was cleared in #493. Five Bolt PRs proposed the same change to the same function (#481, #482, #484, #488, #491) and two Sentinel PRs reported the same finding (#489, #492). The ledger alone could not prevent that -- a rejection recorded in `.jules/bolt.md` is a negative instruction, and the cluster is the evidence it gets routed around: the entry forbade `asyncio.gather`, so every retry proposed `TaskGroup` instead.

## What it does

On `pull_request: opened` only:
1. Classifies the PR as bot-authored by branch name.
2. Labels it `bot-generated`.
3. Closes it with a comment if that actor has opened more than 5 bot PRs in 24h.
4. Labels `possible-duplicate` and comments if another open PR has a similar title.

Non-bot branches exit at step 1 before anything else runs.

## Difference from the template

One line. `runs-on: [self-hosted, linux, arm64]` becomes `runs-on: ubuntu-latest`, because this repo is public and the self-hosted runner is for private repos. `diff` against the Aiora copy reports that single line and nothing else; both files are 90 lines.

## Detection verified against this repo, not assumed

Ran the workflow own `grep -qE` expressions over the real branch names before landing:

**All 13 bot branches classified as bot** -- `bolt-*`, `bolt/*`, `jules-*`, `palette-skip-*`, `palette-no-ui-*`, `palette-headless-skip-*`, `sentinel-*`, `sentinel/*`, `security-path-normalization-*`, `fix-reset-credentials-leakage-*`, `perf/pipeline-*`.

**All 11 human and Renovate branches classified as not-bot** -- `fix/bump-mcp-core-1.21.0`, `fix/backlog-clearance-2026-07-25`, `renovate/non-major-dev`, `renovate/typescript-7.x`, `renovate/actions-checkout-7.x`, `fix/renovate-config-rangestrategy`, `feat/stable-sub-enable`, `fix/pin-action-shas`, `fix/oc-bot-hosted-runner`, `feat/pr-title-lint-gate`, `main`.

Worth recording: the prefix rule contributes little here. It lists `palette-ux-`, but this repo palette branches are `palette-skip-` / `palette-no-ui-` / `palette-headless-skip-`, and `sentinel` is not in the prefix list at all. Those are caught by the second rule instead, because Jules appends a long numeric task ID to every branch it creates. Coverage is complete, so the patterns are left exactly as the template has them -- but the numeric-suffix rule is doing the work, and a future bot that omits that suffix would slip through.

The rate-limit `jq` filter was checked separately against a fixture: it counts only the actor own bot branches inside the 24h window, skipping a human branch, a Renovate branch by another actor, and a bot branch outside the window.

## Prerequisite handled

The repo had neither label the workflow applies. Both `gh pr edit --add-label` calls are `|| true`, so the missing labels would not have failed the run -- they would have silently done nothing. Created `bot-generated` (`#FFA500`) and `possible-duplicate` (`#CCCCCC`) to match the Aiora definitions.