### PR TITLE
fix: prevent environment variable injection in relay config

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -34,3 +34,8 @@ Proposals evaluated and turned down. The reasoning lives here so it carries to t
 
 - **Replacing this file's history with a single entry (#492).** The PR that reported the `reset_credentials` leak also deleted every prior entry in this ledger, leaving only its own. The finding was correct and has been implemented (see the 2026-07-25 entry), but this file is the record of what has already been fixed; clearing it makes past work invisible to the next run and invites re-proposal of things already landed. Append, never rewrite. #489 reported the same issue and appended correctly.
 - **Asserting on the exact error string.** The test proposed alongside #492 asserted `result["error"] == "Internal server error"`, which pins the wording rather than the property. The committed test asserts that the store path and `Errno` do *not* appear in the response, which is what actually matters and survives a reword.
+
+## 2026-08-28 - [CRITICAL] Environment variable injection in apply_config
+**Vulnerability:** The `apply_config` function in `src/imagine_mcp/relay_setup.py` iterated over all keys in the user-provided config dictionary and set them in `os.environ` without any allowlist or validation. This allowed an attacker to overwrite arbitrary environment variables.
+**Learning:** Configuration syncing processes that apply settings directly to `os.environ` must strictly validate all input keys against a predefined allowlist to prevent arbitrary environment variable injection.
+**Prevention:** Implement an `ALLOWED_CONFIG_KEYS` list and ensure that any key being applied to `os.environ` is explicitly present in this list before making the assignment. Log a warning for any rejected keys.

--- a/src/imagine_mcp/relay_setup.py
+++ b/src/imagine_mcp/relay_setup.py
@@ -21,6 +21,13 @@ CREDENTIAL_KEYS: list[str] = [
     "GOOGLE_VERTEX_EXPRESS_API_KEY",
 ]
 
+ALLOWED_CONFIG_KEYS: list[str] = [
+    *CREDENTIAL_KEYS,
+    "UNDERSTAND_MODELS",
+    "GENERATE_MODELS",
+    "GENERATE_PROVIDER_PRIORITY",
+]
+
 # 5 minutes: user needs time to copy URL, open browser, fill up to 3 keys
 RELAY_TIMEOUT_S = 300.0
 
@@ -47,6 +54,9 @@ def apply_config(config: dict[str, str]) -> None:
     ``credential_state.store_for_sub`` and never touches ``os.environ``.
     """
     for key, value in config.items():
+        if key not in ALLOWED_CONFIG_KEYS:
+            logger.warning("Rejected unexpected config key: {}", key)
+            continue
         if value and os.environ.get(key) != value:
             os.environ[key] = value
             logger.debug("Applied relay config: {}", key)

--- a/tests/test_relay_setup.py
+++ b/tests/test_relay_setup.py
@@ -97,6 +97,15 @@ def test_apply_config_skips_empty_values():
     assert "GEMINI_API_KEY" not in os.environ
 
 
+def test_apply_config_blocks_unauthorized_keys():
+    """Environment variable injection prevention: unauthorized keys must be dropped."""
+    apply_config({"EVIL_HACK_KEY": "pwned", "GEMINI_API_KEY": "valid"})
+    import os
+
+    assert "EVIL_HACK_KEY" not in os.environ
+    assert os.environ["GEMINI_API_KEY"] == "valid"
+
+
 # --------------------------------------------------------------------------
 # save_credentials
 # --------------------------------------------------------------------------


### PR DESCRIPTION
**Vulnerability:** The `apply_config` function iterated over all keys in the user-provided config dictionary and set them in `os.environ` without validation, allowing for potential environment variable injection.
**Impact:** A malicious configuration payload could overwrite critical environment variables, potentially affecting server logic or internal operations.
**Fix:** Introduced an `ALLOWED_CONFIG_KEYS` allowlist. Unlisted keys are ignored and logged as warnings.
**Verification:** Added unit test `test_apply_config_blocks_unauthorized_keys` to ensure unlisted keys (like synthetic test keys) are safely rejected. Verified via full test suites.

---
*PR created automatically by Jules for task [8485540937283726861](https://jules.google.com/task/8485540937283726861) started by @n24q02m*