### PR TITLE
fix: drop the code_quality rule from the main ruleset

### DIFF
--- a/.github/rulesets/main.json
+++ b/.github/rulesets/main.json
@@ -40,12 +40,6 @@
       "type": "update"
     },
     {
-      "type": "code_quality",
-      "parameters": {
-        "severity": "errors"
-      }
-    },
-    {
       "type": "code_scanning",
       "parameters": {
         "code_scanning_tools": [


### PR DESCRIPTION
The `code_quality` rule in "Main Ruleset" required an analysis that has never run on this repository, so it never resolved and held every pull request at `BLOCKED`.

## Evidence it never ran

```
gh api "repos/n24q02m/imagine-mcp/code-scanning/analyses?per_page=30" --jq "[.[].tool.name]|unique"
  -> ["CodeQL"]

gh api repos/n24q02m/imagine-mcp/code-quality
  -> 404
```

GitHub Code Quality is a separate product from CodeQL. It reports a check named `CodeQL - Code Quality`, went GA on 2026-07-20, is billed per active committer, and is only available on Team / Enterprise Cloud. This account does not have it, so the rule was waiting on something that could never arrive.

## Symptom, confirmed against this session

Every PR merged here today reported `MERGEABLE / BLOCKED` with **all** checks SUCCESS and `required_approving_review_count: 0` -- and each needed `--admin` to merge:

| PR | checks | state before merge |
|---|---|---|
| #456, #440, #439, #434 | all SUCCESS | BLOCKED |
| #493 | 12/12 SUCCESS | BLOCKED |
| #495 | 12/12 SUCCESS | BLOCKED |
| #496 | 13/13 SUCCESS | BLOCKED |

With review count at 0 and `code_scanning` satisfied by a CodeQL run that did succeed, `code_quality` was the only rule left unsatisfied.

## Why removing it increases enforcement

An admin bypass does not skip one rule, it skips the ruleset. So the unsatisfiable rule was causing `code_scanning` -- which works correctly here, since CodeQL default setup is configured -- to be waved through on every merge too. Removing `code_quality` means CodeQL genuinely gates merges again.

Not enabling GitHub Code Quality: it is paid, needs a plan this account is not on, and is out of scope.

## Scope

`code_quality` only. Every other rule is byte-identical -- verified by diffing the live ruleset before and after; the only change is the removed block. Live ruleset updated via `PUT /repos/.../rulesets/15497545` built from the pre-change object, so `bypass_actors`, `conditions`, `pull_request` parameters and `code_scanning` thresholds all carried over untouched.

## IaC drift found -- reported, deliberately not fixed

`.github/rulesets/main.json` and the live ruleset disagree on three fields, and this PR changes none of them:

| Field | IaC file | Live |
|---|---|---|
| `required_approving_review_count` | `1` | `0` |
| `require_code_owner_review` | `true` | `false` |
| `bypass_actors` | 1 (RepositoryRole 5) | 3 (+ Integration 2740 = Renovate, + Integration 3200052) |

Cause: `scripts/repo-bootstrap/apply.py` treats `rulesets/main.json` as an `atomic-replace` **file** and never calls the rulesets API. Nothing syncs the declaration to GitHub in either direction, so the two drift silently and `audit.py` only checks that *some* active branch ruleset exists, not that it matches the file.

Whether live should rise to the file (require a review + code-owner review) or the file should drop to live is a repo-owner decision, so both are left as they are. Integration `3200052` could not be resolved to a slug without GitHub App authentication; it runs no check suites, which fits a push/release app rather than a checks app.