### PR TITLE
fix: restrict relay environment configuration

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -49,7 +49,7 @@ repos:
     hooks:
       - id: pytest
         name: pytest (Python)
-        entry: uv run pytest --tb=short -q --timeout=30 -m "not live"
+        entry: uv run pytest --tb=short -q --timeout=120 -m "not live"
         language: system
         types: [python]
         pass_filenames: false

--- a/src/imagine_mcp/relay_setup.py
+++ b/src/imagine_mcp/relay_setup.py
@@ -21,6 +21,13 @@ CREDENTIAL_KEYS: list[str] = [
     "GOOGLE_VERTEX_EXPRESS_API_KEY",
 ]
 
+ALLOWED_CONFIG_KEYS: list[str] = [
+    *CREDENTIAL_KEYS,
+    "UNDERSTAND_MODELS",
+    "GENERATE_MODELS",
+    "GENERATE_PROVIDER_PRIORITY",
+]
+
 # 5 minutes: user needs time to copy URL, open browser, fill up to 3 keys
 RELAY_TIMEOUT_S = 300.0
 
@@ -47,6 +54,9 @@ def apply_config(config: dict[str, str]) -> None:
     ``credential_state.store_for_sub`` and never touches ``os.environ``.
     """
     for key, value in config.items():
+        if key not in ALLOWED_CONFIG_KEYS:
+            logger.warning("Rejected disallowed relay config key: {}", key)
+            continue
         if value and os.environ.get(key) != value:
             os.environ[key] = value
             logger.debug("Applied relay config: {}", key)

--- a/tests/test_relay_setup.py
+++ b/tests/test_relay_setup.py
@@ -97,6 +97,26 @@ def test_apply_config_skips_empty_values():
     assert "GEMINI_API_KEY" not in os.environ
 
 
+def test_apply_config_ignores_untrusted_environment_keys(monkeypatch):
+    import os
+
+    original_path = os.environ.get("PATH", "")
+    monkeypatch.setenv("PATH", original_path)
+    monkeypatch.delenv("UNKNOWN_KEY", raising=False)
+
+    apply_config(
+        {
+            "PATH": "/evil/path",
+            "UNKNOWN_KEY": "value",
+            "GEMINI_API_KEY": "valid",
+        }
+    )
+
+    assert os.environ["PATH"] == original_path
+    assert "UNKNOWN_KEY" not in os.environ
+    assert os.environ["GEMINI_API_KEY"] == "valid"
+
+
 # --------------------------------------------------------------------------
 # save_credentials
 # --------------------------------------------------------------------------


### PR DESCRIPTION
Security fix split from the automated bot PRs. Applies a strict allowlist before relay payload keys reach os.environ, adds a regression test for PATH/unknown keys, and raises the local Python pre-commit timeout to 120s because the existing Windows 3.13 suite exceeds 30s during litellm import. Full non-live suite: 314 passed, 4 deselected, 1 warning.