### PR TITLE
fix: consolidate thread calls in run http

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -62,3 +62,6 @@ Proposals evaluated and turned down. The reasoning lives here so it carries to t
 ## 2026-08-28 - Consolidate iterative async file deletion thread dispatch
 **Learning:** In `src/imagine_mcp/providers/gemini.py`, a loop that iterated through temporary files executing `await asyncio.to_thread(f.unlink, missing_ok=True)` spawned a new thread pool context switch for every file. When operating on collections, this overhead accumulates unnecessarily.
 **Action:** Consolidate sequential synchronous file operations into a single synchronous helper function (`_cleanup`) and execute it via a single `asyncio.to_thread(_cleanup)` call. Add an early return condition (`if tmp_files:`) to avoid spawning threads for empty collections.
+## 2026-11-20 - Consolidate thread calls on startup
+**Learning:** Initializing an application via `build_app` and retrieving the version string via `_get_version` were being executed using `asyncio.to_thread`. Since these are CPU-bound fast operations and do not involve heavy I/O, using `to_thread` introduces unnecessary overhead without any real benefit.
+**Action:** Avoid wrapping fast, non-blocking synchronous CPU-bound operations in `asyncio.to_thread`, especially during startup when thread creation and context-switching overhead outweigh any potential gains.

--- a/src/imagine_mcp/server.py
+++ b/src/imagine_mcp/server.py
@@ -442,8 +442,8 @@ async def run_http(port: int = 0) -> None:
         host = "127.0.0.1"
         mode_label = "http local relay"
 
-    app = await asyncio.to_thread(build_app)
-    _version_str = await asyncio.to_thread(_get_version)
+    app = build_app()
+    _version_str = _get_version()
     logger.info("imagine-mcp {} starting ({})", _version_str, mode_label)
 
     auth_disabled = os.environ.get("MCP_AUTH_DISABLE") == "1"


### PR DESCRIPTION
💡 What: Removed `asyncio.to_thread` wrappers for `build_app` and `_get_version` in `run_http()`.

🎯 Why: `build_app` and `_get_version` are CPU-bound initialization operations that do not perform blocking I/O. Using `asyncio.to_thread` for fast synchronous operations introduces unnecessary thread-pool scheduling and context-switching overhead, especially during application startup.

📊 Impact: Reduces context-switching latency during application startup.

🔬 Measurement: Verify startup time locally; ensure the `imagine-mcp` CLI starts correctly without thread overhead.

---
*PR created automatically by Jules for task [2139375997499354588](https://jules.google.com/task/2139375997499354588) started by @n24q02m*