### PR TITLE
fix: ⚡ Bolt: consolidate system status sync to avoid redundant disk I/O

### DIFF
--- a/src/imagine_mcp/server.py
+++ b/src/imagine_mcp/server.py
@@ -99,6 +99,20 @@ def _providers_configured_live() -> list[str]:
     return out
 
 
+def _get_system_status_sync() -> tuple[str, str, list[str]]:
+    """Gather system status sequentially to avoid multiple to_thread dispatches.
+
+    This avoids redundant disk reads since _creds_state() and
+    _providers_configured_live() both eventually trigger PerPluginStore loading.
+    """
+    version = _get_version()
+    # Note: we call _providers_configured_live directly and pass it to _creds_state
+    # logic to avoid duplicated work.
+    providers = _providers_configured_live()
+    creds_state = "CONFIGURED" if providers else "NEEDS_SETUP"
+    return version, creds_state, providers
+
+
 def _set_runtime(key: str | None, value: str | None) -> dict[str, Any]:
     if not key or key not in _VALID_SET_KEYS:
         return {
@@ -311,12 +325,13 @@ def build_app() -> FastMCP:
                     "message": "No heavy resources to warm up in v1.",
                 }
             case "status":
+                version, creds_state, providers = await asyncio.to_thread(
+                    _get_system_status_sync
+                )
                 return {
-                    "version": await asyncio.to_thread(_get_version),
-                    "credentials_state": await asyncio.to_thread(_creds_state),
-                    "providers_configured": await asyncio.to_thread(
-                        _providers_configured_live
-                    ),
+                    "version": version,
+                    "credentials_state": creds_state,
+                    "providers_configured": providers,
                     "default_provider": settings.default_provider,
                     "default_tier": settings.default_tier,
                     "cache_ttl_seconds": settings.cache_ttl_seconds,


### PR DESCRIPTION
💡 What: The optimization introduces a synchronous helper `_get_system_status_sync` in `src/imagine_mcp/server.py` that gathers `version`, `creds_state`, and `providers_configured_live` in a single execution context, and updates the `config(action="status")` handler to call this helper with a single `asyncio.to_thread` dispatch.
🎯 Why: Previously, the `status` handler executed three separate `asyncio.to_thread` calls. Because `_creds_state` internally invoked `_providers_configured_live()`, the application duplicated work and triggered redundant `PerPluginStore` disk reads/JSON parsing across separate thread dispatches.
📊 Impact: Reduces thread-pool context switches for the `status` endpoint by 66% (from 3 down to 1). Eliminates redundant PerPluginStore disk reads when fetching credentials state.
🔬 Measurement: Verify by calling the `config(action="status")` MCP tool; the response should remain identical while internal tracing will show only one thread dispatch.

---
*PR created automatically by Jules for task [10588659736214834809](https://jules.google.com/task/10588659736214834809) started by @n24q02m*