### PR TITLE
fix: 🛡️ Sentinel: prevent environment variable injection in config relay

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -34,3 +34,8 @@ Proposals evaluated and turned down. The reasoning lives here so it carries to t
 
 - **Replacing this file's history with a single entry (#492).** The PR that reported the `reset_credentials` leak also deleted every prior entry in this ledger, leaving only its own. The finding was correct and has been implemented (see the 2026-07-25 entry), but this file is the record of what has already been fixed; clearing it makes past work invisible to the next run and invites re-proposal of things already landed. Append, never rewrite. #489 reported the same issue and appended correctly.
 - **Asserting on the exact error string.** The test proposed alongside #492 asserted `result["error"] == "Internal server error"`, which pins the wording rather than the property. The committed test asserts that the store path and `Errno` do *not* appear in the response, which is what actually matters and survives a reword.
+
+## 2026-08-15 - [CRITICAL] Environment variable injection via config relay
+**Vulnerability:** Untrusted configuration keys received from external sources (e.g., remote relays or local OAuth forms) were applied directly to `os.environ` without validation, allowing arbitrary environment variable injection (e.g., `LD_PRELOAD`).
+**Learning:** Functions that mutate global environment state (`os.environ`) based on external input must strictly allowlist keys. Validating only the presence of expected keys is insufficient if unexpected keys are silently passed through and applied.
+**Prevention:** Always validate configuration keys against a strict, predefined allowlist before setting them in `os.environ`.

--- a/src/imagine_mcp/relay_setup.py
+++ b/src/imagine_mcp/relay_setup.py
@@ -21,6 +21,15 @@ CREDENTIAL_KEYS: list[str] = [
     "GOOGLE_VERTEX_EXPRESS_API_KEY",
 ]
 
+ALLOWED_CONFIG_KEYS = frozenset(
+    [
+        *CREDENTIAL_KEYS,
+        "UNDERSTAND_MODELS",
+        "GENERATE_MODELS",
+        "GENERATE_PROVIDER_PRIORITY",
+    ]
+)
+
 # 5 minutes: user needs time to copy URL, open browser, fill up to 3 keys
 RELAY_TIMEOUT_S = 300.0
 
@@ -47,6 +56,9 @@ def apply_config(config: dict[str, str]) -> None:
     ``credential_state.store_for_sub`` and never touches ``os.environ``.
     """
     for key, value in config.items():
+        if key not in ALLOWED_CONFIG_KEYS:
+            logger.warning("Ignored unallowed config key: {}", key)
+            continue
         if value and os.environ.get(key) != value:
             os.environ[key] = value
             logger.debug("Applied relay config: {}", key)

--- a/tests/test_relay_setup.py
+++ b/tests/test_relay_setup.py
@@ -97,6 +97,14 @@ def test_apply_config_skips_empty_values():
     assert "GEMINI_API_KEY" not in os.environ
 
 
+def test_apply_config_ignores_unallowed_keys():
+    """Verify that injecting an unallowed key is blocked."""
+    apply_config({"LD_PRELOAD": "/malicious/lib.so"})
+    import os
+
+    assert "LD_PRELOAD" not in os.environ
+
+
 # --------------------------------------------------------------------------
 # save_credentials
 # --------------------------------------------------------------------------


### PR DESCRIPTION
🚨 Severity: CRITICAL
💡 Vulnerability: Untrusted configuration values provided via remote relay setup or modified local config files could inject arbitrary environment variables (e.g., `LD_PRELOAD`) due to a missing allowlist when updating `os.environ`.
🎯 Impact: High. An attacker controlling the configuration payload could modify the process environment, potentially leading to arbitrary code execution, authentication bypass, or data exfiltration.
🔧 Fix: Implemented an `ALLOWED_CONFIG_KEYS` strict allowlist in `src/imagine_mcp/relay_setup.py`. Configuration keys from external sources are now validated against this list; unallowed keys generate a warning and are ignored rather than applied to `os.environ`.
✅ Verification: `tests/test_relay_setup.py` has been updated with `test_apply_config_ignores_unallowed_keys` to assert that invalid keys like `LD_PRELOAD` are successfully ignored.

---
*PR created automatically by Jules for task [1880065589745512092](https://jules.google.com/task/1880065589745512092) started by @n24q02m*