### PR TITLE
fix: 🛡️ Sentinel: prevent environment variable injection in config application

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -34,3 +34,7 @@ Proposals evaluated and turned down. The reasoning lives here so it carries to t
 
 - **Replacing this file's history with a single entry (#492).** The PR that reported the `reset_credentials` leak also deleted every prior entry in this ledger, leaving only its own. The finding was correct and has been implemented (see the 2026-07-25 entry), but this file is the record of what has already been fixed; clearing it makes past work invisible to the next run and invites re-proposal of things already landed. Append, never rewrite. #489 reported the same issue and appended correctly.
 - **Asserting on the exact error string.** The test proposed alongside #492 asserted `result["error"] == "Internal server error"`, which pins the wording rather than the property. The committed test asserts that the store path and `Errno` do *not* appear in the response, which is what actually matters and survives a reword.
+## 2024-05-24 - Environment Variable Injection in Relay Setup
+**Vulnerability:** `apply_config` in `src/imagine_mcp/relay_setup.py` indiscriminately loaded keys from untrusted config payloads (e.g., from relay setup or OAuth forms) directly into `os.environ`.
+**Learning:** This exposes the application to environment variable injection (such as setting `LD_PRELOAD` or other dangerous env vars), as the input keys were not strictly validated against an allowlist.
+**Prevention:** Always strictly validate configuration payloads parsed from untrusted sources against an allowlist before applying them to process-level state like `os.environ`.

--- a/src/imagine_mcp/relay_setup.py
+++ b/src/imagine_mcp/relay_setup.py
@@ -21,6 +21,13 @@ CREDENTIAL_KEYS: list[str] = [
     "GOOGLE_VERTEX_EXPRESS_API_KEY",
 ]
 
+ALLOWED_CONFIG_KEYS: set[str] = {
+    *CREDENTIAL_KEYS,
+    "UNDERSTAND_MODELS",
+    "GENERATE_MODELS",
+    "GENERATE_PROVIDER_PRIORITY",
+}
+
 # 5 minutes: user needs time to copy URL, open browser, fill up to 3 keys
 RELAY_TIMEOUT_S = 300.0
 
@@ -47,6 +54,9 @@ def apply_config(config: dict[str, str]) -> None:
     ``credential_state.store_for_sub`` and never touches ``os.environ``.
     """
     for key, value in config.items():
+        if key not in ALLOWED_CONFIG_KEYS:
+            logger.warning("Rejecting invalid config key: {}", key)
+            continue
         if value and os.environ.get(key) != value:
             os.environ[key] = value
             logger.debug("Applied relay config: {}", key)


### PR DESCRIPTION
🚨 Severity: CRITICAL
💡 Vulnerability: `apply_config` indiscriminately loaded keys from untrusted config payloads directly into `os.environ` without validating against an allowlist.
🎯 Impact: This exposed the application to environment variable injection (such as setting `LD_PRELOAD`, `PYTHONPATH`, etc.), which could potentially lead to Remote Code Execution (RCE).
🔧 Fix: Strictly validate configuration payloads against an allowlist (`ALLOWED_CONFIG_KEYS`) before applying them to process-level state.
✅ Verification: Ran `pytest` tests and `ruff` linters to ensure correctness.

---
*PR created automatically by Jules for task [7631487566733298279](https://jules.google.com/task/7631487566733298279) started by @n24q02m*