### PR TITLE
perf: ⚡ Bolt: consolidate system status sync calls

### DIFF
--- a/src/imagine_mcp/server.py
+++ b/src/imagine_mcp/server.py
@@ -39,14 +39,6 @@ def _get_version() -> str:
     return __version__
 
 
-def _creds_state() -> str:
-    """Return CONFIGURED if any provider is set (env or store), else NEEDS_SETUP.
-
-    Checks live store because env vars may not be populated at startup.
-    """
-    return "CONFIGURED" if _providers_configured_live() else "NEEDS_SETUP"
-
-
 def _providers_configured() -> list[str]:
     """Return list of providers configured via environment variables."""
     from imagine_mcp.relay_setup import CREDENTIAL_KEYS
@@ -97,6 +89,15 @@ def _providers_configured_live() -> list[str]:
             seen.add(p)
             out.append(p)
     return out
+
+
+def _get_system_status_sync() -> dict[str, Any]:
+    providers = _providers_configured_live()
+    return {
+        "version": _get_version(),
+        "credentials_state": "CONFIGURED" if providers else "NEEDS_SETUP",
+        "providers_configured": providers,
+    }
 
 
 def _set_runtime(key: str | None, value: str | None) -> dict[str, Any]:
@@ -311,12 +312,9 @@ def build_app() -> FastMCP:
                     "message": "No heavy resources to warm up in v1.",
                 }
             case "status":
+                status = await asyncio.to_thread(_get_system_status_sync)
                 return {
-                    "version": await asyncio.to_thread(_get_version),
-                    "credentials_state": await asyncio.to_thread(_creds_state),
-                    "providers_configured": await asyncio.to_thread(
-                        _providers_configured_live
-                    ),
+                    **status,
                     "default_provider": settings.default_provider,
                     "default_tier": settings.default_tier,
                     "cache_ttl_seconds": settings.cache_ttl_seconds,

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -10,7 +10,7 @@ from fastmcp.exceptions import ToolError
 from imagine_mcp import __version__
 from imagine_mcp.security import UNTRUSTED_SOURCE
 from imagine_mcp.server import (
-    _creds_state,
+    _get_system_status_sync,
     _get_version,
     _providers_configured,
     _providers_configured_live,
@@ -63,23 +63,26 @@ def test_build_app_reports_package_version() -> None:
     assert reported != "3.4.2"
 
 
-def test_creds_state(monkeypatch) -> None:
+def test_get_system_status_sync(monkeypatch) -> None:
     # No keys
     monkeypatch.delenv("GEMINI_API_KEY", raising=False)
     monkeypatch.delenv("OPENAI_API_KEY", raising=False)
     monkeypatch.delenv("XAI_API_KEY", raising=False)
-    assert _creds_state() == "NEEDS_SETUP"
+    status = _get_system_status_sync()
+    assert status["credentials_state"] == "NEEDS_SETUP"
 
     # One key
     monkeypatch.setenv("GEMINI_API_KEY", "test")
-    assert _creds_state() == "CONFIGURED"
+    status = _get_system_status_sync()
+    assert status["credentials_state"] == "CONFIGURED"
     # From store
     monkeypatch.delenv("GEMINI_API_KEY", raising=False)
     with patch(
         "mcp_core.storage.per_plugin_store.PerPluginStore.load",
         return_value={"GEMINI_API_KEY": "test"},
     ):
-        assert _creds_state() == "CONFIGURED"
+        status = _get_system_status_sync()
+        assert status["credentials_state"] == "CONFIGURED"
 
 
 def test_providers_configured(monkeypatch) -> None:


### PR DESCRIPTION
💡 **What:**
Refactored the `config` tool's `"status"` case in `src/imagine_mcp/server.py` to batch multiple synchronous functions (`_get_version`, `_creds_state`, `_providers_configured_live`) into a single helper function (`_get_system_status_sync`). This helper is then executed within a single `asyncio.to_thread` dispatch instead of three separate ones.

🎯 **Why:**
Previously, generating the status response dispatched three separate synchronous calls to the asyncio thread pool sequentially. This introduced unnecessary barrier synchronization latency and thread scheduling overhead. Additionally, `_creds_state` was internally calling `_providers_configured_live()`, which was also being called separately, resulting in redundant disk reads of the `PerPluginStore` when fetching system status.

📊 **Impact:**
- Eliminates 2 redundant thread pool dispatches for every status check.
- Removes a duplicate call to `_providers_configured_live()`, saving an unnecessary synchronous disk read from `PerPluginStore`.
- Improves the latency of the `config` tool's status endpoint, making it snappier.

🔬 **Measurement:**
- Verify that `uv run pytest tests/test_server.py` passes successfully, validating that the new `_get_system_status_sync` helper accurately returns the consolidated status format and removes the old, unused `_creds_state` helper correctly.

---
*PR created automatically by Jules for task [5721012339442676498](https://jules.google.com/task/5721012339442676498) started by @n24q02m*