### PR TITLE
⚡ Bolt: Consolidate synchronous temporary file unlinking in Gemini provider

### DIFF
--- a/src/imagine_mcp/providers/gemini.py
+++ b/src/imagine_mcp/providers/gemini.py
@@ -163,7 +163,6 @@ async def understand_multimodal(
         )
     finally:
         if tmp_files:
-
             # ⚡ Bolt: Consolidate synchronous file unlinking into a single thread dispatch.
             # Expected impact: Eliminates thread-pool scheduling and context-switching overhead per file.
             def _cleanup_sync() -> None:

--- a/src/imagine_mcp/providers/gemini.py
+++ b/src/imagine_mcp/providers/gemini.py
@@ -162,8 +162,15 @@ async def understand_multimodal(
             config=types.GenerateContentConfig(max_output_tokens=max_tokens),
         )
     finally:
-        for f in tmp_files:
-            await asyncio.to_thread(f.unlink, missing_ok=True)
+        if tmp_files:
+
+            # ⚡ Bolt: Consolidate synchronous file unlinking into a single thread dispatch.
+            # Expected impact: Eliminates thread-pool scheduling and context-switching overhead per file.
+            def _cleanup_sync() -> None:
+                for f in tmp_files:
+                    f.unlink(missing_ok=True)
+
+            await asyncio.to_thread(_cleanup_sync)
 
     return {
         "text": resp.text,


### PR DESCRIPTION
💡 What: The optimization consolidated the sequential synchronous file unlinking (`unlink`) into a single helper function and executed it via a single `asyncio.to_thread()` call, and added a check to avoid spawning a thread if the `tmp_files` list is empty.

🎯 Why: To solve the performance problem of introducing unnecessary thread-pool scheduling and context-switching overhead per file inside an async loop.

📊 Impact: Reduces thread-pool dispatches from O(N) to O(1) for temporary file cleanups, eliminating latency.

🔬 Measurement: Verify the change by checking if `asyncio.to_thread` is now called only once in the `finally:` block of `understand_multimodal` in `src/imagine_mcp/providers/gemini.py`.

---
*PR created automatically by Jules for task [9435265943571632520](https://jules.google.com/task/9435265943571632520) started by @n24q02m*