### PR TITLE
fix: prevent environment variable injection in apply_config

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -34,3 +34,7 @@ Proposals evaluated and turned down. The reasoning lives here so it carries to t
 
 - **Replacing this file's history with a single entry (#492).** The PR that reported the `reset_credentials` leak also deleted every prior entry in this ledger, leaving only its own. The finding was correct and has been implemented (see the 2026-07-25 entry), but this file is the record of what has already been fixed; clearing it makes past work invisible to the next run and invites re-proposal of things already landed. Append, never rewrite. #489 reported the same issue and appended correctly.
 - **Asserting on the exact error string.** The test proposed alongside #492 asserted `result["error"] == "Internal server error"`, which pins the wording rather than the property. The committed test asserts that the store path and `Errno` do *not* appear in the response, which is what actually matters and survives a reword.
+## 2025-02-23 - Prevent environment variable injection
+**Vulnerability:** `apply_config` applied any key from the config dictionary to `os.environ`, allowing an attacker to inject arbitrary environment variables.
+**Learning:** The configuration comes from remote relays or OAuth forms which could be controlled or tampered by attackers.
+**Prevention:** Strictly validate incoming configuration keys against an allowlist before applying them to `os.environ`.

--- a/src/imagine_mcp/relay_setup.py
+++ b/src/imagine_mcp/relay_setup.py
@@ -21,6 +21,13 @@ CREDENTIAL_KEYS: list[str] = [
     "GOOGLE_VERTEX_EXPRESS_API_KEY",
 ]
 
+ALLOWED_CONFIG_KEYS: list[str] = [
+    *CREDENTIAL_KEYS,
+    "UNDERSTAND_MODELS",
+    "GENERATE_MODELS",
+    "GENERATE_PROVIDER_PRIORITY",
+]
+
 # 5 minutes: user needs time to copy URL, open browser, fill up to 3 keys
 RELAY_TIMEOUT_S = 300.0
 
@@ -47,7 +54,7 @@ def apply_config(config: dict[str, str]) -> None:
     ``credential_state.store_for_sub`` and never touches ``os.environ``.
     """
     for key, value in config.items():
-        if value and os.environ.get(key) != value:
+        if key in ALLOWED_CONFIG_KEYS and value and os.environ.get(key) != value:
             os.environ[key] = value
             logger.debug("Applied relay config: {}", key)
 


### PR DESCRIPTION
- Defines `ALLOWED_CONFIG_KEYS` in `relay_setup.py` that includes `CREDENTIAL_KEYS` and additional configuration keys (`UNDERSTAND_MODELS`, `GENERATE_MODELS`, `GENERATE_PROVIDER_PRIORITY`).
- Modifies `apply_config` to strictly validate incoming config keys against the `ALLOWED_CONFIG_KEYS` allowlist before writing them to `os.environ`.
- Fixes a critical security vulnerability where untrusted configuration payloads (e.g., from remote relays or OAuth forms) could inject arbitrary environment variables.
- Updates `.jules/sentinel.md` with the finding.

---
*PR created automatically by Jules for task [16099063409896799811](https://jules.google.com/task/16099063409896799811) started by @n24q02m*