### PR TITLE
fix: 🛡️ Sentinel: [CRITICAL] Prevent environment variable injection via config payload

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -34,3 +34,8 @@ Proposals evaluated and turned down. The reasoning lives here so it carries to t
 
 - **Replacing this file's history with a single entry (#492).** The PR that reported the `reset_credentials` leak also deleted every prior entry in this ledger, leaving only its own. The finding was correct and has been implemented (see the 2026-07-25 entry), but this file is the record of what has already been fixed; clearing it makes past work invisible to the next run and invites re-proposal of things already landed. Append, never rewrite. #489 reported the same issue and appended correctly.
 - **Asserting on the exact error string.** The test proposed alongside #492 asserted `result["error"] == "Internal server error"`, which pins the wording rather than the property. The committed test asserts that the store path and `Errno` do *not* appear in the response, which is what actually matters and survives a reword.
+
+## 2026-08-19 - [CRITICAL] Prevent environment variable injection via config payload
+**Vulnerability:** The relay setup process blindly accepted any key-value pairs submitted in the `config` payload and applied them directly to `os.environ` via `apply_config`. This allowed arbitrary environment variable injection during remote relay configuration.
+**Learning:** Any process that synchronizes external, user-controlled configuration payloads into process-level state (`os.environ`) must strictly validate the payload against an explicit allowlist. Trusting that the client only sends expected keys (e.g., `GEMINI_API_KEY`) is a security flaw.
+**Prevention:** Maintain an allowlist (`ALLOWED_CONFIG_KEYS`) of valid configuration keys and validate incoming payloads against it before modifying `os.environ`. Reject any unauthorized keys.

--- a/src/imagine_mcp/relay_setup.py
+++ b/src/imagine_mcp/relay_setup.py
@@ -21,6 +21,13 @@ CREDENTIAL_KEYS: list[str] = [
     "GOOGLE_VERTEX_EXPRESS_API_KEY",
 ]
 
+ALLOWED_CONFIG_KEYS: set[str] = {
+    *CREDENTIAL_KEYS,
+    "UNDERSTAND_MODELS",
+    "GENERATE_MODELS",
+    "GENERATE_PROVIDER_PRIORITY",
+}
+
 # 5 minutes: user needs time to copy URL, open browser, fill up to 3 keys
 RELAY_TIMEOUT_S = 300.0
 
@@ -47,6 +54,9 @@ def apply_config(config: dict[str, str]) -> None:
     ``credential_state.store_for_sub`` and never touches ``os.environ``.
     """
     for key, value in config.items():
+        if key not in ALLOWED_CONFIG_KEYS:
+            logger.warning("Rejecting unauthorized config key: {}", key)
+            continue
         if value and os.environ.get(key) != value:
             os.environ[key] = value
             logger.debug("Applied relay config: {}", key)


### PR DESCRIPTION
🚨 **Severity**: CRITICAL
💡 **Vulnerability**: Environment Variable Injection via untrusted relay configuration payload.
🎯 **Impact**: A malicious actor providing a forged relay setup response could inject arbitrary environment variables directly into the server's process memory by including unexpected keys in the `config` object payload. This could potentially alter execution flows, library loading behaviors, or bypass other server-side restrictions.
🔧 **Fix**: `src/imagine_mcp/relay_setup.py` now enforces an explicit allowlist of valid configuration keys (`ALLOWED_CONFIG_KEYS`) before modifying `os.environ`. Unrecognized keys are securely dropped with a logged warning.
✅ **Verification**: The Python test suite was run (`uv run pytest tests/test_relay_setup.py`) and passes successfully, confirming that the new key enforcement rule breaks no existing valid credential payloads.

---
*PR created automatically by Jules for task [4177734250382154275](https://jules.google.com/task/4177734250382154275) started by @n24q02m*