### PR TITLE
perf: ⚡ Bolt: consolidate system status sync calls

### DIFF
--- a/src/imagine_mcp/server.py
+++ b/src/imagine_mcp/server.py
@@ -99,6 +99,16 @@ def _providers_configured_live() -> list[str]:
     return out
 
 
+def _get_system_status_sync() -> dict[str, Any]:
+    """Consolidated synchronous helper for system status gathering."""
+    live_providers = _providers_configured_live()
+    return {
+        "version": _get_version(),
+        "credentials_state": "CONFIGURED" if live_providers else "NEEDS_SETUP",
+        "providers_configured": live_providers,
+    }
+
+
 def _set_runtime(key: str | None, value: str | None) -> dict[str, Any]:
     if not key or key not in _VALID_SET_KEYS:
         return {
@@ -311,16 +321,15 @@ def build_app() -> FastMCP:
                     "message": "No heavy resources to warm up in v1.",
                 }
             case "status":
-                return {
-                    "version": await asyncio.to_thread(_get_version),
-                    "credentials_state": await asyncio.to_thread(_creds_state),
-                    "providers_configured": await asyncio.to_thread(
-                        _providers_configured_live
-                    ),
-                    "default_provider": settings.default_provider,
-                    "default_tier": settings.default_tier,
-                    "cache_ttl_seconds": settings.cache_ttl_seconds,
-                }
+                status_dict = await asyncio.to_thread(_get_system_status_sync)
+                status_dict.update(
+                    {
+                        "default_provider": settings.default_provider,
+                        "default_tier": settings.default_tier,
+                        "cache_ttl_seconds": settings.cache_ttl_seconds,
+                    }
+                )
+                return status_dict
             case "set":
                 return _set_runtime(key, value)
             case "cache_clear":


### PR DESCRIPTION
💡 **What**: Added `_get_system_status_sync` helper to `src/imagine_mcp/server.py` to construct the synchronous parts of the system status payload, and updated the `status` handler in the `config` tool to use it via a single `asyncio.to_thread` call instead of three separate sequential calls.
🎯 **Why**: The previous implementation awaited `_get_version`, `_creds_state`, and `_providers_configured_live` individually. Because `_creds_state` itself internally calls `_providers_configured_live`, it also caused redundant `PerPluginStore` file system reads. Consolidating this reduces asyncio thread context-switching latency and eliminates the duplicate I/O read.
📊 **Impact**: Reduces thread-pool dispatch overhead per `status` request from 3 calls to 1, and halves the disk I/O required for evaluating the credential state.
🔬 **Measurement**: Verify by running `uv run pytest tests/test_server.py`. Performance is inherently faster by eliminating network/disk I/O and context-switch boundaries, but correctness is proven by all tests passing identically.

---
*PR created automatically by Jules for task [6024571100998673932](https://jules.google.com/task/6024571100998673932) started by @n24q02m*