### PR TITLE
fix: 🛡️ Sentinel: prevent environment variable injection via config

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -34,3 +34,8 @@ Proposals evaluated and turned down. The reasoning lives here so it carries to t
 
 - **Replacing this file's history with a single entry (#492).** The PR that reported the `reset_credentials` leak also deleted every prior entry in this ledger, leaving only its own. The finding was correct and has been implemented (see the 2026-07-25 entry), but this file is the record of what has already been fixed; clearing it makes past work invisible to the next run and invites re-proposal of things already landed. Append, never rewrite. #489 reported the same issue and appended correctly.
 - **Asserting on the exact error string.** The test proposed alongside #492 asserted `result["error"] == "Internal server error"`, which pins the wording rather than the property. The committed test asserts that the store path and `Errno` do *not* appear in the response, which is what actually matters and survives a reword.
+
+## 2026-07-29 - [HIGH] Environment variable injection via config
+**Vulnerability:** The `apply_config` function in `src/imagine_mcp/relay_setup.py` iterated over all keys in the provided config payload and set them in `os.environ`. Since this payload comes from an untrusted source (the browser OAuth form or remote relay), an attacker could inject arbitrary environment variables (like `PATH` or Python execution flags) into the server process.
+**Learning:** Functions that map untrusted configuration payloads directly into process-wide state (like `os.environ`) are dangerous and open up the application to injection attacks that can manipulate process behavior.
+**Prevention:** Always validate configuration keys against a strict allowlist (e.g., `ALLOWED_CONFIG_KEYS`) before applying them to process state or critical configurations.

--- a/src/imagine_mcp/relay_setup.py
+++ b/src/imagine_mcp/relay_setup.py
@@ -46,8 +46,15 @@ def apply_config(config: dict[str, str]) -> None:
     single-user path only -- multi-user mode scopes config per-sub via
     ``credential_state.store_for_sub`` and never touches ``os.environ``.
     """
+    allowed_keys = {
+        *CREDENTIAL_KEYS,
+        "UNDERSTAND_MODELS",
+        "GENERATE_MODELS",
+        "GENERATE_PROVIDER_PRIORITY",
+    }
+
     for key, value in config.items():
-        if value and os.environ.get(key) != value:
+        if key in allowed_keys and value and os.environ.get(key) != value:
             os.environ[key] = value
             logger.debug("Applied relay config: {}", key)
 

--- a/tests/test_relay_setup.py
+++ b/tests/test_relay_setup.py
@@ -97,6 +97,18 @@ def test_apply_config_skips_empty_values():
     assert "GEMINI_API_KEY" not in os.environ
 
 
+def test_apply_config_ignores_unallowed_keys():
+    """Ensure arbitrary environment variables cannot be injected."""
+    apply_config(
+        {"PATH": "/evil/path", "UNKNOWN_KEY": "value", "GEMINI_API_KEY": "valid"}
+    )
+    import os
+
+    assert os.environ.get("PATH") != "/evil/path"
+    assert "UNKNOWN_KEY" not in os.environ
+    assert os.environ.get("GEMINI_API_KEY") == "valid"
+
+
 # --------------------------------------------------------------------------
 # save_credentials
 # --------------------------------------------------------------------------


### PR DESCRIPTION
Added an allowlist in apply_config to prevent arbitrary environment variable injection from untrusted relay payloads.

---
*PR created automatically by Jules for task [7172163124704368177](https://jules.google.com/task/7172163124704368177) started by @n24q02m*