### PR TITLE
fix: ⚡ Bolt: consolidate status check disk IO

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -58,3 +58,7 @@ Proposals evaluated and turned down. The reasoning lives here so it carries to t
 - **`perf:` as a commit or PR title prefix.** This repo enforces a `fix:`/`feat:` subset, and the "Validate PR title" check fails the PR outright. A performance change is a `fix:`. Five PRs in the cluster above were opened with `perf:` and all five failed that check before review.
 - **Persona markers in source comments.** Comments of the form `# ⚡ Bolt: ... Expected impact: ...` were removed from `credential_state.py`, `dispatcher.py`, `media.py` and `providers/gemini.py`. This is a public repository; a comment should describe the code, not who wrote it or how much it was expected to help. Write the rationale, drop the tag.
 - **A PR that changes nothing.** #482 ("evaluated performance optimizations", empty diff) and #485 (palette persona, empty diff) carried no changes. If a run finds no work, record it here and stop -- do not open an empty PR.
+
+## 2026-07-28 - Consolidate status check disk IO
+**Learning:** The `config` tool's `status` handler issued three separate `asyncio.to_thread()` calls for `_get_version`, `_creds_state`, and `_providers_configured_live`. Because `_creds_state` and `_providers_configured_live` both called `PerPluginStore.load()`, this forced redundant disk reads and JSON decodes per status check.
+**Action:** Consolidate these related checks into a single synchronous helper function (`_get_system_status_sync`) and dispatch it via a single `asyncio.to_thread()` call to eliminate redundant IO and thread-pool scheduling overhead.

--- a/src/imagine_mcp/server.py
+++ b/src/imagine_mcp/server.py
@@ -111,6 +111,16 @@ def _set_runtime(key: str | None, value: str | None) -> dict[str, Any]:
     }
 
 
+def _get_system_status_sync() -> dict[str, Any]:
+    """Gather system status synchronously to avoid redundant disk reads."""
+    configured = _providers_configured_live()
+    return {
+        "version": _get_version(),
+        "credentials_state": "CONFIGURED" if configured else "NEEDS_SETUP",
+        "providers_configured": configured,
+    }
+
+
 @cache
 def _get_help_content(topic: str) -> str:
     """Read markdown documentation file from package resources."""
@@ -311,12 +321,9 @@ def build_app() -> FastMCP:
                     "message": "No heavy resources to warm up in v1.",
                 }
             case "status":
+                sync_status = await asyncio.to_thread(_get_system_status_sync)
                 return {
-                    "version": await asyncio.to_thread(_get_version),
-                    "credentials_state": await asyncio.to_thread(_creds_state),
-                    "providers_configured": await asyncio.to_thread(
-                        _providers_configured_live
-                    ),
+                    **sync_status,
                     "default_provider": settings.default_provider,
                     "default_tier": settings.default_tier,
                     "cache_ttl_seconds": settings.cache_ttl_seconds,


### PR DESCRIPTION
💡 What: Consolidate three separate `asyncio.to_thread` calls in the `config` tool `status` handler (`_get_version`, `_creds_state`, `_providers_configured_live`) into a single synchronous helper function (`_get_system_status_sync`).
🎯 Why: Because `_creds_state` and `_providers_configured_live` both invoke `PerPluginStore.load()` internally (which performs an AES decryption and JSON decode), the previous implementation forced redundant disk I/O and processing per status check, in addition to unnecessary thread-pool scheduling overhead.
📊 Impact: Reduces redundant disk reads/decrypts per `status` request by 50% and reduces thread context switches from 3 to 1.
🔬 Measurement: Run the test suite (`uv run pytest tests/test_server.py`) to verify the `status` handler returns identical output and does not regress.

---
*PR created automatically by Jules for task [1957379736037199710](https://jules.google.com/task/1957379736037199710) started by @n24q02m*