### PR TITLE
fix: 🛡️ Sentinel: [CRITICAL] prevent environment variable injection in relay config

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -34,3 +34,8 @@ Proposals evaluated and turned down. The reasoning lives here so it carries to t
 
 - **Replacing this file's history with a single entry (#492).** The PR that reported the `reset_credentials` leak also deleted every prior entry in this ledger, leaving only its own. The finding was correct and has been implemented (see the 2026-07-25 entry), but this file is the record of what has already been fixed; clearing it makes past work invisible to the next run and invites re-proposal of things already landed. Append, never rewrite. #489 reported the same issue and appended correctly.
 - **Asserting on the exact error string.** The test proposed alongside #492 asserted `result["error"] == "Internal server error"`, which pins the wording rather than the property. The committed test asserts that the store path and `Errno` do *not* appear in the response, which is what actually matters and survives a reword.
+
+## 2026-08-20 - [CRITICAL] Prevent environment variable injection in relay config
+**Vulnerability:** Untrusted config payloads received from remote relays or OAuth forms were directly applied to `os.environ` via `apply_config` in `src/imagine_mcp/relay_setup.py`, permitting arbitrary environment variable injection.
+**Learning:** Parsing arbitrary configuration payloads (e.g. from an external relay) and directly writing all dictionary items into the process environment variables creates a severe injection vulnerability, allowing attackers to overwrite sensitive configuration, LD_PRELOAD, Python execution paths, or manipulate subsequent logic.
+**Prevention:** Configuration payloads parsed from untrusted sources must be strictly validated against an allowlist before being applied to `os.environ` or any other sensitive process state.

--- a/src/imagine_mcp/relay_setup.py
+++ b/src/imagine_mcp/relay_setup.py
@@ -21,6 +21,13 @@ CREDENTIAL_KEYS: list[str] = [
     "GOOGLE_VERTEX_EXPRESS_API_KEY",
 ]
 
+ALLOWED_CONFIG_KEYS = {
+    *CREDENTIAL_KEYS,
+    "UNDERSTAND_MODELS",
+    "GENERATE_MODELS",
+    "GENERATE_PROVIDER_PRIORITY",
+}
+
 # 5 minutes: user needs time to copy URL, open browser, fill up to 3 keys
 RELAY_TIMEOUT_S = 300.0
 
@@ -47,6 +54,9 @@ def apply_config(config: dict[str, str]) -> None:
     ``credential_state.store_for_sub`` and never touches ``os.environ``.
     """
     for key, value in config.items():
+        if key not in ALLOWED_CONFIG_KEYS:
+            logger.warning("Rejected disallowed config key: {}", key)
+            continue
         if value and os.environ.get(key) != value:
             os.environ[key] = value
             logger.debug("Applied relay config: {}", key)

--- a/tests/test_relay_setup.py
+++ b/tests/test_relay_setup.py
@@ -97,6 +97,13 @@ def test_apply_config_skips_empty_values():
     assert "GEMINI_API_KEY" not in os.environ
 
 
+def test_apply_config_rejects_disallowed_keys():
+    apply_config({"MALICIOUS_ENV_VAR": "evil"})
+    import os
+
+    assert "MALICIOUS_ENV_VAR" not in os.environ
+
+
 # --------------------------------------------------------------------------
 # save_credentials
 # --------------------------------------------------------------------------


### PR DESCRIPTION
This PR addresses a critical security vulnerability where untrusted config payloads could inject arbitrary environment variables into the process.

**Severity:** CRITICAL
**Vulnerability:** The `apply_config` function directly applied all key-value pairs from an external dictionary to `os.environ`.
**Impact:** Remote attackers or malicious relays could inject environment variables (like `LD_PRELOAD`, Python paths, etc.) to alter the server's behavior or execute arbitrary code.
**Fix:** Introduced an `ALLOWED_CONFIG_KEYS` allowlist that restricts configuration writes strictly to expected variables (`CREDENTIAL_KEYS`, `UNDERSTAND_MODELS`, `GENERATE_MODELS`, `GENERATE_PROVIDER_PRIORITY`).
**Verification:** Added `test_apply_config_rejects_disallowed_keys` to ensure disallowed keys are discarded. Tests pass successfully.

Also updated `.jules/sentinel.md` with the new learnings.

---
*PR created automatically by Jules for task [10998488270775384356](https://jules.google.com/task/10998488270775384356) started by @n24q02m*