### PR TITLE
fix: 🛡️ Sentinel: prevent environment variable injection from relay payload

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -34,3 +34,8 @@ Proposals evaluated and turned down. The reasoning lives here so it carries to t
 
 - **Replacing this file's history with a single entry (#492).** The PR that reported the `reset_credentials` leak also deleted every prior entry in this ledger, leaving only its own. The finding was correct and has been implemented (see the 2026-07-25 entry), but this file is the record of what has already been fixed; clearing it makes past work invisible to the next run and invites re-proposal of things already landed. Append, never rewrite. #489 reported the same issue and appended correctly.
 - **Asserting on the exact error string.** The test proposed alongside #492 asserted `result["error"] == "Internal server error"`, which pins the wording rather than the property. The committed test asserts that the store path and `Errno` do *not* appear in the response, which is what actually matters and survives a reword.
+
+## 2026-08-03 - [CRITICAL] Environment variable injection via relay payload
+**Vulnerability:** Untrusted configuration payloads parsed from remote relays or OAuth forms were directly applied to `os.environ` inside `apply_config` in `src/imagine_mcp/relay_setup.py`, allowing injection of arbitrary environment variables.
+**Learning:** Directly copying user-controlled data into `os.environ` can lead to severe security risks by overriding application behaviour, paths, or settings if unauthorized variables are injected.
+**Prevention:** Always strictly validate configuration payloads against an allowlist (e.g., `ALLOWED_CONFIG_KEYS`) before applying them to `os.environ`.

--- a/src/imagine_mcp/relay_setup.py
+++ b/src/imagine_mcp/relay_setup.py
@@ -21,6 +21,12 @@ CREDENTIAL_KEYS: list[str] = [
     "GOOGLE_VERTEX_EXPRESS_API_KEY",
 ]
 
+ALLOWED_CONFIG_KEYS = set(CREDENTIAL_KEYS) | {
+    "UNDERSTAND_MODELS",
+    "GENERATE_MODELS",
+    "GENERATE_PROVIDER_PRIORITY",
+}
+
 # 5 minutes: user needs time to copy URL, open browser, fill up to 3 keys
 RELAY_TIMEOUT_S = 300.0
 
@@ -47,6 +53,9 @@ def apply_config(config: dict[str, str]) -> None:
     ``credential_state.store_for_sub`` and never touches ``os.environ``.
     """
     for key, value in config.items():
+        if key not in ALLOWED_CONFIG_KEYS:
+            logger.warning("Ignoring unauthorized config key: {}", key)
+            continue
         if value and os.environ.get(key) != value:
             os.environ[key] = value
             logger.debug("Applied relay config: {}", key)

--- a/tests/test_relay_setup.py
+++ b/tests/test_relay_setup.py
@@ -97,6 +97,14 @@ def test_apply_config_skips_empty_values():
     assert "GEMINI_API_KEY" not in os.environ
 
 
+def test_apply_config_skips_unauthorized_keys():
+    apply_config({"HACKED_VAR": "123", "GEMINI_API_KEY": "val"})
+    import os
+
+    assert "HACKED_VAR" not in os.environ
+    assert os.environ.get("GEMINI_API_KEY") == "val"
+
+
 # --------------------------------------------------------------------------
 # save_credentials
 # --------------------------------------------------------------------------


### PR DESCRIPTION
🚨 **Severity**: CRITICAL
💡 **Vulnerability**: Untrusted configuration payloads parsed from remote relays or OAuth forms were directly applied to `os.environ` inside `apply_config` in `src/imagine_mcp/relay_setup.py`, allowing injection of arbitrary environment variables.
🎯 **Impact**: Directly copying user-controlled data into `os.environ` can lead to severe security risks by overriding application behaviour, paths, or settings if unauthorized variables are injected. An attacker could potentially overwrite critical environment variables (like `LD_PRELOAD`, `PYTHONPATH`, or AWS credentials) leading to remote code execution or privilege escalation.
🔧 **Fix**: Implemented a strict allowlist (`ALLOWED_CONFIG_KEYS`) that contains only valid configuration keys (`CREDENTIAL_KEYS`, `UNDERSTAND_MODELS`, `GENERATE_MODELS`, `GENERATE_PROVIDER_PRIORITY`). Unauthorized keys are ignored and logged as warnings.
✅ **Verification**: Run `uv run pytest tests/test_relay_setup.py` and observe `test_apply_config_skips_unauthorized_keys` passes successfully.

---
*PR created automatically by Jules for task [13031498933034444514](https://jules.google.com/task/13031498933034444514) started by @n24q02m*