### PR TITLE
fix: ⚡ Bolt: consolidate status sync helper to avoid redundant disk reads

### DIFF
--- a/src/imagine_mcp/server.py
+++ b/src/imagine_mcp/server.py
@@ -99,6 +99,19 @@ def _providers_configured_live() -> list[str]:
     return out
 
 
+def _get_system_status_sync() -> dict[str, Any]:
+    providers = _providers_configured_live()
+    creds_state = "CONFIGURED" if providers else "NEEDS_SETUP"
+    return {
+        "version": _get_version(),
+        "credentials_state": creds_state,
+        "providers_configured": providers,
+        "default_provider": settings.default_provider,
+        "default_tier": settings.default_tier,
+        "cache_ttl_seconds": settings.cache_ttl_seconds,
+    }
+
+
 def _set_runtime(key: str | None, value: str | None) -> dict[str, Any]:
     if not key or key not in _VALID_SET_KEYS:
         return {
@@ -311,16 +324,7 @@ def build_app() -> FastMCP:
                     "message": "No heavy resources to warm up in v1.",
                 }
             case "status":
-                return {
-                    "version": await asyncio.to_thread(_get_version),
-                    "credentials_state": await asyncio.to_thread(_creds_state),
-                    "providers_configured": await asyncio.to_thread(
-                        _providers_configured_live
-                    ),
-                    "default_provider": settings.default_provider,
-                    "default_tier": settings.default_tier,
-                    "cache_ttl_seconds": settings.cache_ttl_seconds,
-                }
+                return await asyncio.to_thread(_get_system_status_sync)
             case "set":
                 return _set_runtime(key, value)
             case "cache_clear":


### PR DESCRIPTION
💡 **What:** Consolidated the `status` command logic into a single synchronous helper (`_get_system_status_sync`) in `src/imagine_mcp/server.py`.
🎯 **Why:** To avoid making multiple sequential `asyncio.to_thread` calls and redundant `PerPluginStore` disk reads when the server status is fetched.
📊 **Impact:** Reduces thread context switching and file I/O operations, improving status request latency.
🔬 **Measurement:** Status checks are inherently faster due to doing 1 disk read instead of 2 and 1 thread dispatch instead of 3. Code review verified no regression in logic and formatting/lint checks passed.

---
*PR created automatically by Jules for task [18040931068962503281](https://jules.google.com/task/18040931068962503281) started by @n24q02m*