### PR TITLE
fix: prevent environment variable injection in relay config

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -34,3 +34,8 @@ Proposals evaluated and turned down. The reasoning lives here so it carries to t
 
 - **Replacing this file's history with a single entry (#492).** The PR that reported the `reset_credentials` leak also deleted every prior entry in this ledger, leaving only its own. The finding was correct and has been implemented (see the 2026-07-25 entry), but this file is the record of what has already been fixed; clearing it makes past work invisible to the next run and invites re-proposal of things already landed. Append, never rewrite. #489 reported the same issue and appended correctly.
 - **Asserting on the exact error string.** The test proposed alongside #492 asserted `result["error"] == "Internal server error"`, which pins the wording rather than the property. The committed test asserts that the store path and `Errno` do *not* appear in the response, which is what actually matters and survives a reword.
+
+## 2024-05-18 - Prevent Environment Variable Injection
+**Vulnerability:** Unrestricted environment variable injection in relay config (`apply_config`). Remote config dicts could arbitrarily overwrite any `os.environ` variable (e.g., `PATH`, `PYTHONPATH`) if passed via the relay OAuth form.
+**Learning:** `os.environ.update` or equivalent loop assignments without an allowlist are dangerous when processing unvalidated external configuration payloads, as it provides an escalation vector for arbitrary code execution or environment tampering.
+**Prevention:** Strictly validate external configuration keys against an explicit allowlist before applying them to system environment variables. Added `ALLOWED_CONFIG_KEYS` check in `apply_config`.

--- a/src/imagine_mcp/relay_setup.py
+++ b/src/imagine_mcp/relay_setup.py
@@ -21,6 +21,13 @@ CREDENTIAL_KEYS: list[str] = [
     "GOOGLE_VERTEX_EXPRESS_API_KEY",
 ]
 
+ALLOWED_CONFIG_KEYS = [
+    *CREDENTIAL_KEYS,
+    "UNDERSTAND_MODELS",
+    "GENERATE_MODELS",
+    "GENERATE_PROVIDER_PRIORITY",
+]
+
 # 5 minutes: user needs time to copy URL, open browser, fill up to 3 keys
 RELAY_TIMEOUT_S = 300.0
 
@@ -47,6 +54,8 @@ def apply_config(config: dict[str, str]) -> None:
     ``credential_state.store_for_sub`` and never touches ``os.environ``.
     """
     for key, value in config.items():
+        if key not in ALLOWED_CONFIG_KEYS:
+            continue
         if value and os.environ.get(key) != value:
             os.environ[key] = value
             logger.debug("Applied relay config: {}", key)

--- a/tests/test_relay_setup.py
+++ b/tests/test_relay_setup.py
@@ -97,6 +97,13 @@ def test_apply_config_skips_empty_values():
     assert "GEMINI_API_KEY" not in os.environ
 
 
+def test_apply_config_skips_unallowed_keys():
+    apply_config({"EVIL_HACK_KEY": "hacked"})
+    import os
+
+    assert "EVIL_HACK_KEY" not in os.environ
+
+
 # --------------------------------------------------------------------------
 # save_credentials
 # --------------------------------------------------------------------------


### PR DESCRIPTION
### 🚨 Severity: CRITICAL
### 💡 Vulnerability: Unrestricted environment variable injection in relay config (`apply_config`). Remote config dicts could arbitrarily overwrite any `os.environ` variable (e.g., `PATH`, `PYTHONPATH`) if passed via the relay OAuth form.
### 🎯 Impact: An attacker could potentially inject malicious environment variables, providing an escalation vector for arbitrary code execution or environment tampering.
### 🔧 Fix: Added an explicit `ALLOWED_CONFIG_KEYS` list and enforced it within `apply_config`, silently ignoring any unallowed keys. Added a corresponding test using `EVIL_HACK_KEY` to ensure unallowed keys are dropped.
### ✅ Verification: Run `uv run pytest tests/test_relay_setup.py` and verify `test_apply_config_skips_unallowed_keys` passes.

---
*PR created automatically by Jules for task [1800114565422020481](https://jules.google.com/task/1800114565422020481) started by @n24q02m*