### PR TITLE
fix: 🛡️ Sentinel: [CRITICAL] Fix environment variable injection in apply_config

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -34,3 +34,8 @@ Proposals evaluated and turned down. The reasoning lives here so it carries to t
 
 - **Replacing this file's history with a single entry (#492).** The PR that reported the `reset_credentials` leak also deleted every prior entry in this ledger, leaving only its own. The finding was correct and has been implemented (see the 2026-07-25 entry), but this file is the record of what has already been fixed; clearing it makes past work invisible to the next run and invites re-proposal of things already landed. Append, never rewrite. #489 reported the same issue and appended correctly.
 - **Asserting on the exact error string.** The test proposed alongside #492 asserted `result["error"] == "Internal server error"`, which pins the wording rather than the property. The committed test asserts that the store path and `Errno` do *not* appear in the response, which is what actually matters and survives a reword.
+
+## 2026-08-12 - [CRITICAL] Environment Variable Injection in relay_setup.py
+**Vulnerability:** The `apply_config` function iterated over untrusted configuration dictionary values and loaded them directly into `os.environ`, allowing an attacker to inject arbitrary system environment variables such as `PATH`, `PYTHONPATH`, or `LD_PRELOAD`.
+**Learning:** Accepting unbounded keys from remote or user-provided configuration sources and mapping them directly to the process's environment space exposes the application to Remote Code Execution (RCE) and logic bypass vulnerabilities.
+**Prevention:** Always validate configuration keys received from untrusted boundaries against a strict explicit allowlist (e.g., `ALLOWED_CONFIG_KEYS`) before applying them to `os.environ` or other sensitive state maps.

--- a/src/imagine_mcp/relay_setup.py
+++ b/src/imagine_mcp/relay_setup.py
@@ -21,6 +21,13 @@ CREDENTIAL_KEYS: list[str] = [
     "GOOGLE_VERTEX_EXPRESS_API_KEY",
 ]
 
+ALLOWED_CONFIG_KEYS = (
+    *CREDENTIAL_KEYS,
+    "UNDERSTAND_MODELS",
+    "GENERATE_MODELS",
+    "GENERATE_PROVIDER_PRIORITY",
+)
+
 # 5 minutes: user needs time to copy URL, open browser, fill up to 3 keys
 RELAY_TIMEOUT_S = 300.0
 
@@ -47,7 +54,7 @@ def apply_config(config: dict[str, str]) -> None:
     ``credential_state.store_for_sub`` and never touches ``os.environ``.
     """
     for key, value in config.items():
-        if value and os.environ.get(key) != value:
+        if key in ALLOWED_CONFIG_KEYS and value and os.environ.get(key) != value:
             os.environ[key] = value
             logger.debug("Applied relay config: {}", key)
 


### PR DESCRIPTION
🚨 **Severity:** CRITICAL
💡 **Vulnerability:** The `apply_config` function iterated over untrusted configuration dictionary values and loaded them directly into `os.environ`. This allows for an Environment Variable Injection vulnerability where an attacker could inject arbitrary environment variables (e.g., `PATH`, `PYTHONPATH`, `LD_PRELOAD`, `LD_LIBRARY_PATH`) into the process.
🎯 **Impact:** Could lead to Remote Code Execution (RCE) or privilege escalation if an attacker uses the relay form to submit malicious keys.
🔧 **Fix:** Introduced an explicit `ALLOWED_CONFIG_KEYS` allowlist and verify the key is within it prior to assigning it to `os.environ`.
✅ **Verification:** Verified by checking if `apply_config({'PATH': '/hacked'})` altered the real environment. It no longer does. Tests pass successfully.

---
*PR created automatically by Jules for task [15144144079042677330](https://jules.google.com/task/15144144079042677330) started by @n24q02m*