### PR TITLE
fix: 🛡️ Sentinel: prevent env var injection via allowlist

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -34,3 +34,8 @@ Proposals evaluated and turned down. The reasoning lives here so it carries to t
 
 - **Replacing this file's history with a single entry (#492).** The PR that reported the `reset_credentials` leak also deleted every prior entry in this ledger, leaving only its own. The finding was correct and has been implemented (see the 2026-07-25 entry), but this file is the record of what has already been fixed; clearing it makes past work invisible to the next run and invites re-proposal of things already landed. Append, never rewrite. #489 reported the same issue and appended correctly.
 - **Asserting on the exact error string.** The test proposed alongside #492 asserted `result["error"] == "Internal server error"`, which pins the wording rather than the property. The committed test asserts that the store path and `Errno` do *not* appear in the response, which is what actually matters and survives a reword.
+
+## 2026-08-10 - [HIGH] Environment variable injection via relay config
+**Vulnerability:** Configuration payloads from the relay setup page were written directly to `os.environ` without validation, allowing injection of arbitrary variables.
+**Learning:** Configuration parsed from untrusted sources (like remote relays or OAuth forms) must be strictly validated against an allowlist before mutating the process environment, otherwise sensitive internals can be overwritten.
+**Prevention:** Use an explicit allowlist (e.g., `ALLOWED_CONFIG_KEYS`) to validate incoming config dictionaries and drop unauthorized keys before modifying `os.environ` or writing to persistent storage.

--- a/src/imagine_mcp/relay_setup.py
+++ b/src/imagine_mcp/relay_setup.py
@@ -21,6 +21,13 @@ CREDENTIAL_KEYS: list[str] = [
     "GOOGLE_VERTEX_EXPRESS_API_KEY",
 ]
 
+ALLOWED_CONFIG_KEYS = [
+    *CREDENTIAL_KEYS,
+    "UNDERSTAND_MODELS",
+    "GENERATE_MODELS",
+    "GENERATE_PROVIDER_PRIORITY",
+]
+
 # 5 minutes: user needs time to copy URL, open browser, fill up to 3 keys
 RELAY_TIMEOUT_S = 300.0
 
@@ -47,6 +54,9 @@ def apply_config(config: dict[str, str]) -> None:
     ``credential_state.store_for_sub`` and never touches ``os.environ``.
     """
     for key, value in config.items():
+        if key not in ALLOWED_CONFIG_KEYS:
+            logger.warning("Ignoring unauthorized config key: {}", key)
+            continue
         if value and os.environ.get(key) != value:
             os.environ[key] = value
             logger.debug("Applied relay config: {}", key)


### PR DESCRIPTION
🚨 **Severity**: HIGH
💡 **Vulnerability**: Configuration payloads from the relay setup page were written directly to `os.environ` without validation, allowing injection of arbitrary variables.
🎯 **Impact**: Potential remote code execution (RCE) or application hijacking via critical environment variables (e.g., `LD_PRELOAD`, `PYTHONPATH`, `PATH`).
🔧 **Fix**: Implemented an explicit `ALLOWED_CONFIG_KEYS` allowlist in `src/imagine_mcp/relay_setup.py` that validates incoming configuration and ignores unauthorized keys before modifying the process environment.
✅ **Verification**: Run `uv run pytest` to ensure configuration logic still operates correctly without regressions.

---
*PR created automatically by Jules for task [16556975647501430889](https://jules.google.com/task/16556975647501430889) started by @n24q02m*