### PR TITLE
fix: reject malformed KV paths

### DIFF
--- a/src/worker.ts
+++ b/src/worker.ts
@@ -72,7 +72,15 @@ function pickContainerEnv(env: Env): Record<string, string> {
 
 const kvOutbound: OutboundHandler<Env> = async (request, env) => {
   const url = new URL(request.url)
-  const key = decodeURIComponent(url.pathname.replace(/^\//, ''))
+  let key: string
+  try {
+    key = decodeURIComponent(url.pathname.replace(/^\//, ''))
+  } catch (error) {
+    if (error instanceof URIError) {
+      return new Response('Bad Request', { status: 400 })
+    }
+    throw error
+  }
   // Readiness probe (E.1): once this handler answers, outbound interception is
   // wired, so the container's first credential PUT is safe. Reserved key,
   // checked before the normal key lookup so it never shadows a real KV key.

--- a/tests/worker.test.ts
+++ b/tests/worker.test.ts
@@ -61,6 +61,13 @@ describe('outbound handlers', () => {
     const res = await kvH(new Request('http://kv.internal/imagine%2Fsubs%2Fu1%2Fconfig'), env as never)
     expect(res.status).toBe(404)
   })
+
+  it('returns 400 for malformed percent-encoded KV paths', async () => {
+    const env = fakeEnv()
+    const res = await kvH(new Request('http://kv.internal/%E0%A4%A'), env as never)
+    expect(res.status).toBe(400)
+    expect(await res.text()).toBe('Bad Request')
+  })
 })
 
 describe('public fetch entrypoint does NOT expose outbound handlers (security)', () => {


### PR DESCRIPTION
## Summary
- catch malformed percent-encoded KV paths before routing
- return `400 Bad Request` instead of propagating `URIError`
- add a regression test covering the malformed path

## Verification
- targeted malformed-path test: 1 passed
- `tests/worker.test.ts`: 20 passed
- source-only TypeScript check: passed
- targeted pre-commit hooks: all passed

This is a clean source/test replacement for bot PR #504. It intentionally excludes `.jules/sentinel.md` control-plane edits.