### PR TITLE
perf: ⚡ Bolt: Consolidate status lookups into single thread execution

### DIFF
--- a/src/imagine_mcp/server.py
+++ b/src/imagine_mcp/server.py
@@ -39,6 +39,23 @@ def _get_version() -> str:
     return __version__
 
 
+def _get_system_status_sync(settings: Any) -> dict[str, Any]:
+    """Consolidated synchronous lookups for the status action.
+
+    Avoids redundant disk reads in PerPluginStore and multiple thread pool
+    dispatches by fetching version and live providers in a single pass.
+    """
+    live_providers = _providers_configured_live()
+    return {
+        "version": _get_version(),
+        "credentials_state": "CONFIGURED" if live_providers else "NEEDS_SETUP",
+        "providers_configured": live_providers,
+        "default_provider": settings.default_provider,
+        "default_tier": settings.default_tier,
+        "cache_ttl_seconds": settings.cache_ttl_seconds,
+    }
+
+
 def _creds_state() -> str:
     """Return CONFIGURED if any provider is set (env or store), else NEEDS_SETUP.
 
@@ -311,16 +328,7 @@ def build_app() -> FastMCP:
                     "message": "No heavy resources to warm up in v1.",
                 }
             case "status":
-                return {
-                    "version": await asyncio.to_thread(_get_version),
-                    "credentials_state": await asyncio.to_thread(_creds_state),
-                    "providers_configured": await asyncio.to_thread(
-                        _providers_configured_live
-                    ),
-                    "default_provider": settings.default_provider,
-                    "default_tier": settings.default_tier,
-                    "cache_ttl_seconds": settings.cache_ttl_seconds,
-                }
+                return await asyncio.to_thread(_get_system_status_sync, settings)
             case "set":
                 return _set_runtime(key, value)
             case "cache_clear":


### PR DESCRIPTION
💡 What: Created a consolidated synchronous helper function `_get_system_status_sync(settings)` that performs all synchronous lookups for the `status` configuration action in a single pass.
🎯 Why: The previous implementation made three separate thread pool dispatches (`_get_version`, `_creds_state`, and `_providers_configured_live`) and read the `PerPluginStore` from disk redundantly.
📊 Impact: Reduces thread-pool scheduling overhead and completely eliminates redundant file reads and json parsing per `status` request.
🔬 Measurement: Verified functionality using `pytest` and `vitest` tests. All checks passing, ensuring zero regressions.

---
*PR created automatically by Jules for task [768030085325627763](https://jules.google.com/task/768030085325627763) started by @n24q02m*