### PR TITLE
perf: ⚡ Bolt: consolidate system status sync to avoid redundant disk reads

### DIFF
--- a/src/imagine_mcp/server.py
+++ b/src/imagine_mcp/server.py
@@ -47,6 +47,21 @@ def _creds_state() -> str:
     return "CONFIGURED" if _providers_configured_live() else "NEEDS_SETUP"
 
 
+def _get_system_status_sync() -> dict[str, Any]:
+    """Consolidated synchronous I/O for the status tool.
+
+    Avoids redundant disk reads that would occur if _creds_state and
+    _providers_configured_live were called separately via to_thread.
+    """
+    version = _get_version()
+    live = _providers_configured_live()
+    return {
+        "version": version,
+        "credentials_state": "CONFIGURED" if live else "NEEDS_SETUP",
+        "providers_configured": live,
+    }
+
+
 def _providers_configured() -> list[str]:
     """Return list of providers configured via environment variables."""
     from imagine_mcp.relay_setup import CREDENTIAL_KEYS
@@ -311,12 +326,9 @@ def build_app() -> FastMCP:
                     "message": "No heavy resources to warm up in v1.",
                 }
             case "status":
+                status_sync = await asyncio.to_thread(_get_system_status_sync)
                 return {
-                    "version": await asyncio.to_thread(_get_version),
-                    "credentials_state": await asyncio.to_thread(_creds_state),
-                    "providers_configured": await asyncio.to_thread(
-                        _providers_configured_live
-                    ),
+                    **status_sync,
                     "default_provider": settings.default_provider,
                     "default_tier": settings.default_tier,
                     "cache_ttl_seconds": settings.cache_ttl_seconds,


### PR DESCRIPTION
💡 **What:** Created a consolidated `_get_system_status_sync` helper function in `src/imagine_mcp/server.py` to handle the `status` case of the `config` tool, and dispatched it via a single `asyncio.to_thread` call instead of three separate ones.
🎯 **Why:** The previous implementation launched three separate `asyncio.to_thread` calls for `_get_version`, `_creds_state`, and `_providers_configured_live`. Furthermore, `_creds_state` internally invoked `_providers_configured_live()`, which caused redundant disk I/O reads (via `PerPluginStore.load()`) and unnecessary thread handoffs.
📊 **Impact:** Reduces thread context-switching overhead from 3 dispatches to 1 and eliminates redundant file system reads/decryptions during status checks.
🔬 **Measurement:** Verify by running `uv run pytest tests/test_server.py` to ensure the status handler still accurately reflects system state.

---
*PR created automatically by Jules for task [17891504312893576416](https://jules.google.com/task/17891504312893576416) started by @n24q02m*