### PR TITLE
feat: dehost managed Cloudflare runtime

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -353,7 +353,7 @@ jobs:
     # this job (exit 1, no silent bad deploy). Live-image prev_ref for true CI
     # rollback is a tracked follow-up.
     needs: [release]
-    if: needs.release.outputs.released == 'true'
+    if: needs.release.outputs.released == 'true' && vars.CF_HOSTED_ENABLED != 'false'
     runs-on: ubuntu-latest
     steps:
       - name: Harden Runner

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -180,16 +180,18 @@ Multi-user remote mode (deployment property; not a separate config) requires `MC
 
 References: `mcp-core/scripts/e2e/matrix.yaml`, `~/.claude/skills/mcp-dev/references/e2e-full-matrix.md` (harness-readiness gate), `~/.claude/skills/mcp-dev/references/secrets-skret.md` (per-server credential layout), `~/.claude/skills/mcp-dev/references/multi-user-pattern.md` (per-JWT-sub isolation).
 
-## Cloudflare serverless mode
+## Cloudflare self-host template
 
-imagine-mcp runs serverless on Cloudflare (Worker + Container + KV-only). The
-only externalised state is the per-sub credential vault (KV); generation is
-returned base64-only because the container FS is ephemeral.
+The n24q02m Cloudflare Worker/Container host is dehosted. The template remains for operator-owned self-hosting and rollback; `CF_HOSTED_ENABLED=false` prevents repository CD from recreating the personal host.
+
+When an operator self-hosts on Cloudflare, the topology is Worker + Container +
+KV-only. The only externalized state is the per-sub credential vault; generation
+is base64-only because the Container filesystem is ephemeral.
 
 | env var | value | purpose |
 |---|---|---|
 | `MCP_TRANSPORT` | `http` | container detection + multi-user mode |
-| `PUBLIC_URL` | `https://imagine.n24q02m.com` | public bind + per-JWT-sub isolation |
+| `PUBLIC_URL` | `<operator-public-url>` | public bind + per-JWT-sub isolation |
 | `MCP_STORAGE_BACKEND` | `cf-kv` | route PerPluginStore through KV |
 | `MCP_KV_BASE_URL` | `http://kv.internal` | Worker outbound-handler virtual host |
 | `IMAGINE_OUTPUT_MODE` | `base64` | force base64 output (no local media path) |
@@ -204,8 +206,7 @@ ResponseCache (`cache.py`, diskcache) is NOT on the hot path -- `understand` /
 `generate` never read/write it; it is only touched by `config(action="cache_clear")`,
 which is a harmless no-op on the ephemeral FS. No KV migration needed.
 
-`src/worker.ts` + `wrangler.jsonc` are copied from the frozen CF template
-(`wet-mcp/docs/cf-template.md`), KV-only (no D1/Vectorize): `ImagineContainer` DO
-+ `IMAGINE` binding, the `kv.internal` outbound handler off the public `fetch`
-(security), and the 5 footguns. Live OAuth self-test: `scripts/cf_full_flow.py`.
-
+`src/worker.ts` + `wrangler.jsonc` retain the CF self-host template derived from
+`wet-mcp/docs/cf-template.md`: KV-only (no D1/Vectorize), `ImagineContainer` DO
++ `IMAGINE` binding, and the `kv.internal` outbound handler outside the public
+`fetch` path. Operators validate their own deployment with `scripts/cf_full_flow.py`.

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -38,6 +38,9 @@ export interface Env {
   OPENAI_API_KEY?: string
   XAI_API_KEY?: string
   UNDERSTAND_MODELS?: string
+  // Dehost / tombstone drill flag (W4)
+  DEHOSTED?: string
+  TOMBSTONE?: string
 }
 
 // Keys forwarded from the Worker env (wrangler vars + secrets) into the container
@@ -120,8 +123,30 @@ function unauthenticated(request: Request): Response {
   })
 }
 
+function tombstoneResponse(): Response {
+  return new Response(
+    JSON.stringify({
+      error: 'hosted_runtime_dehosted',
+      status: 410,
+      message:
+        'The hosted Cloudflare endpoint for imagine-mcp has been retired. The package remains active via local stdio (uvx imagine-mcp / docker run -i n24q02m/imagine-mcp) and self-hosted HTTP. See https://mcp.n24q02m.com/servers/imagine-mcp/ for instructions.',
+      successor: 'https://mcp.n24q02m.com/servers/imagine-mcp/',
+    }),
+    {
+      status: 410,
+      headers: {
+        'Content-Type': 'application/json',
+        'X-Dehosted-Successor': 'https://mcp.n24q02m.com/servers/imagine-mcp/',
+      },
+    }
+  )
+}
+
 export default {
   async fetch(request: Request, env: Env): Promise<Response> {
+    if (env.DEHOSTED === 'true' || env.TOMBSTONE === 'true') {
+      return tombstoneResponse()
+    }
     // Edge auth gate. mcp-core's OAuth AS runs INSIDE the container, so before
     // this gate every anonymous /mcp request started the container and reset
     // its 5m idle timer -- an unauthenticated caller could pin it awake and

--- a/tests/test_deploy_cf_template.py
+++ b/tests/test_deploy_cf_template.py
@@ -68,4 +68,5 @@ def test_committed_template_renders_to_valid_json(monkeypatch):
         cfg["containers"][0]["image"] == "registry.cloudflare.com/acct/imagine-mcp:v1"
     )
     assert cfg["kv_namespaces"][0]["id"] == "kvid"
+    assert cfg["vars"]["DEHOSTED"] == "true"
     assert cfg["vars"]["PUBLIC_URL"] == "https://imagine.n24q02m.com"

--- a/tests/worker.test.ts
+++ b/tests/worker.test.ts
@@ -261,3 +261,67 @@ describe('edge gate declines the standing GET /mcp SSE stream (405)', () => {
     expect(calls()).toBe(0)
   })
 })
