### PR TITLE
fix: skip bot governance on fork pull requests

### DIFF
--- a/.github/workflows/bot-governance.yml
+++ b/.github/workflows/bot-governance.yml
@@ -12,6 +12,15 @@ permissions:
 jobs:
   governance:
     name: Bot PR Rate Limit & Duplicate Check
+    # Internal PRs only. This repo is public, so `pull_request` gives a fork a
+    # read-only GITHUB_TOKEN that the `permissions:` block above cannot raise --
+    # `gh pr close` would then fail under `set -e` and abort the job. Closing an
+    # outside contributor's PR because someone else spent the rate limit is the
+    # wrong outcome anyway; the bots this governs push their branches to this
+    # repo, so fork PRs are never in scope. Comparing full_name rather than
+    # head.repo.fork keeps this correct if imagine-mcp is ever itself a fork,
+    # where head.repo.fork would be true for internal branches too.
+    if: github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
     steps:
       - name: Detect and govern bot PRs


### PR DESCRIPTION
`gh pr close` in the rate-limit branch of `bot-governance.yml` has no `|| true` while `set -e` is on. This repo is public, so the `pull_request` trigger hands a fork a **read-only** `GITHUB_TOKEN`, and the `permissions: pull-requests: write` block cannot raise it. The template came from Aiora, a private repo, where that path never ran.

## Skipping forks rather than wrapping the failure

`|| true` would stop the job erroring, but it treats the wrong outcome as acceptable. On a public repo, auto-closing an outside contributor PR -- because someone else spent the 5/day budget, or because a title resembled another open PR -- is the worst thing this workflow could do. Suppressing the error would just hide that it tried.

The bots this governs (Bolt, Sentinel, Palette, Jules) push their branches into this repo, so fork PRs were never in scope to begin with.

## Guard on the job, not in the step

The instruction was to place it before every write command. Putting it on the job satisfies that by construction -- there is no ordering to get wrong later -- and no runner starts for a fork PR at all.

It compares `head.repo.full_name` with `github.repository` rather than reading `head.repo.fork`:

```yaml
if: github.event.pull_request.head.repo.full_name == github.repository
```

`head.repo.fork` answers "is the head repo a fork of anything", which is only equivalent to "is this PR external" while this repo is not itself a fork. If imagine-mcp were ever forked-from or transferred, `head.repo.fork` would read `true` for ordinary internal branches and would silently disable governance -- a failure that looks like nothing happening. The `full_name` comparison asks the question we actually mean.

Verified against real payloads -- all internal PRs evaluate TRUE, so governance still runs for them:

| PR | `head.repo.full_name` | `head.repo.fork` | guard |
|---|---|---|---|
| #497 | `n24q02m/imagine-mcp` | false | TRUE, runs |
| #496 | `n24q02m/imagine-mcp` | false | TRUE, runs |
| #493 | `n24q02m/imagine-mcp` | false | TRUE, runs |
| #481 (a real Bolt PR) | `n24q02m/imagine-mcp` | false | TRUE, runs |

## Scope

Nine added lines, eight of them comment. Detection patterns, rate-limit logic and duplicate detection are untouched -- `git diff` is a pure insertion.

## What is not verified

The fork path itself. There is no fork PR open against this repo, and opening one would mean pushing a fork just to trip a guard. The internal path is verified by this PR own run; the fork path rests on GitHub documented token behaviour plus the payload comparison above.

One consequence worth stating: a skipped job logs no message, so a fork PR will show `Bot PR Rate Limit & Duplicate Check` as skipped with no explanation in the run. The reasoning lives in the workflow comment instead.