### PR TITLE
fix: 🛡️ Sentinel: prevent env var injection in relay config

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -34,3 +34,8 @@ Proposals evaluated and turned down. The reasoning lives here so it carries to t
 
 - **Replacing this file's history with a single entry (#492).** The PR that reported the `reset_credentials` leak also deleted every prior entry in this ledger, leaving only its own. The finding was correct and has been implemented (see the 2026-07-25 entry), but this file is the record of what has already been fixed; clearing it makes past work invisible to the next run and invites re-proposal of things already landed. Append, never rewrite. #489 reported the same issue and appended correctly.
 - **Asserting on the exact error string.** The test proposed alongside #492 asserted `result["error"] == "Internal server error"`, which pins the wording rather than the property. The committed test asserts that the store path and `Errno` do *not* appear in the response, which is what actually matters and survives a reword.
+
+## 2024-05-18 - Prevent Environment Variable Injection
+**Vulnerability:** The application was merging untrusted payloads (remote relay config or OAuth forms) directly into `os.environ` without any allowlist validation.
+**Learning:** This exposes the application to arbitrary environment variable injection (e.g. poisoning internal configuration or secrets) if the user controls the config.
+**Prevention:** Always validate configuration payloads parsed from untrusted sources against a strict allowlist (like `ALLOWED_CONFIG_KEYS`) before applying them to `os.environ`.

--- a/src/imagine_mcp/relay_setup.py
+++ b/src/imagine_mcp/relay_setup.py
@@ -21,6 +21,12 @@ CREDENTIAL_KEYS: list[str] = [
     "GOOGLE_VERTEX_EXPRESS_API_KEY",
 ]
 
+ALLOWED_CONFIG_KEYS = set(CREDENTIAL_KEYS) | {
+    "UNDERSTAND_MODELS",
+    "GENERATE_MODELS",
+    "GENERATE_PROVIDER_PRIORITY",
+}
+
 # 5 minutes: user needs time to copy URL, open browser, fill up to 3 keys
 RELAY_TIMEOUT_S = 300.0
 
@@ -47,6 +53,9 @@ def apply_config(config: dict[str, str]) -> None:
     ``credential_state.store_for_sub`` and never touches ``os.environ``.
     """
     for key, value in config.items():
+        if key not in ALLOWED_CONFIG_KEYS:
+            logger.warning("Rejecting invalid config key: {}", key)
+            continue
         if value and os.environ.get(key) != value:
             os.environ[key] = value
             logger.debug("Applied relay config: {}", key)


### PR DESCRIPTION
The relay setup previously merged untrusted remote config payloads and OAuth forms directly into `os.environ` without filtering. This creates an arbitrary environment variable injection vulnerability if the config source is manipulated (e.g., poisoning `PYTHONPATH` or overriding internal server configuration).

This fix introduces an `ALLOWED_CONFIG_KEYS` allowlist comprising `CREDENTIAL_KEYS`, `UNDERSTAND_MODELS`, `GENERATE_MODELS`, and `GENERATE_PROVIDER_PRIORITY`. The `apply_config` function now strictly validates all incoming payload keys against this set and rejects invalid keys, preventing arbitrary variable injection while preserving expected functionality.

A critical security learning entry has been added to `.jules/sentinel.md` documenting this finding and the mitigation strategy.

---
*PR created automatically by Jules for task [9824911410498147089](https://jules.google.com/task/9824911410498147089) started by @n24q02m*