### PR TITLE
fix: ⚡ Bolt: consolidate status sync

### DIFF
--- a/src/imagine_mcp/server.py
+++ b/src/imagine_mcp/server.py
@@ -99,6 +99,16 @@ def _providers_configured_live() -> list[str]:
     return out
 
 
+def _get_system_status_sync() -> dict[str, Any]:
+    """Helper to fetch all system status fields synchronously to avoid redundant disk I/O."""
+    providers = _providers_configured_live()
+    return {
+        "version": _get_version(),
+        "credentials_state": "CONFIGURED" if providers else "NEEDS_SETUP",
+        "providers_configured": providers,
+    }
+
+
 def _set_runtime(key: str | None, value: str | None) -> dict[str, Any]:
     if not key or key not in _VALID_SET_KEYS:
         return {
@@ -311,12 +321,9 @@ def build_app() -> FastMCP:
                     "message": "No heavy resources to warm up in v1.",
                 }
             case "status":
+                status_data = await asyncio.to_thread(_get_system_status_sync)
                 return {
-                    "version": await asyncio.to_thread(_get_version),
-                    "credentials_state": await asyncio.to_thread(_creds_state),
-                    "providers_configured": await asyncio.to_thread(
-                        _providers_configured_live
-                    ),
+                    **status_data,
                     "default_provider": settings.default_provider,
                     "default_tier": settings.default_tier,
                     "cache_ttl_seconds": settings.cache_ttl_seconds,


### PR DESCRIPTION
💡 What: Created a single synchronous helper `_get_system_status_sync` and called it in a single `asyncio.to_thread` dispatch inside the config `status` tool.
🎯 Why: Calling `_creds_state` and `_providers_configured_live` via separate `asyncio.to_thread` dispatches triggered redundant reads to the `PerPluginStore` from disk, and caused unnecessary thread scheduling overhead. 
📊 Impact: Reduces thread switching overhead and file I/O operations from 2 disk reads down to 1.
🔬 Measurement: Verified with test suite (`uv run pytest`) and Ruff (`uv tool run ruff check .`).

---
*PR created automatically by Jules for task [16675291863221075246](https://jules.google.com/task/16675291863221075246) started by @n24q02m*