### PR TITLE
perf: ⚡ Bolt: consolidate system status sync to avoid redundant disk reads

### DIFF
--- a/src/imagine_mcp/server.py
+++ b/src/imagine_mcp/server.py
@@ -99,6 +99,19 @@ def _providers_configured_live() -> list[str]:
     return out
 
 
+def _get_system_status_sync() -> dict[str, Any]:
+    """Gather version and credential state in a single synchronous call."""
+    _live_providers = _providers_configured_live()
+    return {
+        "version": _get_version(),
+        "credentials_state": "CONFIGURED" if _live_providers else "NEEDS_SETUP",
+        "providers_configured": _live_providers,
+        "default_provider": settings.default_provider,
+        "default_tier": settings.default_tier,
+        "cache_ttl_seconds": settings.cache_ttl_seconds,
+    }
+
+
 def _set_runtime(key: str | None, value: str | None) -> dict[str, Any]:
     if not key or key not in _VALID_SET_KEYS:
         return {
@@ -311,16 +324,7 @@ def build_app() -> FastMCP:
                     "message": "No heavy resources to warm up in v1.",
                 }
             case "status":
-                return {
-                    "version": await asyncio.to_thread(_get_version),
-                    "credentials_state": await asyncio.to_thread(_creds_state),
-                    "providers_configured": await asyncio.to_thread(
-                        _providers_configured_live
-                    ),
-                    "default_provider": settings.default_provider,
-                    "default_tier": settings.default_tier,
-                    "cache_ttl_seconds": settings.cache_ttl_seconds,
-                }
+                return await asyncio.to_thread(_get_system_status_sync)
             case "set":
                 return _set_runtime(key, value)
             case "cache_clear":


### PR DESCRIPTION
💡 What: Replaced three sequential `asyncio.to_thread` dispatches in `src/imagine_mcp/server.py`'s `status` handler with a single synchronous helper `_get_system_status_sync` wrapped in a single `asyncio.to_thread` dispatch.
🎯 Why: The original code awaited three separate threaded calls sequentially to populate a dictionary. Because dictionary values in Python are evaluated sequentially, this incurred the overhead of context-switching and thread-pool scheduling three separate times per status check. Furthermore, `_creds_state()` and `_providers_configured_live()` both perform disk reads against `PerPluginStore`, meaning the file was read twice.
📊 Impact: Reduces thread-pool dispatch overhead per status call from three dispatches to one, and reduces `PerPluginStore` JSON parsing/decryption overhead from two disk reads to one.
🔬 Measurement: Run the test suite (`uv run pytest`) to ensure all `status` handlers continue returning the exact same data structure. Micro-benchmarking the `status` handler latency locally under load will show a measurable reduction in response time.

---
*PR created automatically by Jules for task [1139838826893238700](https://jules.google.com/task/1139838826893238700) started by @n24q02m*