### PR TITLE
fix: isolate test HOME so the suite cannot write the real credential store

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -24,3 +24,14 @@ def reset_contextvars():
     from imagine_mcp.credential_state import _request_creds
 
     _request_creds.set(None)
+
+
+@pytest.fixture(autouse=True)
+def _isolate_per_plugin_home(tmp_path_factory, monkeypatch):
+    """Redirect ~/ to a per-test tmp dir so PerPluginStore writes don't
+    pollute the real ~/.imagine-mcp/ between test runs (or worse, between
+    parallel pytest workers in CI). Path.home() reads HOME on POSIX
+    and USERPROFILE on Windows."""
+    fake_home = tmp_path_factory.mktemp("imagine_test_home")
+    monkeypatch.setenv("HOME", str(fake_home))
+    monkeypatch.setenv("USERPROFILE", str(fake_home))

--- a/tests/test_home_isolation_guard.py
+++ b/tests/test_home_isolation_guard.py
@@ -1,0 +1,44 @@
+"""Guard: the autouse home-isolation fixture in conftest must stay in place.
+
+``PerPluginStore`` keys its on-disk layout off ``Path.home()``
+(``~/.imagine-mcp/config.json`` plus the machine key at
+``~/.imagine-mcp/.secret``), so an un-isolated run writes into the
+developer's real home -- and into one shared home when CI runs parallel
+pytest workers. If ``_isolate_per_plugin_home`` is deleted or stops
+working, these tests fail loudly instead of letting the suite silently
+read and overwrite real credentials.
+
+Both assertions are non-destructive: they inspect resolved paths rather
+than performing a store write, so a regression reports the problem
+without itself polluting the real home.
+"""
+
+from pathlib import Path
+
+from imagine_mcp.credential_state import PLUGIN_NAME
+
+# Captured at import (collection) time, before any autouse fixture has
+# redirected HOME/USERPROFILE -- so this is the real user home.
+_REAL_HOME = Path.home()
+_REAL_STORE = _REAL_HOME / f".{PLUGIN_NAME}-mcp"
+
+
+def test_home_is_redirected_away_from_real_home():
+    """Path.home() inside a test must not resolve to the real user home."""
+    assert Path.home() != _REAL_HOME, (
+        "home-isolation fixture is missing: Path.home() still resolves to the "
+        f"real user home ({_REAL_HOME}). Restore _isolate_per_plugin_home in "
+        "tests/conftest.py."
+    )
+
+
+def test_per_plugin_store_path_is_outside_real_home():
+    """The credential store must not resolve into the real ~/.imagine-mcp."""
+    from mcp_core.storage.per_plugin_store import PerPluginStore
+
+    cred_path = PerPluginStore(PLUGIN_NAME).cred_path
+
+    assert _REAL_STORE not in cred_path.parents, (
+        f"PerPluginStore would read/write the real credential store: {cred_path}. "
+        "Restore _isolate_per_plugin_home in tests/conftest.py."
+    )


### PR DESCRIPTION
## Problem

`PerPluginStore` keys its on-disk layout off `Path.home()` — `~/.imagine-mcp/config.json`
plus a machine key at `~/.imagine-mcp/.secret`. Most tests that touch the store patch
`Path.home` themselves, but several do not, so they resolve into the developer's **real**
home.

Measured on this suite at `origin/main` (instrumented run, unmodified tests): **24 store-path
resolutions landed on the real `~/.imagine-mcp/config.json`**, from `test_server.py`,
`test_security.py`, `test_structured_output.py` and `test_g6_ux_status_accuracy.py`.

This is silent today only because the path is absent on a fresh machine — `load()` returns
early when the blob is missing. On any machine that has actually run the server, the file
exists, so `load()` proceeds to `_load_or_generate_machine_key()` and **writes into the real
home**. Reproduced: with a credential file seeded, one suite run created
`~/.imagine-mcp/.secret` (32 bytes) and moved the directory mtime `1785683898` → `1785683968`.

Consequences: the suite reads and can overwrite real credentials, test outcomes depend on
whether the developer has configured the server, and parallel CI workers share one home.

## Fix

An autouse fixture in `tests/conftest.py` redirecting `HOME` + `USERPROFILE` to a per-test
tmp dir (`Path.home()` reads `HOME` on POSIX, `USERPROFILE` on Windows). Ported from the
equivalent fixture in `mnemo-s2-vectorize`.

## Guard

`tests/test_home_isolation_guard.py` fails if the fixture is ever deleted. It captures the
real home at import time (before autouse fixtures run) and asserts both that `Path.home()`
is redirected and that the resolved store path is outside the real `~/.imagine-mcp`. Both
assertions inspect paths rather than writing, so a regression reports the problem without
itself polluting the home.

Verified red/green: with the fixture removed both guard tests fail with actionable messages;
restored, both pass, and the real home is untouched even by the failing run.

## Verification

- Before (unpatched, seeded home): 311 passed — real home gained `.secret`, dir mtime moved.
- After (patched, identical seeded state): 313 passed — `.secret` not recreated, both mtimes
  byte-identical.
- Final run on a clean machine: 313 passed, real `~/.imagine-mcp` still absent.
- Scope: `tests/` only, `src/` untouched.

Note (out of scope): `src/` also writes to `platformdirs.user_cache_dir("imagine-mcp")`
(`media.py`, `providers/gemini.py`, `server.py`). That path keys off `LOCALAPPDATA` on
Windows, so this fixture does not redirect it there. The current suite does not write to it
— its contents predate these runs by ~30 days — so it is left alone rather than widened here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
