### PR TITLE
fix: 🛡️ Sentinel: prevent environment variable injection in config

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -34,3 +34,8 @@ Proposals evaluated and turned down. The reasoning lives here so it carries to t
 
 - **Replacing this file's history with a single entry (#492).** The PR that reported the `reset_credentials` leak also deleted every prior entry in this ledger, leaving only its own. The finding was correct and has been implemented (see the 2026-07-25 entry), but this file is the record of what has already been fixed; clearing it makes past work invisible to the next run and invites re-proposal of things already landed. Append, never rewrite. #489 reported the same issue and appended correctly.
 - **Asserting on the exact error string.** The test proposed alongside #492 asserted `result["error"] == "Internal server error"`, which pins the wording rather than the property. The committed test asserts that the store path and `Errno` do *not* appear in the response, which is what actually matters and survives a reword.
+
+## 2026-08-11 - [CRITICAL] Prevent environment variable injection in relay config
+**Vulnerability:** The relay configuration processing in `apply_config` took user-submitted payload keys and updated `os.environ` without validating against an allowed set, potentially allowing attackers to overwrite critical environment variables (e.g., path settings or internal API secrets).
+**Learning:** Any endpoint or mechanism that accepts configuration data from external sources and applies it to the environment must strictly filter the incoming keys against an allowlist.
+**Prevention:** Introduce and enforce an `ALLOWED_CONFIG_KEYS` check before applying any key-value pair to `os.environ`.

--- a/src/imagine_mcp/relay_setup.py
+++ b/src/imagine_mcp/relay_setup.py
@@ -21,6 +21,13 @@ CREDENTIAL_KEYS: list[str] = [
     "GOOGLE_VERTEX_EXPRESS_API_KEY",
 ]
 
+ALLOWED_CONFIG_KEYS: set[str] = {
+    *CREDENTIAL_KEYS,
+    "UNDERSTAND_MODELS",
+    "GENERATE_MODELS",
+    "GENERATE_PROVIDER_PRIORITY",
+}
+
 # 5 minutes: user needs time to copy URL, open browser, fill up to 3 keys
 RELAY_TIMEOUT_S = 300.0
 
@@ -47,6 +54,9 @@ def apply_config(config: dict[str, str]) -> None:
     ``credential_state.store_for_sub`` and never touches ``os.environ``.
     """
     for key, value in config.items():
+        if key not in ALLOWED_CONFIG_KEYS:
+            logger.warning("Ignoring unauthorized config key in apply_config: {}", key)
+            continue
         if value and os.environ.get(key) != value:
             os.environ[key] = value
             logger.debug("Applied relay config: {}", key)


### PR DESCRIPTION
🚨 Severity: CRITICAL
💡 Vulnerability: Environment variable injection via untrusted configuration payload mapping directly to os.environ.
🎯 Impact: Attacker could overwrite arbitrary environment variables, potentially escalating privileges, overriding internal endpoints, or leaking sensitive credentials on start up.
🔧 Fix: Added `ALLOWED_CONFIG_KEYS` and filtered all incoming config key-value pairs against it before writing to `os.environ`.
✅ Verification: `uv run pytest tests/test_relay_setup.py` and `uv tool run ruff check .` pass cleanly.

---
*PR created automatically by Jules for task [4582166817095696788](https://jules.google.com/task/4582166817095696788) started by @n24q02m*