### PR TITLE
fix: 🛡️ Sentinel: [CRITICAL] fix environment variable injection in apply_config

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -34,3 +34,7 @@ Proposals evaluated and turned down. The reasoning lives here so it carries to t
 
 - **Replacing this file's history with a single entry (#492).** The PR that reported the `reset_credentials` leak also deleted every prior entry in this ledger, leaving only its own. The finding was correct and has been implemented (see the 2026-07-25 entry), but this file is the record of what has already been fixed; clearing it makes past work invisible to the next run and invites re-proposal of things already landed. Append, never rewrite. #489 reported the same issue and appended correctly.
 - **Asserting on the exact error string.** The test proposed alongside #492 asserted `result["error"] == "Internal server error"`, which pins the wording rather than the property. The committed test asserts that the store path and `Errno` do *not* appear in the response, which is what actually matters and survives a reword.
+## 2026-08-15 - Prevent Environment Variable Injection in Configuration
+**Vulnerability:** Untrusted configuration payloads parsed from external sources (e.g., remote relays, OAuth forms) were being directly applied to `os.environ` without validation, allowing arbitrary environment variable injection.
+**Learning:** `apply_config` blindly iterated over configuration dictionaries, assuming only expected keys would be present.
+**Prevention:** Configuration payloads applied to the environment must be strictly validated against an explicit allowlist (e.g., `ALLOWED_CONFIG_KEYS`) prior to modification.

--- a/src/imagine_mcp/relay_setup.py
+++ b/src/imagine_mcp/relay_setup.py
@@ -21,6 +21,13 @@ CREDENTIAL_KEYS: list[str] = [
     "GOOGLE_VERTEX_EXPRESS_API_KEY",
 ]
 
+ALLOWED_CONFIG_KEYS = {
+    *CREDENTIAL_KEYS,
+    "UNDERSTAND_MODELS",
+    "GENERATE_MODELS",
+    "GENERATE_PROVIDER_PRIORITY",
+}
+
 # 5 minutes: user needs time to copy URL, open browser, fill up to 3 keys
 RELAY_TIMEOUT_S = 300.0
 
@@ -47,6 +54,9 @@ def apply_config(config: dict[str, str]) -> None:
     ``credential_state.store_for_sub`` and never touches ``os.environ``.
     """
     for key, value in config.items():
+        if key not in ALLOWED_CONFIG_KEYS:
+            logger.warning("Rejected unallowed config key: {}", key)
+            continue
         if value and os.environ.get(key) != value:
             os.environ[key] = value
             logger.debug("Applied relay config: {}", key)


### PR DESCRIPTION
🚨 Severity: CRITICAL
💡 Vulnerability: `apply_config` in `src/imagine_mcp/relay_setup.py` blindly iterated over configuration dictionaries parsed from external sources (e.g., remote relays, OAuth forms), applying them directly to `os.environ` without validation. This allowed arbitrary environment variable injection.
🎯 Impact: An attacker controlling the remote relay or OAuth response could inject malicious environment variables (e.g., `PYTHONPATH`, `PATH`, or internal API endpoints), potentially leading to Remote Code Execution or privilege escalation.
🔧 Fix: Implemented an explicit allowlist `ALLOWED_CONFIG_KEYS` (comprising `CREDENTIAL_KEYS`, `UNDERSTAND_MODELS`, `GENERATE_MODELS`, and `GENERATE_PROVIDER_PRIORITY`). Now, keys not in this list are rejected with a warning log, ensuring only expected configuration keys can modify the environment. Also appended a critical learning entry to `.jules/sentinel.md`.
✅ Verification: Ran the Python test suite (`uv run pytest`) and worker test suite (`pnpm run test:worker`). Linters and formatters passed.

---
*PR created automatically by Jules for task [6347141703140619310](https://jules.google.com/task/6347141703140619310) started by @n24q02m*