### PR TITLE
fix(deps): bump mcp-core to 1.23.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,16 +40,16 @@ dependencies = [
     "mcp[cli]>=1.29.0",
     "fastmcp>=3.4.7",
     "pydantic>=2.13.4,<2.14",
-    "pydantic-settings>=2.15.0",
+    "pydantic-settings>=2.14.2,<2.15",
     "httpx>=0.28.1,<1",
     "google-genai>=2.20.0",
     "openai>=2.54.0",
     "pillow>=12.3.0",
     "diskcache>=5.6.3",
     "loguru>=0.7.3",
-    # Keep the floor on a stable release; 1.23.0 is the current baseline
+    # Keep the floor on a stable release; 1.23.1 is the current baseline
     # for this repository's HTTP OAuth integration.
-    "n24q02m-mcp-core[llm]>=1.23.0,<2",
+    "n24q02m-mcp-core[llm]>=1.23.1,<2",
     "platformdirs>=4.11.3",
     # Security floors: transitive deps pinned to patched releases.
     # urllib3 < 2.7.0 -> PYSEC-2026-141/142; idna < 3.15 -> CVE-2026-45409.

--- a/uv.lock
+++ b/uv.lock
@@ -771,12 +771,12 @@ requires-dist = [
     { name = "idna", specifier = ">=3.19" },
     { name = "loguru", specifier = ">=0.7.3" },
     { name = "mcp", extras = ["cli"], specifier = ">=1.29.0" },
-    { name = "n24q02m-mcp-core", extras = ["llm"], specifier = ">=1.23.0,<2" },
+    { name = "n24q02m-mcp-core", extras = ["llm"], specifier = ">=1.23.1,<2" },
     { name = "openai", specifier = ">=2.54.0" },
     { name = "pillow", specifier = ">=12.3.0" },
     { name = "platformdirs", specifier = ">=4.11.3" },
     { name = "pydantic", specifier = ">=2.13.4,<2.14" },
-    { name = "pydantic-settings", specifier = ">=2.15.0" },
+    { name = "pydantic-settings", specifier = ">=2.14.2,<2.15" },
     { name = "urllib3", specifier = ">=2.7.0" },
 ]
 
@@ -1163,7 +1163,7 @@ wheels = [
 
 [[package]]
 name = "n24q02m-mcp-core"
-version = "1.23.0"
+version = "1.23.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "authlib" },
@@ -1175,12 +1175,13 @@ dependencies = [
     { name = "loguru" },
     { name = "platformdirs" },
     { name = "pydantic" },
+    { name = "pydantic-settings" },
     { name = "starlette" },
     { name = "tomli-w" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/86/14/31d9b330fd59e891f73ad0b06e38a15f620325ef46b5cab5b6e3fd64fd83/n24q02m_mcp_core-1.23.0.tar.gz", hash = "sha256:cf6010adc23d433634d901ce550fd26f8c8fb754097a5a6e9d920ef3d48ac936", size = 358930, upload-time = "2026-08-07T22:48:12.82Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/d6/ea/060df6d5c00c13a7e5ffe7bf04536bcbbc5577d68180d0533be3b8096f27/n24q02m_mcp_core-1.23.1.tar.gz", hash = "sha256:4408b14f73c16163048988e8b429fd73a02ffe83a4b4b8ffeef312ab843606a9", size = 364418, upload-time = "2026-08-29T12:46:36.993Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/cf/2e/7d7a275171a6455b45df7468d0232484b68973f8e255c71696be56f70e7b/n24q02m_mcp_core-1.23.0-py3-none-any.whl", hash = "sha256:cc738b004299056419247e53da2824bd3745dc84a8cd49bf401f59e46d9e4933", size = 195465, upload-time = "2026-08-07T22:48:11.507Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/63/5ab34cca3f47402314622bd61e755d3c19ea4433676433a8536d6c7507df/n24q02m_mcp_core-1.23.1-py3-none-any.whl", hash = "sha256:8feac38084817544a1f9b9d256ec1b1d78584e971ab9967ba5a9526a6bbf01e6", size = 196653, upload-time = "2026-08-29T12:46:35.66Z" },
 ]
 
 [package.optional-dependencies]
@@ -1458,16 +1459,16 @@ wheels = [
 
 [[package]]
 name = "pydantic-settings"
-version = "2.15.0"
+version = "2.14.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pydantic" },
     { name = "python-dotenv" },
     { name = "typing-inspection" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/68/ca/31c57507b13119d7d3cfa1576dad2911a4861e3be07b579395f4e9d393f9/pydantic_settings-2.15.0.tar.gz", hash = "sha256:694b793e84f766ba76a90ebdefc01d0a9a045dab0382bee70393da93712ad117", size = 261253, upload-time = "2026-08-07T09:24:57.419Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/5c/b5/8f48e906c3e0205276e8bd8cb7512217a87b2685304d64be27cad5b3019f/pydantic_settings-2.14.2.tar.gz", hash = "sha256:c19dd64b19097f1de80184f0cc7b0272a13ae6e170cbf240a3e27e381ed14a5f", size = 237700, upload-time = "2026-06-19T13:44:56.324Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/30/a4/2bffa9f8e804325a09867f0e9d30795c80ea9f8d62560bd1b6ad6220eb2f/pydantic_settings-2.15.0-py3-none-any.whl", hash = "sha256:0ba092c291c94baceb5eff768aa0d56400a457585bc0175925a5a5510303da42", size = 69413, upload-time = "2026-08-07T09:24:55.839Z" },
+    { url = "https://files.pythonhosted.org/packages/77/c1/6e422f34e569cf8e18df68d1939c81c099d2b61e4f7d9621c8a77560799c/pydantic_settings-2.14.2-py3-none-any.whl", hash = "sha256:a20c97b37910b6550d5ea50fbcc2d4187defe58cd57070b73863d069419c9440", size = 61715, upload-time = "2026-06-19T13:44:55.02Z" },
 ]
 
 [[package]]
@@ -1867,14 +1868,14 @@ wheels = [
 
 [[package]]
 name = "starlette"
-version = "1.3.1"
+version = "1.6.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/eb/e3/7c1dc7381d9f8ab7d854328ebfa884e62cb3f3d8549ddfd37c7814f42afa/starlette-1.3.1.tar.gz", hash = "sha256:05d0213193f2fbaae60e2ecb593b4add4262ad4e46536b54abe36f11a71724e0", size = 2703240, upload-time = "2026-06-12T09:23:11.602Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/b5/b4/205b0d5241d934e8add0c38aa924c4f9fb7330834ff11e5444db964ec3f9/starlette-1.6.0.tar.gz", hash = "sha256:d4e3ac5e546444960c710297a3c9fc3f7ebae1b7e963f3d36173b49da535be9b", size = 2716969, upload-time = "2026-08-08T18:27:57.512Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/ec/bb/2799cc2ede3ed41131f8975621e7213dfc7ef4acbbaadfa440f32500c370/starlette-1.3.1-py3-none-any.whl", hash = "sha256:c7372aae11c3c3f26a42df7bd626cec2f47d03483d261d369516a615a53714c6", size = 73632, upload-time = "2026-06-12T09:23:10.017Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/cb/6a6a47d5b464bd08695d254f3da6e7986cc70c9fa5d778eda57538edfe56/starlette-1.6.0-py3-none-any.whl", hash = "sha256:a86dd39d14bb45f85a3d18525215a9ef0cfd1f192ac793220e72598c90335f0c", size = 75969, upload-time = "2026-08-08T18:27:56.196Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- pin `mcp-core` 1.23.1
- align `pydantic-settings` with the core 1.23.1 compatibility window
- refresh the uv lockfile

## Verification
- `uv sync --frozen --group dev`
- `uv run ruff check .`
- `uv run pytest -q` (315 passed, 4 deselected)
- `uv build`

Closes #603