+
+describe('tombstone contract (W4 dehost preparation & drill)', () => {
+  function envWithDoSpy(flags: Record<string, string> = {}) {
+    let stubCalls = 0
+    return {
+      calls: () => stubCalls,
+      env: {
+        IMAGINE: {
+          idFromName: (n: string) => ({ name: n }),
+          get: (_id: unknown) => ({
+            fetch: async () => {
+              stubCalls++
+              return new Response('routed', { status: 200 })
+            },
+          }),
+        },
+        ...flags,
+      },
+    }
+  }
+
+  it('returns 410 Gone with non-sensitive successor message and headers before edge auth when DEHOSTED is true', async () => {
+    const { calls, env } = envWithDoSpy({ DEHOSTED: 'true' })
+    const res = await worker.fetch(
+      new Request('https://imagine.n24q02m.com/mcp', {
+        method: 'POST',
+      }),
+      env as never
+    )
+
+    expect(res.status).toBe(410)
+    expect(res.headers.get('Content-Type')).toBe('application/json')
+    expect(res.headers.get('X-Dehosted-Successor')).toBe('https://mcp.n24q02m.com/servers/imagine-mcp/')
+
+    const body = (await res.json()) as Record<string, unknown>
+    expect(body).toMatchObject({
+      error: 'hosted_runtime_dehosted',
+      status: 410,
+      successor: 'https://mcp.n24q02m.com/servers/imagine-mcp/',
+    })
+    expect(body.message).toContain('retired')
+    expect(body.message).toContain('stdio')
+
+    // CRITICAL: 0 requests reach the Container DO
+    expect(calls()).toBe(0)
+  })
+
+  it('returns 410 Gone on all routes before auth/DO for DEHOSTED and the existing TOMBSTONE drill alias', async () => {
+    for (const flag of ['DEHOSTED', 'TOMBSTONE'] as const) {
+      const { calls, env } = envWithDoSpy({ [flag]: 'true' })
+
+      for (const path of ['/authorize', '/health', '/.well-known/jwks.json', '/mcp/v1']) {
+        const res = await worker.fetch(
+          new Request(`https://imagine.n24q02m.com${path}`, { method: 'GET' }),
+          env as never
+        )
+        expect(res.status).toBe(410)
+        expect(res.headers.get('X-Dehosted-Successor')).toBe('https://mcp.n24q02m.com/servers/imagine-mcp/')
+      }
+
+      expect(calls()).toBe(0)
+    }
+  })
+})

--- a/wrangler.deploy.template.jsonc
+++ b/wrangler.deploy.template.jsonc
@@ -26,6 +26,7 @@
   "migrations": [{ "tag": "v1", "new_sqlite_classes": ["ImagineContainer"] }],
   "kv_namespaces": [{ "binding": "KV", "id": "${CF_KV_ID}" }],
   "vars": {
+    "DEHOSTED": "true",
     "PUBLIC_URL": "${PUBLIC_URL}",
     "MCP_STORAGE_BACKEND": "cf-kv",
     "MCP_KV_BASE_URL": "http://kv.internal",


### PR DESCRIPTION
## Summary
- gate future Cloudflare host deployment with `CF_HOSTED_ENABLED=false`
- keep a deterministic HTTP 410 sentinel if an operator explicitly re-enables the template
- document the retained Cloudflare template as operator-owned self-host support
- keep PyPI, OCI, CI, security, release, local stdio, and repository maintenance active

## Live dehost state
- `imagine-mcp-worker` Worker script and Container application were deleted on 2026-08-24
- `imagine.n24q02m.com` no longer resolves and cannot start an MCP/OAuth session
- repository variable `CF_HOSTED_ENABLED=false` is set
- KV namespace, rollback image `1.10.1`, skret secrets, encrypted backup, and isolated restore proof are retained

## Verification
- Worker Vitest suite: 21 passed
- deployment-template pytest suite: 3 passed in the original change
- repository pre-commit hooks passed
- repository remains public, active, and unarchived

Normal protected-branch review remains required; do not bypass it.