### PR TITLE
fix: remove thread overhead for fast synchronous operations

### DIFF
--- a/src/imagine_mcp/server.py
+++ b/src/imagine_mcp/server.py
@@ -442,8 +442,9 @@ async def run_http(port: int = 0) -> None:
         host = "127.0.0.1"
         mode_label = "http local relay"
 
-    app = await asyncio.to_thread(build_app)
-    _version_str = await asyncio.to_thread(_get_version)
+    # Avoid wrapping fast synchronous functions in to_thread overhead
+    app = build_app()
+    _version_str = _get_version()
     logger.info("imagine-mcp {} starting ({})", _version_str, mode_label)
 
     auth_disabled = os.environ.get("MCP_AUTH_DISABLE") == "1"


### PR DESCRIPTION
💡 What: Removed `asyncio.to_thread` wrappers for `build_app()` and `_get_version()` in `run_http()`.
🎯 Why: These functions execute fast, synchronous operations (such as initializing FastMCP routes and returning a short string) exactly once during server startup. Offloading them to a thread pool incurs scheduling and context-switching overhead that outweighs any benefits, needlessly complicating startup logic.
📊 Impact: Very slightly faster and cleaner server initialization.
🔬 Measurement: Verified the server still initializes correctly by running the integration and unit tests (`pytest`).

---
*PR created automatically by Jules for task [9843199982377501477](https://jules.google.com/task/9843199982377501477) started by @n24q02m*