### PR TITLE
fix: 🛡️ Sentinel: prevent environment variable injection in apply_config

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -34,3 +34,8 @@ Proposals evaluated and turned down. The reasoning lives here so it carries to t
 
 - **Replacing this file's history with a single entry (#492).** The PR that reported the `reset_credentials` leak also deleted every prior entry in this ledger, leaving only its own. The finding was correct and has been implemented (see the 2026-07-25 entry), but this file is the record of what has already been fixed; clearing it makes past work invisible to the next run and invites re-proposal of things already landed. Append, never rewrite. #489 reported the same issue and appended correctly.
 - **Asserting on the exact error string.** The test proposed alongside #492 asserted `result["error"] == "Internal server error"`, which pins the wording rather than the property. The committed test asserts that the store path and `Errno` do *not* appear in the response, which is what actually matters and survives a reword.
+
+## 2026-07-30 - [CRITICAL] Environment Variable Injection in relay config
+**Vulnerability:** The `apply_config` function in `src/imagine_mcp/relay_setup.py` iterated through the provided `config` dictionary and set `os.environ[key] = value` for every key without filtering. An attacker could inject arbitrary, potentially malicious environment variables into the server process.
+**Learning:** Functions that map user-provided or remotely-fetched dictionaries directly to sensitive process state (like `os.environ`) are highly vulnerable if they do not validate or sanitize the incoming keys against an explicit allowlist.
+**Prevention:** Always restrict dynamically applied configurations to a strict, hardcoded allowlist of explicitly expected keys (e.g., `if key not in CREDENTIAL_KEYS: continue`) before modifying system or process-level state.

--- a/src/imagine_mcp/relay_setup.py
+++ b/src/imagine_mcp/relay_setup.py
@@ -47,6 +47,8 @@ def apply_config(config: dict[str, str]) -> None:
     ``credential_state.store_for_sub`` and never touches ``os.environ``.
     """
     for key, value in config.items():
+        if key not in CREDENTIAL_KEYS:
+            continue
         if value and os.environ.get(key) != value:
             os.environ[key] = value
             logger.debug("Applied relay config: {}", key)

--- a/tests/test_relay_setup.py
+++ b/tests/test_relay_setup.py
@@ -97,6 +97,15 @@ def test_apply_config_skips_empty_values():
     assert "GEMINI_API_KEY" not in os.environ
 
 
+def test_apply_config_filters_unauthorized_keys():
+    """Sentinel: Prevent environment variable injection."""
+    apply_config({"GEMINI_API_KEY": "gk", "MALICIOUS_VAR": "injected"})
+    import os
+
+    assert os.environ.get("GEMINI_API_KEY") == "gk"
+    assert "MALICIOUS_VAR" not in os.environ
+
+
 # --------------------------------------------------------------------------
 # save_credentials
 # --------------------------------------------------------------------------


### PR DESCRIPTION
🚨 Severity: CRITICAL
💡 Vulnerability: Environment variable injection via `apply_config`. The function allowed any key-value pair from the `config` dictionary to be applied directly to `os.environ` without filtering.
🎯 Impact: An attacker could supply malicious variables through the relay configuration setup, potentially gaining code execution, manipulating process behavior, or compromising other sensitive configurations on the server.
🔧 Fix: Implemented an allowlist check (`if key not in CREDENTIAL_KEYS: continue`) to restrict modifications to only explicitly expected credential keys.
✅ Verification: Added a test case `test_apply_config_filters_unauthorized_keys` to verify that unauthorized keys are rejected.

---
*PR created automatically by Jules for task [13861109459814779126](https://jules.google.com/task/13861109459814779126) started by @n24q02m*